### PR TITLE
Fix Home safe auto-resolve panel

### DIFF
--- a/src/renderer/src/lib/issue-resolution.test.ts
+++ b/src/renderer/src/lib/issue-resolution.test.ts
@@ -155,6 +155,53 @@ describe('issue resolution request builder', () => {
     ]);
   });
 
+  it('keeps plugin-owned missing-from-agents MCP repairs out of Home auto-resolve batches', () => {
+    const baseMcp = findRepresentativeMcp('missing-from-agents-mcp');
+    const pluginSourceId = 'plugin:live:codex:mcpmarket-my-toolkit@market:1.0.0';
+    const pluginMcp: McpRecord = {
+      ...structuredClone(baseMcp),
+      name: 'mcpmarket-my-toolkit:mcpmarket-my-toolkit',
+      locations: [
+        {
+          ...baseMcp.locations[0],
+          agentId: pluginSourceId,
+          agentLabel: 'Codex Plugin mcpmarket-my-toolkit',
+          configPath: '/Users/tester/.codex/plugins/cache/mcpmarket-my-toolkit/1.0.0/.mcp.json',
+          provenance: {
+            kind: 'plugin',
+            plugin: {
+              host: 'codex',
+              pluginId: 'mcpmarket-my-toolkit@market',
+              version: '1.0.0',
+            },
+            sourcePath: '/Users/tester/.codex/plugins/cache/mcpmarket-my-toolkit/1.0.0/.mcp.json',
+            discoveredAt: '2026-05-01T00:00:00.000Z',
+          },
+          mutability: 'read-only-managed',
+        },
+      ],
+    };
+    const snapshot: SkillInventorySnapshot = {
+      ...representativeInventorySnapshot,
+      mcps: [pluginMcp],
+      sources: [
+        ...representativeInventorySnapshot.sources,
+        {
+          id: pluginSourceId,
+          label: 'Codex Plugin mcpmarket-my-toolkit',
+          canonical: true,
+          kind: 'plugin',
+          writable: false,
+          scope: 'live',
+          skillsDir: '/Users/tester/.codex/plugins/cache/mcpmarket-my-toolkit/1.0.0/skills',
+          mcpConfigPath: '/Users/tester/.codex/plugins/cache/mcpmarket-my-toolkit/1.0.0/.mcp.json',
+        },
+      ],
+    };
+
+    expect(getAutoResolvableMcpRequests(snapshot)).toEqual([]);
+  });
+
   it('builds a missing-symlink skill request without forcing diverged selection when canonical exists', () => {
     const baseSkill = representativeInventorySnapshot.skills.find((entry) => entry.name === 'diagnostic-rich-skill')!;
     const skill: SkillRecord = {

--- a/src/renderer/src/lib/issue-resolution.ts
+++ b/src/renderer/src/lib/issue-resolution.ts
@@ -316,9 +316,14 @@ export function getAutoResolvableMcpRequests(
   snapshot: SkillInventorySnapshot,
 ): ResolveIssueRequest[] {
   const requests: ResolveIssueRequest[] = [];
+  const sourceIndex = new Map(snapshot.sources.map((source) => [source.id, source]));
 
   for (const mcp of snapshot.mcps ?? []) {
     if (mcp.presentation !== 'active' || !mcp.issueReasons.includes('missing-from-agents')) {
+      continue;
+    }
+
+    if (hasPluginMcpLocation(mcp, sourceIndex)) {
       continue;
     }
 
@@ -346,4 +351,13 @@ export function getAutoResolvableMcpRequests(
   }
 
   return requests;
+}
+
+function hasPluginMcpLocation(
+  mcp: McpRecord,
+  sourceIndex: Map<string, SkillScanSource>,
+): boolean {
+  return mcp.locations.some((location) =>
+    location.provenance?.kind === 'plugin'
+    || sourceIndex.get(location.agentId)?.kind === 'plugin');
 }

--- a/src/renderer/src/views/HomeDashboard.test.tsx
+++ b/src/renderer/src/views/HomeDashboard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -104,7 +104,9 @@ describe('HomeDashboard', () => {
 
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Auto-resolve issues with safe resolutions')).toBeInTheDocument();
     expect(screen.getByText('Review planned fixes')).toBeInTheDocument();
+    expect(screen.queryByText(/1 issue across 1 item/i)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /Apply 1 repair/i }));
     expect(onAutoResolve).toHaveBeenCalledTimes(1);
@@ -132,6 +134,99 @@ describe('HomeDashboard', () => {
     expect(screen.getAllByText('Missing From Agents').length).toBeGreaterThan(0);
     expect(screen.getByText('Add to missing agents')).toBeInTheDocument();
     expect(screen.getByText(/2 repairs · 2 items affected/i)).toBeInTheDocument();
+  });
+
+  it('shows how many active issues will still need manual review', () => {
+    const inventorySnapshot = createNoAttentionSnapshot();
+    const safeSkill = structuredClone(representativeInventorySnapshot.skills.find((skill) => skill.name === 'identical-drift-skill')!);
+    safeSkill.driftPresentation = 'active';
+    safeSkill.isDrifted = true;
+    safeSkill.issueReasons = ['identical-copies'];
+    const manualSkill = structuredClone(representativeInventorySnapshot.skills.find((skill) => skill.name === 'diagnostic-rich-skill')!);
+    manualSkill.name = 'manual-choice-skill';
+    manualSkill.driftPresentation = 'active';
+    manualSkill.isDrifted = true;
+    manualSkill.issueReasons = ['diverged-copies', 'invalid-definition'];
+    inventorySnapshot.skills = [safeSkill, manualSkill];
+    inventorySnapshot.counts = {
+      ...inventorySnapshot.counts,
+      totalSkills: 2,
+      healthySkills: 0,
+      driftedSkills: 2,
+    };
+    inventorySnapshot.homeSummary = getHomeSummary(inventorySnapshot);
+
+    renderDashboard({
+      autoResolvableRequests: [safeRepairRequest],
+      homeSummary: getHomeSummary(inventorySnapshot),
+      inventorySnapshot,
+    });
+
+    expect(screen.getByText(/2 issues will still need manual review/i)).toBeInTheDocument();
+    expect(screen.getByText(/explicit choices/i)).toBeInTheDocument();
+    expect(screen.getByText(/plugin-managed contents/i)).toBeInTheDocument();
+  });
+
+  it('uses skill and MCP display names in planned safe repairs', () => {
+    const inventorySnapshot = createNoAttentionSnapshot();
+    const pluginSkill = structuredClone(representativeInventorySnapshot.skills.find((skill) => skill.name === 'mixed-plugin-skill')!);
+    pluginSkill.name = 'toolkit:sync-workflow';
+    pluginSkill.displayName = 'toolkit:sync-workflow';
+    const pluginMcp: McpRecord = {
+      name: 'toolkit:syncServer',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['missing-from-agents'],
+      locations: [
+        {
+          agentId: 'sandbox-plugin-pack',
+          agentLabel: 'Sandbox Plugin bundle',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/plugins/.mcp.json',
+          command: 'node',
+          args: ['server.js'],
+          provenance: {
+            kind: 'plugin',
+            plugin: {
+              host: 'claude',
+              pluginId: 'sandbox-plugin-pack',
+              version: '0.1.0',
+            },
+            sourcePath: '~/.skillindex/sandbox/plugins/.mcp.json',
+            discoveredAt: '2026-01-06T00:00:31.000Z',
+          },
+          mutability: 'read-only-managed',
+        },
+      ],
+    };
+    inventorySnapshot.skills = [pluginSkill];
+    inventorySnapshot.mcps = [pluginMcp];
+
+    renderDashboard({
+      autoResolvableRequests: [
+        {
+          entity: 'skill',
+          issue: 'identical-copies',
+          skillName: 'toolkit:sync-workflow',
+        },
+        {
+          entity: 'mcp',
+          issue: 'missing-from-agents',
+          mcpName: 'toolkit:syncServer',
+        },
+      ],
+      homeSummary: getHomeSummary(inventorySnapshot),
+      inventorySnapshot,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Review 2 safe repairs/i }));
+    const reviewPanel = document.getElementById('home-auto-repair-review-panel');
+    expect(reviewPanel).not.toBeNull();
+
+    expect(within(reviewPanel!).getByText('sync-workflow')).toBeInTheDocument();
+    expect(within(reviewPanel!).getByText('syncServer')).toBeInTheDocument();
+    expect(within(reviewPanel!).queryByText('toolkit:sync-workflow')).not.toBeInTheDocument();
+    expect(within(reviewPanel!).queryByText('toolkit:syncServer')).not.toBeInTheDocument();
   });
 
   it('shows busy auto-resolve controls as disabled', () => {

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -10,6 +10,7 @@ import {
   getMcpStatusLabels,
   getSkillStatusLabels,
   getSkillRowDescription,
+  getDisplaySkillIssueReasons,
   formatLastScanLabel,
 } from '../lib/inventory-presentation';
 import {
@@ -37,6 +38,48 @@ const FIX_TYPE_LABELS: Record<string, string> = {
   'missing-from-agents': 'Missing From Agents',
 };
 
+interface PlannedFixRow {
+  key: string;
+  name: string;
+}
+
+function getResolveRequestDisplayName(
+  request: ResolveIssueRequest,
+  inventorySnapshot: SkillInventorySnapshot | null,
+): string {
+  if (request.entity === 'skill') {
+    const skill = inventorySnapshot?.skills.find((entry) => entry.name === request.skillName);
+    return skill ? getSkillDisplayName(skill) : request.skillName;
+  }
+
+  const mcp = inventorySnapshot?.mcps?.find((entry) => entry.name === request.mcpName);
+  return mcp ? getMcpDisplayName(mcp) : request.mcpName;
+}
+
+function getResolveRequestKey(request: ResolveIssueRequest): string {
+  return [
+    request.entity,
+    request.skillName ?? request.mcpName,
+    request.issue,
+    request.selectedVariantPath ?? '',
+  ].join(':');
+}
+
+function getActiveIssueCount(inventorySnapshot: SkillInventorySnapshot | null): number {
+  if (!inventorySnapshot) {
+    return 0;
+  }
+
+  const skillIssueCount = inventorySnapshot.skills
+    .filter((skill) => skill.driftPresentation === 'active')
+    .reduce((count, skill) => count + getDisplaySkillIssueReasons(skill).length, 0);
+  const mcpIssueCount = (inventorySnapshot.mcps ?? [])
+    .filter((mcp) => mcp.presentation === 'active' && mcp.status === 'needs-attention')
+    .reduce((count, mcp) => count + mcp.issueReasons.length, 0);
+
+  return skillIssueCount + mcpIssueCount;
+}
+
 function RepairError({ errorMessage }: { errorMessage: string | null }) {
   if (!errorMessage) {
     return null;
@@ -54,6 +97,7 @@ function RepairSurface({
   autoResolvableRequests,
   errorMessage,
   hasAttentionIssues,
+  inventorySnapshot,
   isAutoResolving,
   onAutoResolve,
   onViewSkills,
@@ -61,6 +105,7 @@ function RepairSurface({
   autoResolvableRequests: ResolveIssueRequest[];
   errorMessage: string | null;
   hasAttentionIssues: boolean;
+  inventorySnapshot: SkillInventorySnapshot | null;
   isAutoResolving: boolean;
   onAutoResolve: () => void;
   onViewSkills: () => void;
@@ -68,15 +113,19 @@ function RepairSurface({
   const [reviewOpen, setReviewOpen] = useState(false);
   const reviewPanelId = 'home-auto-repair-review-panel';
 
-  const fixesByType = autoResolvableRequests.reduce<Map<string, string[]>>((acc, req) => {
+  const fixesByType = autoResolvableRequests.reduce<Map<string, PlannedFixRow[]>>((acc, req) => {
     const names = acc.get(req.issue) ?? [];
-    names.push(req.skillName ?? req.mcpName ?? '');
+    names.push({
+      key: getResolveRequestKey(req),
+      name: getResolveRequestDisplayName(req, inventorySnapshot),
+    });
     acc.set(req.issue, names);
     return acc;
   }, new Map());
 
   const totalIssues = autoResolvableRequests.length;
   const totalItems = new Set(autoResolvableRequests.map((r) => r.skillName ?? r.mcpName)).size;
+  const manualIssueCount = Math.max(0, getActiveIssueCount(inventorySnapshot) - totalIssues);
 
   if (autoResolvableRequests.length === 0 && !hasAttentionIssues) {
     return (
@@ -121,7 +170,12 @@ function RepairSurface({
       <div className="repair-banner">
         <Wrench aria-hidden className="repair-banner-wrench" />
         <div className="repair-banner-copy">
-          <div className="repair-banner-title">Auto-resolve easy issues</div>
+          <div className="repair-banner-title">Auto-resolve issues with safe resolutions</div>
+          <div className="repair-banner-sub">
+            {manualIssueCount === 0
+              ? '0 issues should need manual review after these safe repairs.'
+              : `${manualIssueCount} ${manualIssueCount === 1 ? 'issue' : 'issues'} will still need manual review. Some issues require explicit choices; plugin-managed contents stay manual.`}
+          </div>
         </div>
         <button
           aria-controls={reviewPanelId}
@@ -148,19 +202,18 @@ function RepairSurface({
         <div className="review-panel review-panel--open" id={reviewPanelId}>
           <div className="review-header">
             <span className="review-header-title">Review planned fixes</span>
-            <span className="review-header-sub">· {totalIssues} {totalIssues === 1 ? 'issue' : 'issues'} across {totalItems} {totalItems === 1 ? 'item' : 'items'}</span>
           </div>
           <div className="review-body">
-            {[...fixesByType.entries()].map(([issueType, skillNames]) => (
+            {[...fixesByType.entries()].map(([issueType, fixRows]) => (
               <div className="issue-bucket" key={issueType}>
                 <div className="issue-bucket-header">
                   <span className="issue-bucket-label">{FIX_TYPE_LABELS[issueType] ?? issueType}</span>
-                  <span className="issue-bucket-count">{skillNames.length} {skillNames.length === 1 ? 'item' : 'items'}</span>
+                  <span className="issue-bucket-count">{fixRows.length} {fixRows.length === 1 ? 'item' : 'items'}</span>
                 </div>
                 <div className="issue-bucket-rows">
-                  {skillNames.map((name) => (
-                    <div className="skill-fix-row" key={name}>
-                      <span className="skill-fix-name">{name}</span>
+                  {fixRows.map((row) => (
+                    <div className="skill-fix-row" key={row.key}>
+                      <span className="skill-fix-name">{row.name}</span>
                       <span className="skill-fix-action">{FIX_ACTION_LABELS[issueType] ?? issueType}</span>
                     </div>
                   ))}
@@ -282,6 +335,7 @@ export function HomeDashboard({
               autoResolvableRequests={autoResolvableRequests}
               errorMessage={errorMessage}
               hasAttentionIssues={skillAttentionRows.length > 0 || mcpAttentionRows.length > 0}
+              inventorySnapshot={inventorySnapshot}
               isAutoResolving={isAutoResolving}
               onAutoResolve={onAutoResolve}
               onViewSkills={onNavigateToSkills}


### PR DESCRIPTION
Changed:
- Excluded plugin-owned MCPs from Home safe auto-resolve batches.
- Updated the Home safe-fix panel copy/counts and planned-fix display names.

Screenshot: 
<img width="1332" height="379" alt="image" src="https://github.com/user-attachments/assets/e7677d26-1d24-4d06-b735-b9ecbe6a4fb1" />