### PR TITLE
Show update download progress

### DIFF
--- a/src/main/auto-update.test.ts
+++ b/src/main/auto-update.test.ts
@@ -49,7 +49,7 @@ describe('auto-update lifecycle', () => {
     expect(runtime.updater.checkForUpdates).toHaveBeenCalledTimes(2);
   });
 
-  it('publishes downloading and ready statuses without a native prompt', () => {
+  it('publishes download progress and ready statuses without a native prompt', () => {
     const runtime = createRuntime({ buildFlavor: 'standard', isPackaged: true });
 
     configureAutoUpdates(runtime);
@@ -58,6 +58,23 @@ describe('auto-update lifecycle', () => {
     expect(downloadingStatus.phase).toBe('downloading');
     expect(downloadingStatus.version).toBe('0.2.0');
     expect(downloadingStatus.lastCheckedAt).toEqual(expect.any(String));
+
+    runtime.listeners.get('download-progress')?.({
+      bytesPerSecond: 1_024_000,
+      percent: 23.5714,
+      total: 28_000_000,
+      transferred: 6_600_000,
+    });
+    expect(getAutoUpdateStatus()).toEqual(expect.objectContaining({
+      downloadProgress: {
+        bytesPerSecond: 1_024_000,
+        percent: 23.5714,
+        totalBytes: 28_000_000,
+        transferredBytes: 6_600_000,
+      },
+      phase: 'downloading',
+      version: '0.2.0',
+    }));
 
     runtime.listeners.get('update-downloaded')?.({ version: '0.2.0' });
     const readyStatus = getAutoUpdateStatus();

--- a/src/main/auto-update.ts
+++ b/src/main/auto-update.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
 
 import { getSkillIndexBuildFlavor, type SkillIndexBuildFlavor } from '@shared/build-flavor';
-import { IPC_CHANNELS, type AutoUpdateStatus } from '@shared/contracts';
+import { IPC_CHANNELS, type AutoUpdateDownloadProgress, type AutoUpdateStatus } from '@shared/contracts';
 
 export const STARTUP_UPDATE_CHECK_DELAY_MS = 5_000;
 export const UPDATE_CHECK_INTERVAL_MS = 5 * 60_000;
@@ -79,6 +79,7 @@ export function configureAutoUpdates(runtime: AutoUpdateRuntime): boolean {
   runtime.updater.on('download-progress', (info) => {
     setAutoUpdateStatus({
       ...getAutoUpdateStatus(),
+      downloadProgress: readDownloadProgress(info),
       phase: 'downloading',
       version: getAutoUpdateStatus().version ?? readUpdateVersion(info),
     });
@@ -203,8 +204,32 @@ function readUpdateVersion(info: unknown): string | undefined {
   return typeof version === 'string' ? version : undefined;
 }
 
+function readDownloadProgress(info: unknown): AutoUpdateDownloadProgress | undefined {
+  if (!info || typeof info !== 'object') {
+    return undefined;
+  }
+
+  const downloadProgress = removeUndefinedFields({
+    bytesPerSecond: readFiniteNumberField(info, 'bytesPerSecond'),
+    percent: readFiniteNumberField(info, 'percent'),
+    totalBytes: readFiniteNumberField(info, 'total'),
+    transferredBytes: readFiniteNumberField(info, 'transferred'),
+  });
+
+  return Object.keys(downloadProgress).length > 0 ? downloadProgress : undefined;
+}
+
+function readFiniteNumberField(source: object, field: string): number | undefined {
+  const value = (source as Record<string, unknown>)[field];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
 function removeUndefinedStatusFields(status: AutoUpdateStatus): AutoUpdateStatus {
+  return removeUndefinedFields(status) as AutoUpdateStatus;
+}
+
+function removeUndefinedFields<T extends object>(value: T): Partial<T> {
   return Object.fromEntries(
-    Object.entries(status).filter(([, value]) => value !== undefined),
-  ) as AutoUpdateStatus;
+    Object.entries(value).filter(([, fieldValue]) => fieldValue !== undefined),
+  ) as Partial<T>;
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -170,6 +170,7 @@ export default function App() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [autoUpdateStatus, setAutoUpdateStatus] = useState<AutoUpdateStatus>({ phase: 'disabled' });
   const [isInstallingUpdate, setIsInstallingUpdate] = useState(false);
+  const didRequestUpdateInstallRef = useRef(false);
   const [isPreviewingOnboarding, setIsPreviewingOnboarding] = useState(false);
   const [isCompletingOnboarding, setIsCompletingOnboarding] = useState(false);
   const [onboardingErrorMessage, setOnboardingErrorMessage] = useState<string | null>(null);
@@ -1258,15 +1259,38 @@ export default function App() {
   }, [resetMcpSelection, resetSkillSelection]);
 
   const handleInstallUpdate = useCallback(async () => {
+    if (didRequestUpdateInstallRef.current) {
+      return;
+    }
+
+    didRequestUpdateInstallRef.current = true;
     setIsInstallingUpdate(true);
     try {
       const nextStatus = await desktopApi.installUpdate();
       setAutoUpdateStatus(nextStatus);
     } catch (error) {
+      didRequestUpdateInstallRef.current = false;
       setIsInstallingUpdate(false);
       setErrorMessage(error instanceof Error ? error.message : 'Failed to install update.');
     }
   }, [desktopApi]);
+
+  useEffect(() => {
+    if (autoUpdateStatus.phase !== 'ready' || didRequestUpdateInstallRef.current) {
+      return;
+    }
+
+    void handleInstallUpdate();
+  }, [autoUpdateStatus.phase, handleInstallUpdate]);
+
+  useEffect(() => {
+    if (autoUpdateStatus.phase === 'downloading' || autoUpdateStatus.phase === 'ready') {
+      return;
+    }
+
+    didRequestUpdateInstallRef.current = false;
+    setIsInstallingUpdate(false);
+  }, [autoUpdateStatus.phase]);
 
   const chooseOnboardingPreferredSource = useCallback(async () => {
     setOnboardingErrorMessage(null);
@@ -1497,13 +1521,20 @@ export default function App() {
 
   if (shouldShowOnboarding) {
     return (
-      <OnboardingFlow
-        errorMessage={onboardingErrorMessage}
-        isCompleting={isCompletingOnboarding}
-        universalSkillsPath={CANONICAL_USER_SKILLS_DISPLAY_PATH}
-        onChoosePreferredSource={chooseOnboardingPreferredSource}
-        onComplete={completeOnboarding}
-      />
+      <>
+        <OnboardingFlow
+          errorMessage={onboardingErrorMessage}
+          isCompleting={isCompletingOnboarding}
+          universalSkillsPath={CANONICAL_USER_SKILLS_DISPLAY_PATH}
+          onChoosePreferredSource={chooseOnboardingPreferredSource}
+          onComplete={completeOnboarding}
+        />
+        <AutoUpdateDialog
+          appName={shellState?.appName ?? APP_NAME}
+          isInstallingUpdate={isInstallingUpdate}
+          status={autoUpdateStatus}
+        />
+      </>
     );
   }
 
@@ -1573,8 +1604,104 @@ export default function App() {
           </section>
         </div>
       ) : null}
+
+      <AutoUpdateDialog
+        appName={shellState?.appName ?? APP_NAME}
+        isInstallingUpdate={isInstallingUpdate}
+        status={autoUpdateStatus}
+      />
     </div>
   );
+}
+
+function AutoUpdateDialog({
+  appName,
+  isInstallingUpdate,
+  status,
+}: {
+  appName: string;
+  isInstallingUpdate: boolean;
+  status: AutoUpdateStatus;
+}) {
+  if (status.phase !== 'downloading' && status.phase !== 'ready' && !isInstallingUpdate) {
+    return null;
+  }
+
+  const isRelaunching = status.phase === 'ready' || isInstallingUpdate;
+  const progressPercent = getUpdateDownloadPercent(status);
+  const visualProgressPercent = isRelaunching ? 100 : progressPercent ?? 22;
+  const sizeLabel = getUpdateDownloadSizeLabel(status);
+  const progressValue = progressPercent === null ? undefined : Math.round(progressPercent);
+
+  return (
+    <div className="auto-update-dialog-root">
+      <section
+        aria-labelledby="auto-update-dialog-title"
+        aria-modal="true"
+        className="auto-update-dialog"
+        role="dialog"
+      >
+        <header className="auto-update-dialog__titlebar">
+          <h2 id="auto-update-dialog-title">Updating {appName}</h2>
+        </header>
+        <div className="auto-update-dialog__body">
+          <div className="auto-update-dialog__mark" aria-hidden="true">
+            <img src={skillIndexMark} alt="" />
+          </div>
+          <div className="auto-update-dialog__content">
+            <h3>{isRelaunching ? `Relaunching ${appName}...` : 'Downloading update...'}</h3>
+            <div
+              aria-label="Update download progress"
+              aria-valuemax={100}
+              aria-valuemin={0}
+              aria-valuenow={progressValue}
+              aria-valuetext={sizeLabel ?? (progressValue === undefined ? 'Preparing download' : `${progressValue}% downloaded`)}
+              className={`auto-update-dialog__progress${progressPercent === null && !isRelaunching ? ' auto-update-dialog__progress--indeterminate' : ''}`}
+              role="progressbar"
+            >
+              <div style={{ width: `${visualProgressPercent}%` }} />
+            </div>
+            <strong className="auto-update-dialog__bytes">
+              {isRelaunching ? 'Download complete' : sizeLabel ?? 'Preparing download...'}
+            </strong>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function getUpdateDownloadPercent(status: AutoUpdateStatus): number | null {
+  const percent = status.downloadProgress?.percent;
+  if (typeof percent !== 'number' || !Number.isFinite(percent)) {
+    return null;
+  }
+
+  return Math.min(Math.max(percent, 0), 100);
+}
+
+function getUpdateDownloadSizeLabel(status: AutoUpdateStatus): string | null {
+  const transferredBytes = status.downloadProgress?.transferredBytes;
+  const totalBytes = status.downloadProgress?.totalBytes;
+
+  if (typeof transferredBytes === 'number' && Number.isFinite(transferredBytes)
+    && typeof totalBytes === 'number' && Number.isFinite(totalBytes)) {
+    return `${formatMegabytes(transferredBytes)} of ${formatMegabytes(totalBytes)}`;
+  }
+
+  if (typeof transferredBytes === 'number' && Number.isFinite(transferredBytes)) {
+    return `${formatMegabytes(transferredBytes)} downloaded`;
+  }
+
+  if (typeof totalBytes === 'number' && Number.isFinite(totalBytes)) {
+    return `${formatMegabytes(totalBytes)} update`;
+  }
+
+  return null;
+}
+
+function formatMegabytes(bytes: number): string {
+  return `${(bytes / 1_000_000).toFixed(1)} MB`;
 }
 
 function StartupScreen({ appName }: { appName: string }) {

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -6,6 +6,7 @@ import {
   type AgentRecord,
   type AppShellState,
   type AuditOperation,
+  type AutoUpdateStatus,
   type SettingsState,
   type SkillInventorySnapshot,
   type SkillRecord,
@@ -66,6 +67,7 @@ describe('App shell inventory views', () => {
   let onUpdateStatusUpdatedMock: Mock<SkillIndexDesktopApi['onUpdateStatusUpdated']>;
   let onAuditUpdatedMock: Mock<SkillIndexDesktopApi['onAuditUpdated']>;
   let inventoryUpdatedListener: ((snapshot: SkillInventorySnapshot) => void) | null;
+  let updateStatusUpdatedListener: ((status: AutoUpdateStatus) => void) | null;
 
   beforeEach(() => {
     getShellStateMock = vi.fn().mockResolvedValue(createShellState());
@@ -102,11 +104,15 @@ describe('App shell inventory views', () => {
     readUpdateStatusMock = vi.fn().mockResolvedValue({ phase: 'disabled' });
     installUpdateMock = vi.fn().mockResolvedValue({ phase: 'ready', version: '0.2.0' });
     inventoryUpdatedListener = null;
+    updateStatusUpdatedListener = null;
     onInventoryUpdatedMock = vi.fn((listener: (snapshot: SkillInventorySnapshot) => void) => {
       inventoryUpdatedListener = listener;
       return () => undefined;
     });
-    onUpdateStatusUpdatedMock = vi.fn(() => () => undefined);
+    onUpdateStatusUpdatedMock = vi.fn((listener: (status: AutoUpdateStatus) => void) => {
+      updateStatusUpdatedListener = listener;
+      return () => undefined;
+    });
     onAuditUpdatedMock = vi.fn(() => {
       return () => undefined;
     });
@@ -390,7 +396,62 @@ describe('App shell inventory views', () => {
     expect(completeOnboardingMock).not.toHaveBeenCalled();
   });
 
-  it('shows a compact sidebar update button when an update is ready', async () => {
+  it('shows a download progress dialog while an update downloads', async () => {
+    readUpdateStatusMock.mockResolvedValue({
+      downloadProgress: {
+        percent: 23.5714,
+        totalBytes: 28_000_000,
+        transferredBytes: 6_600_000,
+      },
+      phase: 'downloading',
+      version: '0.2.0',
+      lastCheckedAt: '2026-05-17T00:00:00.000Z',
+    });
+    render(<App />);
+
+    const updateDialog = await screen.findByRole('dialog', { name: /Updating Skill Index/i });
+    const progressbar = within(updateDialog).getByRole('progressbar', { name: /Update download progress/i });
+
+    expect(within(updateDialog).getByRole('heading', { name: /Downloading update/i })).toBeInTheDocument();
+    expect(within(updateDialog).getByText('6.6 MB of 28.0 MB')).toBeInTheDocument();
+    expect(progressbar).toHaveAttribute('aria-valuenow', '24');
+  });
+
+  it('relaunches automatically once a downloaded update is ready', async () => {
+    readUpdateStatusMock.mockResolvedValue({
+      downloadProgress: {
+        percent: 100,
+        totalBytes: 28_000_000,
+        transferredBytes: 28_000_000,
+      },
+      phase: 'downloading',
+      version: '0.2.0',
+      lastCheckedAt: '2026-05-17T00:00:00.000Z',
+    });
+    render(<App />);
+
+    await screen.findByRole('dialog', { name: /Updating Skill Index/i });
+    await waitFor(() => {
+      expect(onUpdateStatusUpdatedMock).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      updateStatusUpdatedListener?.({
+        phase: 'ready',
+        version: '0.2.0',
+        lastCheckedAt: '2026-05-17T00:00:01.000Z',
+      });
+    });
+
+    await waitFor(() => {
+      expect(installUpdateMock).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByRole('dialog', { name: /Updating Skill Index/i })).toHaveTextContent(
+      /Relaunching Skill Index/i,
+    );
+  });
+
+  it('relaunches automatically when an update is already ready', async () => {
     readUpdateStatusMock.mockResolvedValue({
       phase: 'ready',
       version: '0.2.0',
@@ -398,14 +459,12 @@ describe('App shell inventory views', () => {
     });
     render(<App />);
 
-    const updateButton = await screen.findByRole('button', { name: /Restart to install Skill Index 0\.2\.0/i });
-
-    expect(updateButton).toHaveTextContent(/^Update$/);
-    fireEvent.click(updateButton);
-
     await waitFor(() => {
       expect(installUpdateMock).toHaveBeenCalledTimes(1);
     });
+    expect(await screen.findByRole('dialog', { name: /Updating Skill Index/i })).toHaveTextContent(
+      /Relaunching Skill Index/i,
+    );
   });
 
   it('hides the sidebar update affordance when updates are disabled', async () => {

--- a/src/renderer/src/app/browser-preview-adapter.ts
+++ b/src/renderer/src/app/browser-preview-adapter.ts
@@ -209,6 +209,12 @@ function getBrowserPreviewUpdateStatus() {
   }
   if (mockUpdate === 'downloading') {
     return {
+      downloadProgress: {
+        bytesPerSecond: 1_024_000,
+        percent: 23.5714,
+        totalBytes: 28_000_000,
+        transferredBytes: 6_600_000,
+      },
       phase: 'downloading' as const,
       version: '0.2.0',
       lastCheckedAt: new Date().toISOString(),

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -5745,6 +5745,142 @@ body {
   transform-origin: center;
 }
 
+.auto-update-dialog-root {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(11, 15, 17, 0.24);
+  backdrop-filter: blur(4px);
+}
+
+.auto-update-dialog {
+  width: min(500px, calc(100vw - 32px));
+  overflow: hidden;
+  border: 1px solid rgba(139, 158, 166, 0.36);
+  border-radius: 16px;
+  background: #20292c;
+  color: #eef2f3;
+  box-shadow:
+    0 22px 64px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.auto-update-dialog__titlebar {
+  display: flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 24px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.24);
+  background: #202a2e;
+}
+
+.auto-update-dialog__titlebar h2 {
+  margin: 0;
+  font-family: Inter, sans-serif;
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 700;
+  letter-spacing: 0;
+  color: #aeb9be;
+}
+
+.auto-update-dialog__body {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: 16px;
+  align-items: center;
+  padding: 16px 24px 20px;
+}
+
+.auto-update-dialog__mark {
+  width: 56px;
+  height: 56px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  background: #fbfbfb;
+  box-shadow:
+    0 10px 22px rgba(0, 0, 0, 0.24),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+.auto-update-dialog__mark img {
+  width: 46px;
+  height: 46px;
+  object-fit: contain;
+}
+
+.auto-update-dialog__content {
+  display: grid;
+  min-width: 0;
+  gap: 10px;
+}
+
+.auto-update-dialog__content h3 {
+  margin: 0;
+  font-family: Inter, sans-serif;
+  font-size: 17px;
+  line-height: 22px;
+  font-weight: 750;
+  letter-spacing: 0;
+  color: #f4f6f7;
+}
+
+.auto-update-dialog__progress {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #3a4448;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.34);
+}
+
+.auto-update-dialog__progress > div {
+  height: 100%;
+  min-width: 8px;
+  border-radius: inherit;
+  background: #1188f4;
+  box-shadow: 0 0 18px rgba(17, 136, 244, 0.3);
+  transition: width 180ms ease;
+}
+
+.auto-update-dialog__progress--indeterminate > div {
+  animation: auto-update-progress-pulse 1200ms ease-in-out infinite;
+}
+
+.auto-update-dialog__bytes {
+  display: block;
+  font-size: 16px;
+  line-height: 22px;
+  font-weight: 600;
+  letter-spacing: 0;
+  color: #e5eaec;
+}
+
+@keyframes auto-update-progress-pulse {
+  0% {
+    transform: translateX(-40%);
+  }
+
+  50% {
+    transform: translateX(160%);
+  }
+
+  100% {
+    transform: translateX(-40%);
+  }
+}
+
+@media (max-width: 560px) {
+  .auto-update-dialog__body {
+    grid-template-columns: 1fr;
+  }
+}
+
 .add-skill-modal-root {
   position: fixed;
   inset: 0;

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -83,9 +83,17 @@ export type AutoUpdatePhase =
 
 export interface AutoUpdateStatus {
   phase: AutoUpdatePhase;
+  downloadProgress?: AutoUpdateDownloadProgress;
   version?: string;
   lastCheckedAt?: string;
   errorMessage?: string;
+}
+
+export interface AutoUpdateDownloadProgress {
+  bytesPerSecond?: number;
+  percent?: number;
+  totalBytes?: number;
+  transferredBytes?: number;
 }
 
 export type SkillSourceScope = 'sandbox' | 'live' | 'custom';


### PR DESCRIPTION
Changes:

Added auto-update download progress to the shared status contract and main-process event handling. Rendered a compact update dialog that shows download progress and relaunches automatically when the update is ready.

Validation:
pnpm test -- src/renderer/src/app-shell.test.tsx
pnpm typecheck
