### PR TITLE
Harden skill inventory scans

### DIFF
--- a/src/main/skill-inventory.test.ts
+++ b/src/main/skill-inventory.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { mkdir, mkdtemp, readFile, readlink, realpath, rm, symlink, utimes, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readlink, realpath, rm, symlink, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -2458,6 +2458,259 @@ describe('representative-agent scan foundation', () => {
     expect(divergedPartialSymlink?.locations.map((location) => location.fileType)).toEqual(['real-file', 'symlink', 'symlink', 'real-file']);
     expect(divergedPartialSymlink?.structuralState).toBe('diverged-drift');
     expect(divergedPartialSymlink?.diff?.files?.map((file) => file.relativePath)).toEqual(['rules/usage.md']);
+  });
+
+  it('keeps scanning when a skill folder contains a stale SKILL.md symlink', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-stale-entrypoint-symlink-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+    const skillDir = path.join(paths.sandboxAgentsSkillsDir, 'stale-entrypoint-symlink-skill');
+    const missingEntrypointTarget = path.join(root, 'removed-source', 'stale-entrypoint-symlink-skill', 'SKILL.md');
+
+    await mkdir(skillDir, { recursive: true });
+    await symlink(missingEntrypointTarget, path.join(skillDir, 'SKILL.md'));
+
+    const inventory = await scanSkillInventory({
+      paths,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+
+    expect(inventory.skills.find((skill) => skill.name === 'stale-entrypoint-symlink-skill')).toMatchObject({
+      issueReasons: arrayContaining(['invalid-definition']),
+      detailDiagnostics: {
+        definitionIssues: arrayContaining([
+          objectContaining({
+            type: 'unreadable-file',
+            entrypointPath: path.join(skillDir, 'SKILL.md'),
+          }),
+        ]),
+      },
+    });
+  });
+
+  it('keeps scanning the live Claude skills folder when SKILL.md points at a removed nested skill', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-live-claude-stale-entrypoint-'));
+    const homeDir = path.join(root, 'home');
+    const dataDir = path.join(root, 'data');
+    const env = {
+      SKILL_INDEX_AGENT_SUBSET: 'claude',
+    };
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: dataDir,
+      },
+      homeDir,
+    });
+    const claudeSkillsDir = path.join(homeDir, '.claude', 'skills');
+    const autoplanDir = path.join(claudeSkillsDir, 'autoplan');
+    const missingNestedEntrypoint = path.join(claudeSkillsDir, 'gstack', 'autoplan', 'SKILL.md');
+
+    await mkdir(autoplanDir, { recursive: true });
+    await symlink(missingNestedEntrypoint, path.join(autoplanDir, 'SKILL.md'));
+
+    const inventory = await scanSkillInventory({
+      paths,
+      homeDir,
+      env,
+      includeLiveSources: true,
+      includeSandboxSources: false,
+    });
+
+    expect(inventory.skills.find((skill) => skill.name === 'autoplan')).toMatchObject({
+      locations: arrayContaining([
+        objectContaining({
+          path: autoplanDir,
+          entrypointPath: path.join(autoplanDir, 'SKILL.md'),
+          sourceId: 'live-claude',
+        }),
+      ]),
+      issueReasons: arrayContaining(['invalid-definition']),
+      detailDiagnostics: {
+        definitionIssues: arrayContaining([
+          objectContaining({
+            type: 'unreadable-file',
+            entrypointPath: path.join(autoplanDir, 'SKILL.md'),
+          }),
+        ]),
+      },
+    });
+  });
+
+  it('keeps scanning valid skills when discovery reaches an unreadable nested directory', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-unreadable-discovery-dir-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+    const customSkillsDir = path.join(root, 'custom-skills');
+    const unreadableDir = path.join(customSkillsDir, 'archived');
+
+    await writeSkillFile(
+      customSkillsDir,
+      'healthy-custom-skill',
+      [
+        '---',
+        'name: healthy-custom-skill',
+        'description: Healthy custom skill.',
+        '---',
+        '',
+        '# Healthy custom skill',
+        '',
+      ].join('\n'),
+      '2026-04-09T00:00:00.000Z',
+    );
+    await mkdir(unreadableDir, { recursive: true });
+    await chmod(unreadableDir, 0o000);
+    try {
+      await writeSkillIndexConfig(paths.configFile, {
+        customScanPaths: [customSkillsDir],
+        preferredCanonicalSourcePath: null,
+        dismissedDriftSignatures: [],
+        dismissedMcpSignatures: [],
+      });
+
+      const inventory = await scanSkillInventory({
+        paths,
+        includeSandboxSources: false,
+        includeLiveSources: false,
+      });
+
+      expect(inventory.skills.find((skill) => skill.name === 'healthy-custom-skill')).toMatchObject({
+        issueReasons: arrayContaining(['missing-canonical']),
+      });
+    } finally {
+      await chmod(unreadableDir, 0o700).catch(() => undefined);
+    }
+  });
+
+  it('keeps a skill readable when an unreadable support directory cannot be walked', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-unreadable-support-dir-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+    const skillDir = path.join(paths.sandboxAgentsSkillsDir, 'support-dir-permission-skill');
+    const unreadableSupportDir = path.join(skillDir, 'private');
+
+    await writeSkillFile(
+      paths.sandboxAgentsSkillsDir,
+      'support-dir-permission-skill',
+      [
+        '---',
+        'name: support-dir-permission-skill',
+        'description: Skill with a private support directory.',
+        '---',
+        '',
+        '# Support dir permission skill',
+        '',
+      ].join('\n'),
+      '2026-04-09T00:00:00.000Z',
+    );
+    await mkdir(unreadableSupportDir, { recursive: true });
+    await chmod(unreadableSupportDir, 0o000);
+    try {
+      const inventory = await scanSkillInventory({
+        paths,
+        includeSandboxSources: true,
+        includeLiveSources: false,
+      });
+
+      expect(inventory.skills.find((skill) => skill.name === 'support-dir-permission-skill')).toMatchObject({
+        description: 'Skill with a private support directory.',
+        detailDiagnostics: {
+          definitionIssues: [],
+        },
+      });
+    } finally {
+      await chmod(unreadableSupportDir, 0o700).catch(() => undefined);
+    }
+  });
+
+  it('keeps scanning when discovery encounters a symlinked directory cycle', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-discovery-cycle-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+    const customSkillsDir = path.join(root, 'custom-skills');
+
+    await writeSkillFile(
+      customSkillsDir,
+      'cycle-neighbor-skill',
+      [
+        '---',
+        'name: cycle-neighbor-skill',
+        'description: Neighbor skill next to a directory loop.',
+        '---',
+        '',
+        '# Cycle neighbor skill',
+        '',
+      ].join('\n'),
+      '2026-04-09T00:00:00.000Z',
+    );
+    await symlink(customSkillsDir, path.join(customSkillsDir, 'loop'));
+    await writeSkillIndexConfig(paths.configFile, {
+      customScanPaths: [customSkillsDir],
+      preferredCanonicalSourcePath: null,
+      dismissedDriftSignatures: [],
+      dismissedMcpSignatures: [],
+    });
+
+    const inventory = await scanSkillInventory({
+      paths,
+      includeSandboxSources: false,
+      includeLiveSources: false,
+    });
+
+    expect(inventory.skills.find((skill) => skill.name === 'cycle-neighbor-skill')).toMatchObject({
+      description: 'Neighbor skill next to a directory loop.',
+    });
+  });
+
+  it('keeps a skill readable when its support files contain a symlinked directory cycle', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-package-cycle-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+    const skillDir = path.join(paths.sandboxAgentsSkillsDir, 'support-dir-cycle-skill');
+
+    await writeSkillFile(
+      paths.sandboxAgentsSkillsDir,
+      'support-dir-cycle-skill',
+      [
+        '---',
+        'name: support-dir-cycle-skill',
+        'description: Skill with a support directory cycle.',
+        '---',
+        '',
+        '# Support dir cycle skill',
+        '',
+      ].join('\n'),
+      '2026-04-09T00:00:00.000Z',
+    );
+    await symlink(skillDir, path.join(skillDir, 'loop'));
+
+    const inventory = await scanSkillInventory({
+      paths,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+
+    expect(inventory.skills.find((skill) => skill.name === 'support-dir-cycle-skill')).toMatchObject({
+      description: 'Skill with a support directory cycle.',
+      detailDiagnostics: {
+        definitionIssues: [],
+      },
+    });
   });
 
   it('treats identical zero-byte markdown copies as identical drift with stable hashes', async () => {

--- a/src/main/skill-inventory.test.ts
+++ b/src/main/skill-inventory.test.ts
@@ -2713,6 +2713,57 @@ describe('representative-agent scan foundation', () => {
     });
   });
 
+  it('keeps repeated support-directory aliases in package files when they are not recursive cycles', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-package-aliases-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+    const skillDir = path.join(paths.sandboxAgentsSkillsDir, 'support-dir-alias-skill');
+    const sharedSupportDir = path.join(skillDir, 'shared-support');
+
+    await writeSkillFile(
+      paths.sandboxAgentsSkillsDir,
+      'support-dir-alias-skill',
+      [
+        '---',
+        'name: support-dir-alias-skill',
+        'description: Skill with repeated support directory aliases.',
+        '---',
+        '',
+        '# Support dir alias skill',
+        '',
+      ].join('\n'),
+      '2026-04-09T00:00:00.000Z',
+    );
+    await writeNestedSkillFile(
+      path.join(sharedSupportDir, 'guide.md'),
+      '# Shared support guide\n',
+      '2026-04-09T00:00:01.000Z',
+    );
+    await symlink(sharedSupportDir, path.join(skillDir, 'alias-a'));
+    await symlink(sharedSupportDir, path.join(skillDir, 'alias-b'));
+
+    const inventory = await scanSkillInventory({
+      paths,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+
+    expect(
+      inventory.skills
+        .find((skill) => skill.name === 'support-dir-alias-skill')
+        ?.locations.find((location) => location.path === skillDir)
+        ?.packageFiles?.map((file) => file.relativePath),
+    ).toEqual([
+      'alias-a/guide.md',
+      'alias-b/guide.md',
+      'shared-support/guide.md',
+      'SKILL.md',
+    ].sort((left, right) => left.localeCompare(right)));
+  });
+
   it('treats identical zero-byte markdown copies as identical drift with stable hashes', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-scan-'));
     const paths = resolveSkillIndexPaths({

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -595,45 +595,51 @@ async function collectNestedSkillEntryFiles(
   source: SkillScanSource,
   rootDir: string,
   currentDir: string,
-  visitedDirectories: Set<string>,
+  activeDirectories: Set<string>,
 ): Promise<SkillPackageEntry[]> {
   const visitKey = await getDirectoryVisitKey(currentDir);
-  if (visitKey && visitedDirectories.has(visitKey)) {
+  if (visitKey && activeDirectories.has(visitKey)) {
     return [];
   }
   if (visitKey) {
-    visitedDirectories.add(visitKey);
+    activeDirectories.add(visitKey);
   }
 
-  let entries: Dirent[];
   try {
-    entries = await readdir(currentDir, { withFileTypes: true });
-  } catch {
-    return [];
+    let entries: Dirent[];
+    try {
+      entries = await readdir(currentDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    const files: SkillPackageEntry[] = [];
+
+    for (const entry of entries) {
+      const entryPath = path.join(currentDir, entry.name);
+      if (
+        (!entry.isDirectory() && !entry.isSymbolicLink())
+        || shouldIgnoreSkillDiscoveryEntry(source, rootDir, entryPath, entry.name)
+      ) {
+        continue;
+      }
+
+      const skillPackage = await describeExistingSkillPackage(rootDir, entryPath);
+      if (skillPackage) {
+        files.push(skillPackage);
+        continue;
+      }
+
+      if (await isDirectoryLikePath(entryPath)) {
+        files.push(...(await collectNestedSkillEntryFiles(source, rootDir, entryPath, activeDirectories)));
+      }
+    }
+
+    return files.sort((left, right) => left.rootPath.localeCompare(right.rootPath));
+  } finally {
+    if (visitKey) {
+      activeDirectories.delete(visitKey);
+    }
   }
-  const files: SkillPackageEntry[] = [];
-
-  for (const entry of entries) {
-    const entryPath = path.join(currentDir, entry.name);
-    if (
-      (!entry.isDirectory() && !entry.isSymbolicLink())
-      || shouldIgnoreSkillDiscoveryEntry(source, rootDir, entryPath, entry.name)
-    ) {
-      continue;
-    }
-
-    const skillPackage = await describeExistingSkillPackage(rootDir, entryPath);
-    if (skillPackage) {
-      files.push(skillPackage);
-      continue;
-    }
-
-    if (await isDirectoryLikePath(entryPath)) {
-      files.push(...(await collectNestedSkillEntryFiles(source, rootDir, entryPath, visitedDirectories)));
-    }
-  }
-
-  return files.sort((left, right) => left.rootPath.localeCompare(right.rootPath));
 }
 
 async function readSkillLocation(
@@ -3143,50 +3149,56 @@ async function readPackageFiles(rootPath: string): Promise<SkillPackageFileRecor
 async function walkPackageFiles(
   rootDir: string,
   currentDir: string,
-  visitedDirectories: Set<string>,
+  activeDirectories: Set<string>,
 ): Promise<SkillPackageFileRecord[]> {
   const visitKey = await getDirectoryVisitKey(currentDir);
-  if (visitKey && visitedDirectories.has(visitKey)) {
+  if (visitKey && activeDirectories.has(visitKey)) {
     return [];
   }
   if (visitKey) {
-    visitedDirectories.add(visitKey);
+    activeDirectories.add(visitKey);
   }
 
-  let entries: Dirent[];
   try {
-    entries = await readdir(currentDir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  const files: SkillPackageFileRecord[] = [];
-
-  for (const entry of entries) {
-    if (shouldIgnorePackageEntry(entry.name, entry.isDirectory())) {
-      continue;
+    let entries: Dirent[];
+    try {
+      entries = await readdir(currentDir, { withFileTypes: true });
+    } catch {
+      return [];
     }
+    const files: SkillPackageFileRecord[] = [];
 
-    const entryPath = path.join(currentDir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...(await walkPackageFiles(rootDir, entryPath, visitedDirectories)));
-      continue;
-    }
-
-    if (entry.isSymbolicLink()) {
-      const stats = await safeStat(entryPath);
-      if (stats?.isDirectory()) {
-        files.push(...(await walkPackageFiles(rootDir, entryPath, visitedDirectories)));
+    for (const entry of entries) {
+      if (shouldIgnorePackageEntry(entry.name, entry.isDirectory())) {
         continue;
+      }
+
+      const entryPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...(await walkPackageFiles(rootDir, entryPath, activeDirectories)));
+        continue;
+      }
+
+      if (entry.isSymbolicLink()) {
+        const stats = await safeStat(entryPath);
+        if (stats?.isDirectory()) {
+          files.push(...(await walkPackageFiles(rootDir, entryPath, activeDirectories)));
+          continue;
+        }
+      }
+
+      const file = await readPackageFile(entryPath, path.relative(rootDir, entryPath));
+      if (file) {
+        files.push(file);
       }
     }
 
-    const file = await readPackageFile(entryPath, path.relative(rootDir, entryPath));
-    if (file) {
-      files.push(file);
+    return files;
+  } finally {
+    if (visitKey) {
+      activeDirectories.delete(visitKey);
     }
   }
-
-  return files;
 }
 
 function shouldIgnorePackageEntry(name: string, isDirectoryEntry: boolean): boolean {

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { accessSync, constants, readFileSync } from 'node:fs';
+import { accessSync, constants, readFileSync, type Dirent } from 'node:fs';
 import { lstat, readdir, readFile, realpath, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -549,7 +549,11 @@ async function collectLocationsFromSource(
   const npxLockCache: NpxSkillLockCache = new Map();
   const locations = await Promise.all(
     filePaths.map(async ({ rootPath, name }) => {
-      const record = await readSkillLocation(rootPath, source, npxLockCache);
+      const record = await safeReadSkillLocation(rootPath, source, npxLockCache);
+      if (!record) {
+        return null;
+      }
+
       return {
         name: createInventorySkillName(name, source),
         record,
@@ -557,7 +561,7 @@ async function collectLocationsFromSource(
     }),
   );
 
-  return locations;
+  return locations.filter((location): location is { name: string; record: IndexedSkillLocation } => location !== null);
 }
 
 function createInventorySkillName(skillName: string, source: SkillScanSource): string {
@@ -584,15 +588,29 @@ function normalizeSelfQualifiedSkillName(skillName: string): string {
 }
 
 async function collectSkillEntryFiles(source: SkillScanSource): Promise<SkillPackageEntry[]> {
-  return collectNestedSkillEntryFiles(source, source.skillsDir, source.skillsDir);
+  return collectNestedSkillEntryFiles(source, source.skillsDir, source.skillsDir, new Set());
 }
 
 async function collectNestedSkillEntryFiles(
   source: SkillScanSource,
   rootDir: string,
   currentDir: string,
+  visitedDirectories: Set<string>,
 ): Promise<SkillPackageEntry[]> {
-  const entries = await readdir(currentDir, { withFileTypes: true });
+  const visitKey = await getDirectoryVisitKey(currentDir);
+  if (visitKey && visitedDirectories.has(visitKey)) {
+    return [];
+  }
+  if (visitKey) {
+    visitedDirectories.add(visitKey);
+  }
+
+  let entries: Dirent[];
+  try {
+    entries = await readdir(currentDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
   const files: SkillPackageEntry[] = [];
 
   for (const entry of entries) {
@@ -611,7 +629,7 @@ async function collectNestedSkillEntryFiles(
     }
 
     if (await isDirectoryLikePath(entryPath)) {
-      files.push(...(await collectNestedSkillEntryFiles(source, rootDir, entryPath)));
+      files.push(...(await collectNestedSkillEntryFiles(source, rootDir, entryPath, visitedDirectories)));
     }
   }
 
@@ -828,9 +846,13 @@ function getOptionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-async function safeReadSkillLocation(filePath: string, source: SkillScanSource): Promise<IndexedSkillLocation | null> {
+async function safeReadSkillLocation(
+  filePath: string,
+  source: SkillScanSource,
+  npxLockCache?: NpxSkillLockCache,
+): Promise<IndexedSkillLocation | null> {
   try {
-    return await readSkillLocation(filePath, source);
+    return await readSkillLocation(filePath, source, npxLockCache);
   } catch {
     return null;
   }
@@ -3114,12 +3136,29 @@ async function isBrokenTopLevelSkillSymlink(rootDir: string, rootPath: string): 
 }
 
 async function readPackageFiles(rootPath: string): Promise<SkillPackageFileRecord[]> {
-  const files = await walkPackageFiles(rootPath, rootPath);
+  const files = await walkPackageFiles(rootPath, rootPath, new Set());
   return files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
 }
 
-async function walkPackageFiles(rootDir: string, currentDir: string): Promise<SkillPackageFileRecord[]> {
-  const entries = await readdir(currentDir, { withFileTypes: true });
+async function walkPackageFiles(
+  rootDir: string,
+  currentDir: string,
+  visitedDirectories: Set<string>,
+): Promise<SkillPackageFileRecord[]> {
+  const visitKey = await getDirectoryVisitKey(currentDir);
+  if (visitKey && visitedDirectories.has(visitKey)) {
+    return [];
+  }
+  if (visitKey) {
+    visitedDirectories.add(visitKey);
+  }
+
+  let entries: Dirent[];
+  try {
+    entries = await readdir(currentDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
   const files: SkillPackageFileRecord[] = [];
 
   for (const entry of entries) {
@@ -3129,14 +3168,14 @@ async function walkPackageFiles(rootDir: string, currentDir: string): Promise<Sk
 
     const entryPath = path.join(currentDir, entry.name);
     if (entry.isDirectory()) {
-      files.push(...(await walkPackageFiles(rootDir, entryPath)));
+      files.push(...(await walkPackageFiles(rootDir, entryPath, visitedDirectories)));
       continue;
     }
 
     if (entry.isSymbolicLink()) {
       const stats = await safeStat(entryPath);
       if (stats?.isDirectory()) {
-        files.push(...(await walkPackageFiles(rootDir, entryPath)));
+        files.push(...(await walkPackageFiles(rootDir, entryPath, visitedDirectories)));
         continue;
       }
     }
@@ -3246,8 +3285,13 @@ async function getLocationModifiedAt(
     return stats.mtime.toISOString();
   }
 
-  const stats = await stat(entrypointPath);
-  return stats.mtime.toISOString();
+  const resolvedEntrypointStats = await safeStat(entrypointPath);
+  if (resolvedEntrypointStats) {
+    return resolvedEntrypointStats.mtime.toISOString();
+  }
+
+  const entrypointStats = await lstat(entrypointPath);
+  return entrypointStats.mtime.toISOString();
 }
 
 function buildPackageDiffFiles(
@@ -3321,6 +3365,10 @@ async function safeRealpath(filePath: string): Promise<string | undefined> {
   } catch {
     return undefined;
   }
+}
+
+async function getDirectoryVisitKey(directoryPath: string): Promise<string | null> {
+  return normalizePath(await safeRealpath(directoryPath) ?? directoryPath);
 }
 
 function collectMcpOwners(agents: AgentRecord[], sources: SkillScanSource[], plugins: PluginRecord[] = []): McpOwnerRecord[] {


### PR DESCRIPTION
Changes:

Harden skill inventory scans against stale SKILL.md symlinks, unreadable directories, deleted scan entries, and symlinked directory cycles so filesystem problems do not abort a full scan.

Validation:
pnpm exec vitest run src/main/skill-inventory.test.ts
pnpm typecheck
git diff --check
