### PR TITLE
Add resolution failure traces and feedback

### DIFF
--- a/src/main/audit-log.test.ts
+++ b/src/main/audit-log.test.ts
@@ -255,6 +255,32 @@ describe('audit log service', () => {
     });
   });
 
+  it('exposes failed operation error details for issue reports', async () => {
+    const { paths } = await createTempPaths('audit-failure-trace-');
+    const service = createAuditLogService({ paths });
+    const error = new Error('MCP "stale-mcp" no longer has Missing From Agents.');
+
+    await expect(service.runOperation({
+      kind: 'resolve-mcp-issue',
+      title: 'Resolved Missing From Agents for stale-mcp',
+      summary: 'Resolution failed before mutating configs.',
+      sourceMode: 'sandbox',
+      entity: { type: 'mcp', name: 'stale-mcp' },
+      affectedPaths: [],
+      undoable: false,
+    }, () => Promise.reject(error))).rejects.toThrow('MCP "stale-mcp" no longer has Missing From Agents.');
+
+    const [operation] = await service.readOperations();
+    expect(operation).toMatchObject({
+      status: 'failed',
+      failure: {
+        message: 'MCP "stale-mcp" no longer has Missing From Agents.',
+      },
+    });
+    expect(operation.failure?.trace).toContain('MCP "stale-mcp" no longer has Missing From Agents.');
+    expect(operation.failure?.trace).toContain('audit-log.test.ts');
+  });
+
   it('blocks undo when permissions changed after the audited write', async () => {
     const { paths, root } = await createTempPaths('audit-mode-change-');
     const service = createAuditLogService({ paths });

--- a/src/main/audit-log.ts
+++ b/src/main/audit-log.ts
@@ -7,6 +7,7 @@ import type {
   AuditActionDiagnostics,
   AuditDismissedDriftSignatureDiagnostic,
   AuditDriftSignatureSummary,
+  AuditFailureDiagnostic,
   AuditActionKind,
   AuditOperation,
   AuditOperationKind,
@@ -62,6 +63,7 @@ interface OperationCompletedRecord {
 interface OperationFailedRecord {
   completedAt: string;
   error: string;
+  trace?: string;
   operationId: string;
   recordKind: 'operation-failed';
 }
@@ -105,6 +107,7 @@ interface UndoBlockedRecord {
 interface UndoFailedRecord {
   completedAt: string;
   error: string;
+  trace?: string;
   operationId: string;
   recordKind: 'undo-failed';
 }
@@ -177,6 +180,7 @@ interface GroupedOperation {
   actionRecords: ActionCompletedRecord[];
   blockedPath?: string;
   completedAt?: string;
+  failure?: AuditFailureDiagnostic;
   failedAt?: string;
   operation: OperationStartedRecord['operation'];
   status: AuditOperation['status'];
@@ -261,12 +265,14 @@ export function createAuditLogService({
     try {
       result = await run();
     } catch (error) {
+      const failure = formatFailureDiagnostic(error);
       await appendChangedActionRecords(operationId, request.undoable, uniqueAffectedPaths, beforeSnapshots).catch(() => undefined);
       await appendRecord({
         recordKind: 'operation-failed',
         operationId,
         completedAt: now().toISOString(),
-        error: formatError(error),
+        error: failure.message,
+        trace: failure.trace,
       });
       throw error;
     }
@@ -282,11 +288,13 @@ export function createAuditLogService({
 
       operation = (await readOperations()).find((candidate) => candidate.id === operationId);
     } catch (error) {
+      const failure = formatFailureDiagnostic(error, 'Audit finalization failed after mutation');
       await appendRecord({
         recordKind: 'operation-failed',
         operationId,
         completedAt: now().toISOString(),
-        error: `Audit finalization failed after mutation: ${formatError(error)}`,
+        error: failure.message,
+        trace: failure.trace,
       }).catch(() => undefined);
       operation = (await readOperations().catch(() => []))
         .find((candidate) => candidate.id === operationId);
@@ -408,11 +416,13 @@ export function createAuditLogService({
         completedAt: now().toISOString(),
       });
     } catch (error) {
+      const failure = formatFailureDiagnostic(error);
       await appendRecord({
         recordKind: 'undo-failed',
         operationId,
         completedAt: now().toISOString(),
-        error: formatError(error),
+        error: failure.message,
+        trace: failure.trace,
       });
       throw error;
     }
@@ -464,6 +474,7 @@ function groupRecords(records: AuditLogRecord[], currentSessionId: string): Audi
       actor: record.operation.actor,
       sourceMode: record.operation.sourceMode,
       entity: record.operation.entity,
+      failure: record.failure,
       undoState,
       actionCount: actions.length,
       actions,
@@ -502,6 +513,10 @@ function groupRawRecords(records: AuditLogRecord[]): Map<string, GroupedOperatio
       case 'operation-failed':
         groupedOperation.failedAt = record.completedAt;
         groupedOperation.completedAt = record.completedAt;
+        groupedOperation.failure = {
+          message: record.error,
+          trace: record.trace ?? record.error,
+        };
         groupedOperation.status = 'failed';
         break;
       case 'undo-action-completed':
@@ -518,6 +533,10 @@ function groupRawRecords(records: AuditLogRecord[]): Map<string, GroupedOperatio
       case 'undo-failed':
         groupedOperation.status = 'undo-failed';
         groupedOperation.completedAt = record.completedAt;
+        groupedOperation.failure = {
+          message: record.error,
+          trace: record.trace ?? record.error,
+        };
         break;
       case 'undo-started':
         break;
@@ -1114,4 +1133,17 @@ function isFileNotFoundError(error: unknown): boolean {
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function formatFailureDiagnostic(error: unknown, prefix?: string): AuditFailureDiagnostic {
+  const message = formatError(error);
+  const prefixedMessage = prefix ? `${prefix}: ${message}` : message;
+  const trace = error instanceof Error && error.stack
+    ? error.stack
+    : prefixedMessage;
+
+  return {
+    message: prefixedMessage,
+    trace: prefix && trace !== prefixedMessage ? `${prefix}: ${trace}` : trace,
+  };
 }

--- a/src/main/inventory-runtime.test.ts
+++ b/src/main/inventory-runtime.test.ts
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createInventoryRuntime } from '@main/inventory-runtime';
 import { seedRepresentativeFixtures } from '@main/sandbox-fixtures';
-import type { McpConnectivityRecord, SkillInventorySnapshot } from '@shared/contracts';
+import type { AuditOperation, McpConnectivityRecord, SkillInventorySnapshot } from '@shared/contracts';
 import { resolveSkillIndexPaths } from '@shared/skill-index-paths';
 
 interface FakeWatcher {
@@ -902,6 +902,52 @@ describe('inventory runtime', () => {
       kind: 'add-skill',
       sourceMode: 'sandbox',
       title: 'Added sandbox-only-skill',
+    });
+  });
+
+  it('audits failed issue resolutions with a shareable failure trace', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-runtime-failed-resolution-audit-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+    const runtime = createInventoryRuntime();
+    runtimes.push(runtime);
+    const auditUpdates: AuditOperation[][] = [];
+    runtime.onDidAuditUpdate((operations) => {
+      auditUpdates.push(operations);
+    });
+
+    await writeSkillFile(paths.sandboxAgentsSkillsDir, 'healthy-skill', '# Healthy skill\n', '2026-04-09T00:00:00.000Z');
+    await runtime.scanInventory({
+      paths,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+
+    await expect(runtime.resolveIssue({
+      entity: 'skill',
+      issue: 'missing-symlinks',
+      skillName: 'healthy-skill',
+    })).rejects.toThrow('Skill "healthy-skill" no longer has Missing Symlinks.');
+
+    const [operation] = await runtime.readAuditLog();
+    expect(operation).toMatchObject({
+      kind: 'resolve-skill-issue',
+      status: 'failed',
+      entity: { type: 'skill', name: 'healthy-skill' },
+      failure: {
+        message: 'Skill "healthy-skill" no longer has Missing Symlinks. Refresh inventory and try again if it still needs attention.',
+      },
+    });
+    expect(operation.failure?.trace).toContain('Skill "healthy-skill" no longer has Missing Symlinks.');
+    expect(auditUpdates.at(-1)?.[0]).toMatchObject({
+      kind: 'resolve-skill-issue',
+      status: 'failed',
+      failure: {
+        message: 'Skill "healthy-skill" no longer has Missing Symlinks. Refresh inventory and try again if it still needs attention.',
+      },
     });
   });
 });

--- a/src/main/inventory-runtime.ts
+++ b/src/main/inventory-runtime.ts
@@ -366,13 +366,18 @@ export function createInventoryRuntime(options: CreateInventoryRuntimeOptions = 
 
       const beforeSnapshot = currentSnapshot ?? await scanSkillInventory(lastScanOptions);
       const auditRequest = buildResolveIssueAuditRequest(request, beforeSnapshot, lastScanOptions);
-      const { result: nextSnapshot } = await getAuditService(lastScanOptions).runOperation(
-        auditRequest,
-        () => resolveInventoryIssue(request, lastScanOptions),
-      );
-      commitSnapshot(nextSnapshot);
-      await emitAudit(lastScanOptions);
-      return nextSnapshot;
+      try {
+        const { result: nextSnapshot } = await getAuditService(lastScanOptions).runOperation(
+          auditRequest,
+          () => resolveInventoryIssue(request, lastScanOptions),
+        );
+        commitSnapshot(nextSnapshot);
+        await emitAudit(lastScanOptions);
+        return nextSnapshot;
+      } catch (error) {
+        await emitAudit(lastScanOptions).catch(() => undefined);
+        throw error;
+      }
     },
     async applyCapabilityAction(request, optionsOverride = {}) {
       if (refreshInFlight) {

--- a/src/main/issue-resolution.test.ts
+++ b/src/main/issue-resolution.test.ts
@@ -15,6 +15,38 @@ import type { McpConnectivityRecord } from '@shared/contracts';
 import { readSkillIndexConfig, resolveSkillIndexPaths, writeSkillIndexConfig } from '@shared/skill-index-paths';
 
 describe('resolveInventoryIssue', () => {
+  it('rejects stale skill and MCP resolution requests instead of silently no-oping', async () => {
+    const paths = await createPaths('skillindex-resolve-stale-request-');
+    const skillDir = path.join(paths.sandboxAgentsSkillsDir, 'healthy-skill');
+    await writeSkillFile(path.join(skillDir, 'SKILL.md'), '# Healthy skill\n');
+
+    await expect(resolveInventoryIssue(
+      {
+        entity: 'skill',
+        issue: 'missing-symlinks',
+        skillName: 'healthy-skill',
+      },
+      {
+        paths,
+        includeSandboxSources: true,
+        includeLiveSources: false,
+      },
+    )).rejects.toThrow('Skill "healthy-skill" no longer has Missing Symlinks.');
+
+    await expect(resolveInventoryIssue(
+      {
+        entity: 'mcp',
+        issue: 'missing-from-agents',
+        mcpName: 'missing-mcp',
+      },
+      {
+        paths,
+        includeSandboxSources: true,
+        includeLiveSources: false,
+      },
+    )).rejects.toThrow('MCP "missing-mcp" was not found in the current inventory.');
+  });
+
   it('writes missing MCP definitions into Codex config.toml while preserving existing settings', async () => {
     const paths = await createPaths('skillindex-resolve-codex-mcp-');
     const agentsConfigPath = path.join(paths.sandboxRoot, '.agents', 'mcp.json');
@@ -1156,7 +1188,7 @@ describe('resolveInventoryIssue', () => {
     await writeSkillFile(path.join(homeDir, '.factory', 'settings.json'), '{}\n');
     const beforeManual = await readFile(path.join(manualSkillPath, 'SKILL.md'), 'utf8');
 
-    await applyCapabilityAction({
+    const resolvedSnapshot = await applyCapabilityAction({
       entity: 'skill',
       action: 'choose-universal-version',
       skillName: 'tools:foo',
@@ -1167,20 +1199,6 @@ describe('resolveInventoryIssue', () => {
       includeSandboxSources: false,
       includeLiveSources: true,
     });
-
-    const resolvedSnapshot = await resolveInventoryIssue(
-      {
-        entity: 'skill',
-        issue: 'missing-symlinks',
-        skillName: 'tools:foo',
-      },
-      {
-        paths,
-        homeDir,
-        includeSandboxSources: false,
-        includeLiveSources: true,
-      },
-    );
 
     expect(await readlink(agentsPath)).toBe(pluginSkillPath);
     expect(await readlink(factoryPath)).toBe(pluginSkillPath);
@@ -1234,7 +1252,7 @@ describe('resolveInventoryIssue', () => {
     await writeSkillFile(path.join(homeDir, '.factory', 'settings.json'), '{}\n');
     const beforePlugin = await readFile(path.join(pluginSkillPath, 'SKILL.md'), 'utf8');
 
-    await applyCapabilityAction({
+    const resolvedSnapshot = await applyCapabilityAction({
       entity: 'skill',
       action: 'choose-universal-version',
       skillName: 'foo',
@@ -1245,20 +1263,6 @@ describe('resolveInventoryIssue', () => {
       includeSandboxSources: false,
       includeLiveSources: true,
     });
-
-    const resolvedSnapshot = await resolveInventoryIssue(
-      {
-        entity: 'skill',
-        issue: 'missing-symlinks',
-        skillName: 'foo',
-      },
-      {
-        paths,
-        homeDir,
-        includeSandboxSources: false,
-        includeLiveSources: true,
-      },
-    );
 
     expect(await readlink(factoryPath)).toBe(manualSkillPath);
     expect(await readFile(path.join(pluginSkillPath, 'SKILL.md'), 'utf8')).toBe(beforePlugin);
@@ -1713,7 +1717,7 @@ describe('resolveInventoryIssue', () => {
     expect(resolvedSkill?.detailDiagnostics.universalDecision?.acceptedAlternates).toEqual([]);
   });
 
-  it('treats stale skill issue resolution requests as a no-op rescan', async () => {
+  it('rejects stale skill issue resolution requests after the issue is already resolved', async () => {
     const paths = await createPaths('skillindex-resolve-stale-skill-');
     await seedRepresentativeFixtures({ paths });
 
@@ -1731,14 +1735,11 @@ describe('resolveInventoryIssue', () => {
     expect(firstSnapshot.skills.find((skill) => skill.name === request.skillName)?.issueReasons)
       .not.toContain(request.issue);
 
-    const staleSnapshot = await resolveInventoryIssue(request, {
+    await expect(resolveInventoryIssue(request, {
       paths,
       includeSandboxSources: true,
       includeLiveSources: false,
-    });
-
-    expect(staleSnapshot.skills.find((skill) => skill.name === request.skillName)?.issueReasons)
-      .not.toContain(request.issue);
+    })).rejects.toThrow('Skill "missing-symlink-skill" no longer has Missing Symlinks.');
   });
 
   it('uses plugin A as Universal while keeping plugin B as a healthy separate version', async () => {
@@ -1790,7 +1791,7 @@ describe('resolveInventoryIssue', () => {
     await writeSkillFile(path.join(homeDir, '.factory', 'settings.json'), '{}\n');
     const beforeClaude = await readFile(path.join(claudeSkillPath, 'SKILL.md'), 'utf8');
 
-    await applyCapabilityAction({
+    const resolvedSnapshot = await applyCapabilityAction({
       entity: 'skill',
       action: 'choose-universal-version',
       skillName: 'tools:foo',
@@ -1801,20 +1802,6 @@ describe('resolveInventoryIssue', () => {
       includeSandboxSources: false,
       includeLiveSources: true,
     });
-
-    const resolvedSnapshot = await resolveInventoryIssue(
-      {
-        entity: 'skill',
-        issue: 'missing-symlinks',
-        skillName: 'tools:foo',
-      },
-      {
-        paths,
-        homeDir,
-        includeSandboxSources: false,
-        includeLiveSources: true,
-      },
-    );
 
     expect(await readlink(agentsPath)).toBe(codexSkillPath);
     expect(await readlink(factoryPath)).toBe(codexSkillPath);

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -73,6 +73,8 @@ export async function resolveInventoryIssue(
     paths,
   });
 
+  assertResolutionIssueIsCurrent(snapshot, request);
+
   if (request.entity === 'skill') {
     await resolveSkillIssueIfCurrent(snapshot, request, {
       ...options,
@@ -82,10 +84,12 @@ export async function resolveInventoryIssue(
     await resolveMcpIssueIfCurrent(snapshot, request);
   }
 
-  return scanSkillInventory({
+  const nextSnapshot = await scanSkillInventory({
     ...options,
     paths,
   });
+  assertResolutionIssueWasResolved(nextSnapshot, request);
+  return nextSnapshot;
 }
 
 export async function addMcpServer(
@@ -130,6 +134,60 @@ export async function addMcpServer(
   });
 }
 
+function assertResolutionIssueIsCurrent(snapshot: SkillInventorySnapshot, request: ResolveIssueRequest): void {
+  if (request.entity === 'skill') {
+    const skill = snapshot.skills.find((entry) => entry.name === request.skillName);
+    if (!skill) {
+      throw new Error(`Skill "${request.skillName}" was not found in the current inventory.`);
+    }
+
+    if (!(skill.issueReasons ?? []).includes(request.issue) && !canResolveSkillIssueWithoutListedReason(skill, request.issue)) {
+      throw new Error(`Skill "${request.skillName}" no longer has ${formatIssueLabel(request.issue)}. Refresh inventory and try again if it still needs attention.`);
+    }
+    return;
+  }
+
+  const mcp = (snapshot.mcps ?? []).find((entry) => entry.name === request.mcpName);
+  if (!mcp) {
+    throw new Error(`MCP "${request.mcpName}" was not found in the current inventory.`);
+  }
+
+  if (!mcp.issueReasons.includes(request.issue)) {
+    throw new Error(`MCP "${request.mcpName}" no longer has ${formatIssueLabel(request.issue)}. Refresh inventory and try again if it still needs attention.`);
+  }
+}
+
+function assertResolutionIssueWasResolved(snapshot: SkillInventorySnapshot, request: ResolveIssueRequest): void {
+  if (request.entity === 'skill') {
+    const skill = snapshot.skills.find((entry) => entry.name === request.skillName);
+    if (skill && (skill.issueReasons ?? []).includes(request.issue)) {
+      throw new Error(`Skill "${request.skillName}" still has ${formatIssueLabel(request.issue)} after resolution.`);
+    }
+    return;
+  }
+
+  const mcp = (snapshot.mcps ?? []).find((entry) => entry.name === request.mcpName);
+  if (mcp && mcp.issueReasons.includes(request.issue)) {
+    throw new Error(`MCP "${request.mcpName}" still has ${formatIssueLabel(request.issue)} after resolution.`);
+  }
+}
+
+function formatIssueLabel(issue: ResolveIssueRequest['issue']): string {
+  return issue
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function canResolveSkillIssueWithoutListedReason(skill: SkillRecord, issue: ResolveIssueRequest['issue']): boolean {
+  if (issue !== 'missing-symlinks') {
+    return false;
+  }
+
+  return Boolean(skill.detailDiagnostics.universalDecision)
+    && (skill.detailDiagnostics.missingInstallSources?.length ?? 0) > 0;
+}
+
 async function resolveSkillIssueIfCurrent(
   snapshot: SkillInventorySnapshot,
   request: Extract<ResolveIssueRequest, { entity: 'skill' }>,
@@ -137,11 +195,11 @@ async function resolveSkillIssueIfCurrent(
 ): Promise<void> {
   const skill = snapshot.skills.find((entry) => entry.name === request.skillName);
   if (!skill) {
-    return;
+    throw new Error(`Skill "${request.skillName}" was not found in the current inventory.`);
   }
 
-  if (!(skill.issueReasons ?? []).includes(request.issue)) {
-    return;
+  if (!(skill.issueReasons ?? []).includes(request.issue) && !canResolveSkillIssueWithoutListedReason(skill, request.issue)) {
+    throw new Error(`Skill "${request.skillName}" no longer has ${formatIssueLabel(request.issue)}. Refresh inventory and try again if it still needs attention.`);
   }
 
   assertSkillResolutionScopeAllowed(skill);
@@ -299,11 +357,11 @@ async function resolveMcpIssueIfCurrent(
 ): Promise<void> {
   const mcp = (snapshot.mcps ?? []).find((entry) => entry.name === request.mcpName);
   if (!mcp) {
-    return;
+    throw new Error(`MCP "${request.mcpName}" was not found in the current inventory.`);
   }
 
   if (!mcp.issueReasons.includes(request.issue)) {
-    return;
+    throw new Error(`MCP "${request.mcpName}" no longer has ${formatIssueLabel(request.issue)}. Refresh inventory and try again if it still needs attention.`);
   }
 
   const selectedVariant = pickMcpSelection(mcp.locations, request.selectedVariantPath, {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -150,6 +150,7 @@ export default function App() {
   const [appToast, setAppToast] = useState<{
     description: string;
     id: number;
+    tone: 'error' | 'success';
     title: string;
     undoOperationId?: string;
   } | null>(null);
@@ -207,10 +208,16 @@ export default function App() {
     return nextAuditOperations;
   }, [desktopApi]);
 
-  const showAppToast = useCallback((title: string, description: string, undoOperation?: AuditOperation | null) => {
+  const showAppToast = useCallback((
+    title: string,
+    description: string,
+    undoOperation?: AuditOperation | null,
+    tone: 'error' | 'success' = 'success',
+  ) => {
     appToastIdRef.current += 1;
     setAppToast({
       id: appToastIdRef.current,
+      tone,
       title,
       description,
       undoOperationId: undoOperation?.undoState === 'available' ? undoOperation.id : undefined,
@@ -862,13 +869,15 @@ export default function App() {
         }
       } catch (error) {
         setPendingDriftTransitionSkillName(null);
-        setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+        const message = error instanceof Error ? error.message : 'Unknown preload error';
+        setErrorMessage(message);
+        showAppToast('Resolution failed', message, null, 'error');
       } finally {
         await waitForResolvePendingPaintWindow();
         setIsResolvingIssue(false);
       }
     },
-    [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo],
+    [applyInventorySnapshot, desktopApi, showAppToast, showAppToastWithLatestUndo],
   );
 
   const handleCapabilityAction = useCallback(async (request: CapabilityActionRequest) => {
@@ -947,11 +956,13 @@ export default function App() {
         { includeUndo: plannedRepairCount === 1 },
       );
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+      const message = error instanceof Error ? error.message : 'Unknown preload error';
+      setErrorMessage(message);
+      showAppToast('Repairs failed', message, null, 'error');
     } finally {
       setIsAutoResolving(false);
     }
-  }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo]);
+  }, [applyInventorySnapshot, desktopApi, showAppToast, showAppToastWithLatestUndo]);
 
   const resetSkillSelection = useCallback(() => {
     setSelectedSkillName(null);
@@ -1536,9 +1547,9 @@ export default function App() {
 
       {appToast ? (
         <div aria-live="polite" className="app-toast-region" role="status">
-          <section className="app-toast app-toast--success" aria-label={appToast.title}>
+          <section className={`app-toast app-toast--${appToast.tone}`} aria-label={appToast.title}>
             <div className="app-toast-icon" aria-hidden="true">
-              <span>✓</span>
+              <span>{appToast.tone === 'error' ? '!' : '✓'}</span>
             </div>
             <div className="app-toast-copy">
               <strong>{appToast.title}</strong>

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -478,6 +478,50 @@ describe('App shell inventory views', () => {
     });
   });
 
+  it('shows and copies failure traces from failed audit operations', async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: writeTextMock,
+      },
+    });
+    readAuditLogMock.mockResolvedValue(createAuditOperations({
+      status: 'failed',
+      undoState: 'not-undoable',
+      actionCount: 0,
+      actions: [],
+      failure: {
+        message: 'MCP "missing-from-agents-mcp" no longer has Missing From Agents.',
+        trace: [
+          'Error: MCP "missing-from-agents-mcp" no longer has Missing From Agents.',
+          '    at resolveMcpIssueIfCurrent (src/main/issue-resolution.ts:1:1)',
+        ].join('\n'),
+      },
+    }));
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /^Audit Log$/i }));
+
+    const auditTable = await screen.findByRole('table', { name: /^Audit events$/i });
+    fireEvent.click(within(auditTable).getByRole('button', { name: /^Expand audit row/i }));
+
+    expect(await within(auditTable).findByText('Failure')).toBeInTheDocument();
+    expect(within(auditTable).getByText('MCP "missing-from-agents-mcp" no longer has Missing From Agents.')).toBeInTheDocument();
+    const failureDetail = within(auditTable).getByText('Failure').closest('.audit-detail-item');
+    expect(failureDetail).not.toBeNull();
+    expect(within(failureDetail as HTMLElement).getByRole('button', { name: /^Copy failure trace$/i })).toBeInTheDocument();
+    expect(document.querySelector('.audit-undo-panel .audit-copy-trace-button')).toBeNull();
+
+    fireEvent.click(within(auditTable).getByRole('button', { name: /^Copy failure trace$/i }));
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining('resolveMcpIssueIfCurrent'));
+    });
+    expect(within(failureDetail as HTMLElement).getByRole('button', { name: /^Failure trace copied$/i })).toBeInTheDocument();
+  });
+
   it('paginates compact Audit rows for large audit trails', async () => {
     readAuditLogMock.mockResolvedValue(createAuditOperationsWithActionCount(55));
     render(<App />);

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -5143,6 +5143,11 @@ body {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), var(--healthy-bg));
 }
 
+.app-toast--error {
+  border-color: #f3d4cf;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), #fbecea);
+}
+
 .app-toast-icon {
   display: inline-flex;
   align-items: center;
@@ -5152,6 +5157,11 @@ body {
   border-radius: 999px;
   background: #dfeeda;
   color: #456b38;
+}
+
+.app-toast--error .app-toast-icon {
+  background: #f8d8d3;
+  color: #ba1a1a;
 }
 
 .app-toast-icon span {
@@ -9821,13 +9831,27 @@ body {
   grid-column: 1 / -1;
 }
 
-.audit-detail-item span {
+.audit-detail-item__label-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.audit-detail-item__label {
+  flex: 0 0 auto;
   color: var(--text-tertiary);
   font-size: 9.5px;
   font-weight: 650;
   letter-spacing: 0.05em;
   line-height: 12px;
   text-transform: uppercase;
+}
+
+.audit-detail-item__action {
+  display: inline-flex;
+  flex: 0 0 auto;
 }
 
 .audit-detail-item code {
@@ -9837,6 +9861,97 @@ body {
   line-height: 15px;
   overflow-wrap: anywhere;
   white-space: normal;
+}
+
+.audit-copy-trace-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 22px;
+  padding: 0 8px 0 7px;
+  border: 1px solid var(--panel-border);
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--panel-muted-bg) 80%, white);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 1;
+  text-transform: none;
+  transition:
+    background-color 160ms cubic-bezier(0.25, 1, 0.5, 1),
+    border-color 160ms cubic-bezier(0.25, 1, 0.5, 1),
+    color 160ms cubic-bezier(0.25, 1, 0.5, 1),
+    transform 120ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.audit-copy-trace-button:hover {
+  border-color: var(--border-strong);
+  background: var(--panel-bg);
+  color: var(--text-primary);
+}
+
+.audit-copy-trace-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--action) 34%, transparent);
+  outline-offset: 2px;
+}
+
+.audit-copy-trace-button:active {
+  transform: translateY(1px);
+}
+
+.audit-copy-trace-button--copied {
+  border-color: color-mix(in srgb, var(--success) 24%, var(--panel-border));
+  color: var(--success);
+}
+
+.audit-copy-trace-button--failed {
+  border-color: color-mix(in srgb, var(--attention) 24%, var(--panel-border));
+  color: var(--attention);
+}
+
+.audit-copy-trace-button__icon {
+  position: relative;
+  display: inline-flex;
+  width: 13px;
+  height: 13px;
+  flex: 0 0 13px;
+  color: currentColor;
+}
+
+.audit-copy-trace-button__glyph {
+  position: absolute;
+  inset: 0;
+  width: 13px;
+  height: 13px;
+  opacity: 1;
+  transform: scale(1) rotate(0deg);
+  transition:
+    opacity 260ms cubic-bezier(0.25, 1, 0.5, 1),
+    transform 260ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.audit-copy-trace-button__glyph--check {
+  opacity: 0;
+  transform: scale(0.7) rotate(-8deg);
+}
+
+.audit-copy-trace-button--copied .audit-copy-trace-button__glyph--copy {
+  opacity: 0;
+  transform: scale(0.72) rotate(8deg);
+}
+
+.audit-copy-trace-button--copied .audit-copy-trace-button__glyph--check {
+  opacity: 1;
+  transform: scale(1) rotate(0deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .audit-copy-trace-button,
+  .audit-copy-trace-button__glyph {
+    transition: none;
+  }
 }
 
 .audit-undo-panel {

--- a/src/renderer/src/views/AuditWorkspaceView.tsx
+++ b/src/renderer/src/views/AuditWorkspaceView.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState, type RefObject } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { useEffect, useMemo, useState, type ReactNode, type RefObject } from 'react';
 
 import type { AuditAction, AuditOperation, AuditStateSummary } from '@shared/contracts';
 
@@ -171,10 +172,39 @@ function AuditEventTableRow({
   onToggle: () => void;
   row: AuditEventRow;
 }) {
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const action = row.action;
   const title = action?.title ?? row.operation.title;
   const path = action?.path ?? row.operation.summary;
   const eventTime = action?.completedAt ?? row.operation.completedAt ?? row.operation.startedAt;
+  const failure = row.operation.failure;
+  useEffect(() => {
+    if (copyState === 'idle') {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setCopyState('idle');
+    }, copyState === 'copied' ? 1800 : 2400);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [copyState]);
+
+  const handleCopyFailureTrace = () => {
+    if (!failure?.trace) {
+      return;
+    }
+    if (!navigator.clipboard?.writeText) {
+      setCopyState('failed');
+      return;
+    }
+
+    void navigator.clipboard.writeText(failure.trace)
+      .then(() => setCopyState('copied'))
+      .catch(() => setCopyState('failed'));
+  };
 
   return (
     <>
@@ -207,6 +237,36 @@ function AuditEventTableRow({
               <DetailItem label="Change" value={action ? formatAuditKind(action.kind) : formatAuditKind(row.operation.kind)} />
               <DetailItem label="Before" value={formatStateSummary(action?.before)} variant="wide" />
               <DetailItem label="After" value={formatStateSummary(action?.after)} variant="wide" />
+              {failure ? (
+                <DetailItem
+                  action={failure.trace ? (
+                    <button
+                      aria-label={copyState === 'copied'
+                        ? 'Failure trace copied'
+                        : copyState === 'failed'
+                          ? 'Copy failure trace failed'
+                          : 'Copy failure trace'}
+                      className={[
+                        'audit-copy-trace-button',
+                        copyState === 'copied' ? 'audit-copy-trace-button--copied' : '',
+                        copyState === 'failed' ? 'audit-copy-trace-button--failed' : '',
+                      ].filter(Boolean).join(' ')}
+                      title="Copy failure trace"
+                      type="button"
+                      onClick={handleCopyFailureTrace}
+                    >
+                      <span className="audit-copy-trace-button__icon" aria-hidden="true">
+                        <Copy className="audit-copy-trace-button__glyph audit-copy-trace-button__glyph--copy" strokeWidth={2} />
+                        <Check className="audit-copy-trace-button__glyph audit-copy-trace-button__glyph--check" strokeWidth={2.3} />
+                      </span>
+                      <span>{copyState === 'failed' ? 'Copy failed' : 'Copy trace'}</span>
+                    </button>
+                  ) : null}
+                  label="Failure"
+                  value={failure.message}
+                  variant="wide"
+                />
+              ) : null}
               <DetailItem label="Path" value={path} variant="wide" />
             </div>
             <div className="audit-undo-panel">
@@ -234,17 +294,22 @@ function AuditEventTableRow({
 }
 
 function DetailItem({
+  action,
   label,
   value,
   variant = 'normal',
 }: {
+  action?: ReactNode;
   label: string;
   value: string;
   variant?: 'normal' | 'wide';
 }) {
   return (
     <div className={`audit-detail-item audit-detail-item--${variant}`}>
-      <span>{label}</span>
+      <span className="audit-detail-item__label-row">
+        <span className="audit-detail-item__label">{label}</span>
+        {action ? <span className="audit-detail-item__action">{action}</span> : null}
+      </span>
       <code>{value}</code>
     </div>
   );
@@ -283,6 +348,8 @@ function filterAuditRows(rows: AuditEventRow[], query: string): AuditEventRow[] 
     row.action?.path,
     row.action?.targetPath,
     row.action?.kind,
+    row.operation.failure?.message,
+    row.operation.failure?.trace,
   ].some((value) => value?.toLocaleLowerCase().includes(normalizedQuery)));
 }
 

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -761,6 +761,11 @@ export interface AuditActionDiagnostics {
   };
 }
 
+export interface AuditFailureDiagnostic {
+  message: string;
+  trace: string;
+}
+
 export interface AuditOperation {
   id: string;
   kind: AuditOperationKind;
@@ -772,6 +777,7 @@ export interface AuditOperation {
   actor: 'app';
   sourceMode: InventorySourceMode;
   entity?: { type: 'skill' | 'mcp' | 'settings' | 'sandbox'; name?: string };
+  failure?: AuditFailureDiagnostic;
   undoState: AuditUndoState;
   actionCount: number;
   actions: AuditAction[];


### PR DESCRIPTION
## Summary
- Make stale Skill/MCP resolution requests fail explicitly instead of silently no-oping.
- Capture failed resolution diagnostics in the audit log, including shareable failure traces.
- Add error toasts and a local Audit Log copy-trace CTA with copy/check feedback.

## Validation
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run src/main/audit-log.test.ts src/main/issue-resolution.test.ts src/main/inventory-runtime.test.ts src/renderer/src/app-shell.test.tsx
- Playwright screenshot/DOM check for the Audit Log failure trace CTA