### PR TITLE
Allow canceling MCP connectivity checks

### DIFF
--- a/src/main/inventory-runtime.test.ts
+++ b/src/main/inventory-runtime.test.ts
@@ -702,6 +702,61 @@ describe('inventory runtime', () => {
     });
   }, 10000);
 
+  it('cancels MCP connectivity testing without publishing failed connection results', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-runtime-cancel-mcp-connectivity-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+    const connectivityDeferred = createDeferred<McpConnectivityRecord>();
+    let connectivityProbeStarted = false;
+
+    const runtime = createInventoryRuntime();
+    runtimes.push(runtime);
+
+    const updates: SkillInventorySnapshot[] = [];
+    runtime.onDidUpdate((snapshot) => {
+      updates.push(snapshot);
+    });
+
+    await seedRepresentativeFixtures({ paths });
+    const initialSnapshot = await runtime.scanInventory({
+      paths,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+
+    const connectivityPromise = runtime.testMcpConnectivity({
+      paths,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+      mcpConnectivityConcurrency: 1,
+      verifyMcpConnectivity: async () => {
+        connectivityProbeStarted = true;
+        return connectivityDeferred.promise;
+      },
+    });
+
+    await waitFor(() => {
+      expect(connectivityProbeStarted).toBe(true);
+    });
+
+    runtime.cancelMcpConnectivityTest();
+
+    connectivityDeferred.resolve({
+      status: 'failed',
+      checkedAt: '2026-05-28T12:00:00.000Z',
+      error: 'Canceled run should not publish this failure.',
+    });
+
+    const canceledSnapshot = await connectivityPromise;
+
+    expect(canceledSnapshot).toBe(initialSnapshot);
+    expect(updates).toHaveLength(1);
+    expect((updates[0].mcps ?? []).flatMap((mcp) => mcp.issueReasons)).not.toContain('connection-failed');
+  }, 10000);
+
   it('keeps accepted plugin alternates during watcher refresh after creating missing symlinks', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-runtime-'));
     const paths = resolveSkillIndexPaths({

--- a/src/main/inventory-runtime.ts
+++ b/src/main/inventory-runtime.ts
@@ -66,6 +66,7 @@ export interface InventoryRuntime {
   scanInventory(options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
   rescanInventory(options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
   testMcpConnectivity(options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
+  cancelMcpConnectivityTest(): void;
   addSkill(request: AddSkillRequest, options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
   addMcpServer(request: AddMcpServerRequest, options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
   resolveIssue(request: ResolveIssueRequest): Promise<SkillInventorySnapshot>;
@@ -99,6 +100,8 @@ export function createInventoryRuntime(options: CreateInventoryRuntimeOptions = 
   let refreshInFlight: Promise<SkillInventorySnapshot> | null = null;
   let committedSnapshotRevision = 0;
   let watchRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  let mcpConnectivityRunId = 0;
+  let activeMcpConnectivityAbortController: AbortController | null = null;
 
   const emit = (snapshot: SkillInventorySnapshot) => {
     for (const subscriber of subscribers) {
@@ -200,25 +203,52 @@ export function createInventoryRuntime(options: CreateInventoryRuntimeOptions = 
   const runPassiveMcpConnectivityScan = async (optionsOverride: ScanSkillInventoryOptions = {}): Promise<SkillInventorySnapshot> => {
     const { verifyMcpConnectivity, ...persistentOptionsOverride } = optionsOverride;
     delete persistentOptionsOverride.writeCache;
+    delete persistentOptionsOverride.mcpConnectivityAbortSignal;
+    activeMcpConnectivityAbortController?.abort();
+    const abortController = new AbortController();
+    activeMcpConnectivityAbortController = abortController;
+    const runId = mcpConnectivityRunId + 1;
+    mcpConnectivityRunId = runId;
     const scanOptions: ScanSkillInventoryOptions = {
       ...lastScanOptions,
       ...persistentOptionsOverride,
       verifyMcpConnectivity: verifyMcpConnectivity ?? true,
+      mcpConnectivityAbortSignal: abortController.signal,
       writeCache: false,
     };
     const revisionAtStart = committedSnapshotRevision;
 
-    const snapshot = await scanSkillInventory(scanOptions);
+    try {
+      const snapshot = await scanSkillInventory(scanOptions);
 
-    if (committedSnapshotRevision !== revisionAtStart && currentSnapshot) {
-      await writeSkillInventorySnapshotCache(currentSnapshot, lastScanOptions);
-      return currentSnapshot;
+      if (abortController.signal.aborted || runId !== mcpConnectivityRunId) {
+        return currentSnapshot ?? snapshot;
+      }
+
+      if (committedSnapshotRevision !== revisionAtStart && currentSnapshot) {
+        await writeSkillInventorySnapshotCache(currentSnapshot, lastScanOptions);
+        return currentSnapshot;
+      }
+
+      lastScanOptions = { ...lastScanOptions, ...persistentOptionsOverride };
+      commitSnapshot(snapshot);
+      await writeSkillInventorySnapshotCache(snapshot, lastScanOptions);
+      return snapshot;
+    } finally {
+      if (activeMcpConnectivityAbortController === abortController) {
+        activeMcpConnectivityAbortController = null;
+      }
+    }
+  };
+
+  const cancelMcpConnectivityTest = () => {
+    if (!activeMcpConnectivityAbortController) {
+      return;
     }
 
-    lastScanOptions = { ...lastScanOptions, ...persistentOptionsOverride };
-    commitSnapshot(snapshot);
-    await writeSkillInventorySnapshotCache(snapshot, lastScanOptions);
-    return snapshot;
+    activeMcpConnectivityAbortController.abort();
+    activeMcpConnectivityAbortController = null;
+    mcpConnectivityRunId += 1;
   };
 
   const resolvePersistentRefreshOptions = (optionsOverride?: ScanSkillInventoryOptions): ScanSkillInventoryOptions => {
@@ -368,6 +398,7 @@ export function createInventoryRuntime(options: CreateInventoryRuntimeOptions = 
     async testMcpConnectivity(optionsOverride = {}) {
       return runPassiveMcpConnectivityScan(optionsOverride);
     },
+    cancelMcpConnectivityTest,
     async addSkill(request, optionsOverride = {}) {
       if (refreshInFlight) {
         await refreshInFlight;
@@ -496,6 +527,8 @@ export function createInventoryRuntime(options: CreateInventoryRuntimeOptions = 
       };
     },
     dispose() {
+      cancelMcpConnectivityTest();
+
       if (watchRefreshTimer) {
         clearTimeout(watchRefreshTimer);
         watchRefreshTimer = null;

--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -20,6 +20,7 @@ const { inventoryRuntime } = vi.hoisted(() => ({
     scanInventory: vi.fn(),
     rescanInventory: vi.fn(),
     testMcpConnectivity: vi.fn(),
+    cancelMcpConnectivityTest: vi.fn(),
     addSkill: vi.fn(),
     addMcpServer: vi.fn(),
     resolveIssue: vi.fn(),
@@ -431,6 +432,27 @@ describe('registerIpcHandlers', () => {
     await testConnectivityHandler();
 
     expect(inventoryRuntime.testMcpConnectivity).toHaveBeenCalledWith(expect.objectContaining({}));
+  });
+
+  it('registers a standalone MCP connectivity cancellation handler', async () => {
+    electronMocks.ipcHandle.mockClear();
+    inventoryRuntime.cancelMcpConnectivityTest.mockClear();
+
+    registerIpcHandlers();
+
+    const cancelConnectivityHandler = electronMocks.ipcHandle.mock.calls.find(
+      ([channel]) => channel === IPC_CHANNELS.cancelMcpConnectivityTest,
+    )?.[1] as (() => Promise<unknown>) | undefined;
+
+    expect(cancelConnectivityHandler).toBeTypeOf('function');
+
+    if (!cancelConnectivityHandler) {
+      throw new Error('Expected the MCP connectivity cancellation IPC handler to be registered.');
+    }
+
+    await cancelConnectivityHandler();
+
+    expect(inventoryRuntime.cancelMcpConnectivityTest).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -66,6 +66,7 @@ export function registerIpcHandlers(): void {
   ipcMain.removeHandler(IPC_CHANNELS.scanInventory);
   ipcMain.removeHandler(IPC_CHANNELS.rescanInventory);
   ipcMain.removeHandler(IPC_CHANNELS.testMcpConnectivity);
+  ipcMain.removeHandler(IPC_CHANNELS.cancelMcpConnectivityTest);
   ipcMain.removeHandler(IPC_CHANNELS.addSkill);
   ipcMain.removeHandler(IPC_CHANNELS.addMcpServer);
   ipcMain.removeHandler(IPC_CHANNELS.resolveIssue);
@@ -139,6 +140,9 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.testMcpConnectivity, () =>
     inventoryRuntime.testMcpConnectivity(resolveInventoryScanOptions()),
   );
+  ipcMain.handle(IPC_CHANNELS.cancelMcpConnectivityTest, () => {
+    inventoryRuntime.cancelMcpConnectivityTest();
+  });
   ipcMain.handle(
     IPC_CHANNELS.addSkill,
     (_event, request: AddSkillRequest) =>

--- a/src/main/mcp-connectivity-transport.test.ts
+++ b/src/main/mcp-connectivity-transport.test.ts
@@ -174,6 +174,24 @@ describe('verifyMcpConnection transport setup', () => {
     expect(sdkRecords.clients[0]?.closed).toBe(true);
   });
 
+  it('skips connection setup when the connectivity check is already canceled', async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const result = await verifyMcpConnection(mcpLocation(), {
+      checkedAt: '2026-05-04T12:00:00.000Z',
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      status: 'skipped',
+      checkedAt: '2026-05-04T12:00:00.000Z',
+      error: 'MCP connectivity check canceled.',
+    });
+    expect(sdkRecords.clients).toEqual([]);
+    expect(sdkRecords.stdioTransports).toEqual([]);
+  });
+
   it('uses OpenCode-style environment fields for stdio transports', async () => {
     await verifyMcpConnection(mcpLocation({
       command: 'bun',

--- a/src/main/mcp-connectivity.ts
+++ b/src/main/mcp-connectivity.ts
@@ -18,6 +18,7 @@ interface VerifyMcpConnectionOptions {
   checkedAt?: string;
   timeoutMs?: number;
   definition?: McpDefinitionObject;
+  signal?: AbortSignal;
 }
 
 const DEFAULT_TIMEOUT_MS = 5_000;
@@ -37,6 +38,14 @@ export async function verifyMcpConnection(
   options: VerifyMcpConnectionOptions = {},
 ): Promise<McpConnectivityRecord> {
   const checkedAt = options.checkedAt ?? new Date().toISOString();
+  if (options.signal?.aborted) {
+    return {
+      status: 'skipped',
+      checkedAt,
+      error: 'MCP connectivity check canceled.',
+    };
+  }
+
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const startedAt = Date.now();
   const transport = createTransport(location, options.definition);
@@ -55,13 +64,25 @@ export async function verifyMcpConnection(
   });
 
   try {
-    await client.connect(transport, { timeout: timeoutMs, maxTotalTimeout: timeoutMs });
+    await raceMcpConnectWithAbort(
+      client.connect(transport, { timeout: timeoutMs, maxTotalTimeout: timeoutMs }),
+      options.signal,
+    );
     return {
       status: 'verified',
       checkedAt,
       latencyMs: Date.now() - startedAt,
     };
   } catch (error) {
+    if (isAbortError(error)) {
+      return {
+        status: 'skipped',
+        checkedAt,
+        latencyMs: Date.now() - startedAt,
+        error: 'MCP connectivity check canceled.',
+      };
+    }
+
     return {
       status: 'failed',
       checkedAt,
@@ -71,6 +92,31 @@ export async function verifyMcpConnection(
   } finally {
     await closeClient(client);
   }
+}
+
+async function raceMcpConnectWithAbort(connectPromise: Promise<void>, signal: AbortSignal | undefined): Promise<void> {
+  if (!signal) {
+    return connectPromise;
+  }
+
+  if (signal.aborted) {
+    throw new DOMException('MCP connectivity check canceled.', 'AbortError');
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      reject(new DOMException('MCP connectivity check canceled.', 'AbortError'));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    connectPromise.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
 }
 
 function createTransport(location: McpLocationRecord, definition: McpDefinitionObject | undefined): Transport | null {

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -76,6 +76,7 @@ import { buildPluginSkillScanSources, scanPluginInventory } from '@main/plugin-i
 export interface ScanSkillInventoryOptions extends ScanInventoryOptions, ResolveSkillIndexPathOptions {
   paths?: SkillIndexPaths;
   verifyMcpConnectivity?: boolean | McpConnectivityVerifier;
+  mcpConnectivityAbortSignal?: AbortSignal;
   mcpConnectivityTimeoutMs?: number;
   mcpConnectivityConcurrency?: number;
   writeCache?: boolean;
@@ -87,7 +88,14 @@ export interface McpConnectivityProbeTarget {
   definition: McpDefinitionObject;
 }
 
-export type McpConnectivityVerifier = (target: McpConnectivityProbeTarget) => Promise<McpConnectivityRecord>;
+export interface McpConnectivityVerifierContext {
+  signal?: AbortSignal;
+}
+
+export type McpConnectivityVerifier = (
+  target: McpConnectivityProbeTarget,
+  context?: McpConnectivityVerifierContext,
+) => Promise<McpConnectivityRecord>;
 
 interface IndexedSkillLocation extends SkillLocationRecord {
   entrypointContent?: string;
@@ -1019,7 +1027,7 @@ async function verifyMcpProbeTargets(
   options: ScanSkillInventoryOptions,
 ): Promise<void> {
   const verifier = resolveMcpConnectivityVerifier(options);
-  if (!verifier || targets.length === 0) {
+  if (!verifier || targets.length === 0 || options.mcpConnectivityAbortSignal?.aborted) {
     return;
   }
 
@@ -1027,8 +1035,15 @@ async function verifyMcpProbeTargets(
     targets,
     Math.max(1, options.mcpConnectivityConcurrency ?? 3),
     async (target) => {
-      target.location.connectivity = await verifier(target);
+      if (options.mcpConnectivityAbortSignal?.aborted) {
+        return;
+      }
+
+      target.location.connectivity = await verifier(target, {
+        signal: options.mcpConnectivityAbortSignal,
+      });
     },
+    () => !options.mcpConnectivityAbortSignal?.aborted,
   );
 }
 
@@ -1041,7 +1056,7 @@ function resolveMcpConnectivityVerifier(options: ScanSkillInventoryOptions): Mcp
     return null;
   }
 
-  return async (target) => {
+  return async (target, context) => {
     if (target.location.scope === 'sandbox') {
       return {
         status: 'skipped',
@@ -1052,6 +1067,7 @@ function resolveMcpConnectivityVerifier(options: ScanSkillInventoryOptions): Mcp
 
     return verifyMcpConnection(target.location, {
       definition: target.definition,
+      signal: context?.signal,
       timeoutMs: options.mcpConnectivityTimeoutMs,
     });
   };
@@ -1061,12 +1077,13 @@ async function mapWithConcurrency<T>(
   items: T[],
   concurrency: number,
   run: (item: T) => Promise<void>,
+  shouldContinue: () => boolean = () => true,
 ): Promise<void> {
   let nextIndex = 0;
   const workerCount = Math.min(concurrency, items.length);
 
   await Promise.all(Array.from({ length: workerCount }, async () => {
-    while (nextIndex < items.length) {
+    while (shouldContinue() && nextIndex < items.length) {
       const item = items[nextIndex];
       nextIndex += 1;
       if (item !== undefined) {

--- a/src/preload/bridge.test.ts
+++ b/src/preload/bridge.test.ts
@@ -191,6 +191,7 @@ describe('createSkillIndexDesktopApi', () => {
       if (channel === IPC_CHANNELS.scanInventory) return Promise.resolve(inventorySnapshot);
       if (channel === IPC_CHANNELS.rescanInventory) return Promise.resolve(inventorySnapshot);
       if (channel === IPC_CHANNELS.testMcpConnectivity) return Promise.resolve(inventorySnapshot);
+      if (channel === IPC_CHANNELS.cancelMcpConnectivityTest) return Promise.resolve(undefined);
       if (channel === IPC_CHANNELS.addSkill) return Promise.resolve(inventorySnapshot);
       if (channel === IPC_CHANNELS.addMcpServer) return Promise.resolve(inventorySnapshot);
       if (channel === IPC_CHANNELS.resolveIssue) return Promise.resolve(inventorySnapshot);
@@ -246,6 +247,7 @@ describe('createSkillIndexDesktopApi', () => {
     await expect(api.scanInventory()).resolves.toEqual(inventorySnapshot);
     await expect(api.rescanInventory({ verifyMcpConnectivity: false })).resolves.toEqual(inventorySnapshot);
     await expect((api as unknown as { testMcpConnectivity(): Promise<SkillInventorySnapshot> }).testMcpConnectivity()).resolves.toEqual(inventorySnapshot);
+    await expect(api.cancelMcpConnectivityTest()).resolves.toBeUndefined();
     await expect(api.addSkill({
       sourceType: 'url',
       source: 'https://github.com/vercel-labs/agent-skills',
@@ -313,6 +315,7 @@ describe('createSkillIndexDesktopApi', () => {
     expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.scanInventory);
     expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.rescanInventory, { verifyMcpConnectivity: false });
     expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.testMcpConnectivity);
+    expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.cancelMcpConnectivityTest);
     expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.addSkill, {
       sourceType: 'url',
       source: 'https://github.com/vercel-labs/agent-skills',

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -276,6 +276,20 @@ export default function App() {
       });
   }, [applyInventorySnapshot, desktopApi]);
 
+  const cancelMcpConnectivityTest = useCallback(() => {
+    const previousConnectivityError = mcpConnectivityErrorMessageRef.current;
+    mcpConnectivityRunIdRef.current += 1;
+    mcpConnectivityErrorMessageRef.current = null;
+    setIsTestingMcpConnectivity(false);
+    setErrorMessage((currentMessage) =>
+      currentMessage === previousConnectivityError ? null : currentMessage);
+
+    void desktopApi.cancelMcpConnectivityTest()
+      .catch((error) => {
+        setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+      });
+  }, [desktopApi]);
+
   const triggerRescan = useCallback(async ({
     pendingOperation = null,
     shouldManagePendingOperation = true,
@@ -309,11 +323,13 @@ export default function App() {
       if (showSuccessToast) {
         showAppToast('Inventory refreshed', 'Manual rescan completed successfully.');
       }
+      return true;
     } catch (error) {
       if (showSuccessToast) {
         setAppToast(null);
       }
       setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+      return false;
     } finally {
       setIsRescanning(false);
       if (shouldManagePendingOperation) {
@@ -323,8 +339,15 @@ export default function App() {
   }, [applyInventorySnapshot, desktopApi, showAppToast]);
 
   const triggerManualRescan = useCallback(async () => {
-    await triggerRescan({ showSuccessToast: true });
-  }, [triggerRescan]);
+    const didRescan = await triggerRescan({
+      showSuccessToast: true,
+      verifyMcpConnectivity: false,
+    });
+
+    if (didRescan && inventorySourceMode === 'live') {
+      startMcpConnectivityTest();
+    }
+  }, [inventorySourceMode, startMcpConnectivityTest, triggerRescan]);
 
   useEffect(() => {
     if (!appToast) {
@@ -1342,6 +1365,7 @@ export default function App() {
 
   const isInventoryRefreshActive = isRescanning;
   const isRescanActionBusy = isRescanning || isTestingMcpConnectivity;
+  const onCancelMcpConnectivityTest = isTestingMcpConnectivity ? cancelMcpConnectivityTest : undefined;
   if (!hasLoadedStartupState) {
     return <StartupScreen appName={APP_NAME} />;
   }
@@ -1360,6 +1384,7 @@ export default function App() {
           isAutoResolving={isAutoResolving}
           isRescanning={isRescanActionBusy}
           onAutoResolve={() => { void handleAutoResolve(); }}
+          onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onNavigateToSkills={navigateToSkills}
           onSelectMcp={openMcpFromHome}
           onRescan={triggerManualRescan}
@@ -1378,6 +1403,7 @@ export default function App() {
           isApplyingCapabilityAction={isApplyingCapabilityAction}
           isRescanning={isRescanActionBusy}
           onAddSkill={handleAddSkill}
+          onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onDismissDrift={handleDismissDrift}
           onResolveIssue={handleResolveIssue}
           onApplyCapabilityAction={handleCapabilityAction}
@@ -1415,6 +1441,7 @@ export default function App() {
           mcpInspectorModel={selectedMcpInspectorModel}
           sandboxRoot={shellState?.devTools?.sandboxRoot ?? null}
           onAddMcpServer={handleAddMcpServer}
+          onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onClearSelection={resetMcpSelection}
           onDismissDrift={handleDismissDrift}
           onResolveIssue={handleResolveIssue}
@@ -1437,6 +1464,7 @@ export default function App() {
           errorMessage={errorMessage}
           inventorySnapshot={inventorySnapshot}
           isRescanning={isRescanActionBusy}
+          onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onRescan={triggerManualRescan}
           onSearchQueryChange={setAgentSearchQuery}
           rows={agentRows}
@@ -1451,6 +1479,7 @@ export default function App() {
           errorMessage={errorMessage}
           inventorySnapshot={inventorySnapshot}
           isRescanning={isRescanActionBusy}
+          onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onRescan={triggerManualRescan}
           onSearchQueryChange={setPluginSearchQuery}
           onSelectMcpAsset={openMcpFromHome}
@@ -1476,6 +1505,7 @@ export default function App() {
           auditOperations={auditOperations}
           isRescanning={isRescanActionBusy}
           isUndoingOperation={isUndoingToastOperation}
+          onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onUndoOperation={(operationId) => {
             void handleUndoToastOperation(operationId);
           }}
@@ -1507,6 +1537,7 @@ export default function App() {
           isUpdatingSettings={isUpdatingSettings}
           inventorySnapshot={inventorySnapshot}
           onOpenOnboarding={openOnboardingFromDevelopment}
+          onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onRescan={triggerManualRescan}
           pendingInventoryOperation={pendingInventoryOperation}
           preferredCanonicalSourcePathInput={preferredCanonicalSourcePathInput}

--- a/src/renderer/src/app-search.test.tsx
+++ b/src/renderer/src/app-search.test.tsx
@@ -147,7 +147,7 @@ describe('App search behavior', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /^Rescan$/i }));
 
-    const loadingButton = await screen.findByRole('button', { name: /^Testing MCP connectivity…$/i });
+    const loadingButton = await screen.findByRole('button', { name: /^Rescanning…$/i });
     expect(loadingButton).toBeDisabled();
     expect(loadingButton).toHaveAttribute('aria-busy', 'true');
 
@@ -240,6 +240,7 @@ function createDesktopApi(inventorySnapshot: SkillInventorySnapshot): SkillIndex
     scanInventory: vi.fn().mockResolvedValue(inventorySnapshot),
     rescanInventory: vi.fn().mockResolvedValue(inventorySnapshot),
     testMcpConnectivity: vi.fn().mockResolvedValue(inventorySnapshot),
+    cancelMcpConnectivityTest: vi.fn().mockResolvedValue(undefined),
     addSkill: vi.fn().mockResolvedValue(inventorySnapshot),
     addMcpServer: vi.fn().mockResolvedValue(inventorySnapshot),
     resolveIssue: vi.fn().mockResolvedValue(inventorySnapshot),

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -45,6 +45,7 @@ describe('App shell inventory views', () => {
   let scanInventoryMock: Mock<SkillIndexDesktopApi['scanInventory']>;
   let rescanInventoryMock: Mock<SkillIndexDesktopApi['rescanInventory']>;
   let testMcpConnectivityMock: Mock<SkillIndexDesktopApi['testMcpConnectivity']>;
+  let cancelMcpConnectivityTestMock: Mock<SkillIndexDesktopApi['cancelMcpConnectivityTest']>;
   let addSkillMock: Mock<SkillIndexDesktopApi['addSkill']>;
   let addMcpServerMock: Mock<SkillIndexDesktopApi['addMcpServer']>;
   let makeCanonicalMock: Mock<SkillIndexDesktopApi['resolveIssue']>;
@@ -76,6 +77,7 @@ describe('App shell inventory views', () => {
     scanInventoryMock = vi.fn().mockResolvedValue(createInventorySnapshot());
     rescanInventoryMock = vi.fn().mockResolvedValue(createReconciledInventorySnapshot());
     testMcpConnectivityMock = vi.fn().mockResolvedValue(createReconciledInventorySnapshot());
+    cancelMcpConnectivityTestMock = vi.fn().mockResolvedValue(undefined);
     addSkillMock = vi.fn().mockResolvedValue(createInventorySnapshot());
     addMcpServerMock = vi.fn().mockResolvedValue(createInventorySnapshot());
     makeCanonicalMock = vi.fn().mockResolvedValue(createCanonicalizedDivergedInventorySnapshot());
@@ -129,6 +131,7 @@ describe('App shell inventory views', () => {
       scanInventory: scanInventoryMock,
       rescanInventory: rescanInventoryMock,
       testMcpConnectivity: testMcpConnectivityMock,
+      cancelMcpConnectivityTest: cancelMcpConnectivityTestMock,
       addSkill: addSkillMock,
       addMcpServer: addMcpServerMock,
       resolveIssue: makeCanonicalMock,
@@ -888,7 +891,8 @@ describe('App shell inventory views', () => {
 
     expect(within(settingsSourceControl).getByRole('radio', { name: /Sandbox/i })).toBeEnabled();
     expect(within(settingsSourceControl).getByRole('radio', { name: /Live/i })).toBeEnabled();
-    expect(screen.getByRole('button', { name: /Testing MCP connectivity/i })).toBeDisabled();
+    expect(screen.getByText('Testing MCP connectivity…')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Cancel MCP connectivity test/i })).toBeEnabled();
 
     connectivityDeferred.resolve(createReconciledInventorySnapshot());
 
@@ -897,6 +901,74 @@ describe('App shell inventory views', () => {
       expect(within(settingsSourceControl).getByRole('radio', { name: /Sandbox/i })).toBeEnabled();
       expect(within(settingsSourceControl).getByRole('radio', { name: /Live/i })).toBeEnabled();
     });
+  });
+
+  it('cancels live MCP connectivity testing without applying the eventual test result', async () => {
+    const rescanDeferred = createDeferred<SkillInventorySnapshot>();
+    const connectivityDeferred = createDeferred<SkillInventorySnapshot>();
+    rescanInventoryMock.mockReturnValueOnce(rescanDeferred.promise);
+    testMcpConnectivityMock.mockReturnValueOnce(connectivityDeferred.promise);
+
+    render(<App />);
+
+    await openSettings();
+    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Inventory source' })).getByRole('radio', { name: /Live/i }));
+    rescanDeferred.resolve(createInventorySnapshot());
+
+    await waitFor(() => {
+      expect(testMcpConnectivityMock).toHaveBeenCalledTimes(1);
+    });
+
+    const cancelButton = screen.getByRole('button', { name: /Cancel MCP connectivity test/i });
+    expect(cancelButton).toBeEnabled();
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(cancelMcpConnectivityTestMock).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('button', { name: /^Rescan$/i })).toBeEnabled();
+    });
+
+    connectivityDeferred.resolve(createMcpConnectionFailedInventorySnapshot());
+
+    await openMcps();
+
+    expect(screen.queryByText('Connection Failed')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /healthy-mcp Healthy/i })).toBeInTheDocument();
+  });
+
+  it('runs manual rescans structurally before starting cancelable MCP connectivity in live mode', async () => {
+    const liveShellState = createShellState({
+      devTools: {
+        ...createShellState().devTools!,
+        inventoryMode: 'live',
+      },
+    });
+    const rescanDeferred = createDeferred<SkillInventorySnapshot>();
+    const connectivityDeferred = createDeferred<SkillInventorySnapshot>();
+    getShellStateMock.mockResolvedValue(liveShellState);
+    rescanInventoryMock.mockReturnValueOnce(rescanDeferred.promise);
+    testMcpConnectivityMock.mockReturnValueOnce(connectivityDeferred.promise);
+
+    render(<App />);
+
+    await screen.findByLabelText(/Home summary metrics/i);
+    fireEvent.click(screen.getByRole('button', { name: /^Rescan$/i }));
+
+    await waitFor(() => {
+      expect(rescanInventoryMock).toHaveBeenCalledWith({ verifyMcpConnectivity: false });
+    });
+    expect(testMcpConnectivityMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /^Rescanning…$/i })).toBeDisabled();
+
+    rescanDeferred.resolve(createInventorySnapshot());
+
+    await waitFor(() => {
+      expect(testMcpConnectivityMock).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Testing MCP connectivity…')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Cancel MCP connectivity test/i })).toBeEnabled();
+    });
+
+    connectivityDeferred.resolve(createReconciledInventorySnapshot());
   });
 
   it('keeps issue actions enabled while MCP connectivity testing runs in the background', async () => {
@@ -913,7 +985,8 @@ describe('App shell inventory views', () => {
 
     await waitFor(() => {
       expect(testMcpConnectivityMock).toHaveBeenCalledTimes(1);
-      expect(screen.getByRole('button', { name: /Testing MCP connectivity/i })).toBeDisabled();
+      expect(screen.getByText('Testing MCP connectivity…')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Cancel MCP connectivity test/i })).toBeEnabled();
     });
 
     await openSkills();
@@ -3012,6 +3085,44 @@ function createReconciledInventorySnapshot(): SkillInventorySnapshot {
       identicalDriftSkills: 2,
       divergedDriftSkills: 1,
       dismissedDriftSkills: 1,
+    },
+  });
+}
+
+function createMcpConnectionFailedInventorySnapshot(): SkillInventorySnapshot {
+  const snapshot = createInventorySnapshot();
+  const mcps = (snapshot.mcps ?? []).map<NonNullable<SkillInventorySnapshot['mcps']>[number]>((mcp) => {
+    if (mcp.name !== 'healthy-mcp') {
+      return mcp;
+    }
+
+    return {
+      ...mcp,
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['connection-failed'],
+      locations: mcp.locations.map((location, index) => index === 0
+        ? {
+            ...location,
+            connectivity: {
+              status: 'failed',
+              checkedAt: '2026-05-28T12:00:00.000Z',
+              error: 'Canceled run should not apply this result.',
+            },
+          }
+        : location),
+    };
+  });
+
+  return withSnapshotDetailDiagnostics({
+    ...snapshot,
+    scannedAt: '2026-04-09T00:00:10.000Z',
+    mcps,
+    mcpCounts: {
+      totalMcps: mcps.length,
+      attentionMcps: mcps.filter((mcp) => mcp.presentation === 'active' && mcp.status === 'needs-attention').length,
+      healthyMcps: mcps.filter((mcp) => mcp.status === 'healthy').length,
+      dismissedAttentionMcps: mcps.filter((mcp) => mcp.presentation === 'dismissed').length,
     },
   });
 }

--- a/src/renderer/src/app/browser-preview-adapter.ts
+++ b/src/renderer/src/app/browser-preview-adapter.ts
@@ -73,6 +73,7 @@ const browserPreviewApi: SkillIndexDesktopApi = {
   scanInventory: () => Promise.resolve(cloneInventorySnapshot(browserPreviewSnapshot)),
   rescanInventory: () => resolveWithOptionalPreviewHold(cloneInventorySnapshot(browserPreviewSnapshot)),
   testMcpConnectivity: () => resolveWithOptionalPreviewHold(cloneInventorySnapshot(browserPreviewSnapshot)),
+  cancelMcpConnectivityTest: () => Promise.resolve(),
   addSkill: (request: AddSkillRequest) => {
     void request;
     return Promise.resolve(cloneInventorySnapshot(browserPreviewSnapshot));

--- a/src/renderer/src/components/ui.tsx
+++ b/src/renderer/src/components/ui.tsx
@@ -1,5 +1,5 @@
 import type { AgentRecord } from '@shared/contracts';
-import { Check, Plug, Search } from 'lucide-react';
+import { Check, Plug, Search, X } from 'lucide-react';
 import {
   useEffect,
   useId,
@@ -190,30 +190,61 @@ export function PageTopBar({
 }
 
 export function ToolbarButton({
+  cancelLoadingLabel,
   disabled = false,
   icon,
   isLoading = false,
   label,
   loadingLabel,
+  onCancelLoading,
   onClick,
   subtle = false,
   variant = 'default',
 }: {
+  cancelLoadingLabel?: string;
   disabled?: boolean;
   icon?: Extract<NavIconName, 'rescan'>;
   isLoading?: boolean;
   label: string;
   loadingLabel?: string;
+  onCancelLoading?: () => void;
   onClick?: () => void;
   subtle?: boolean;
   variant?: 'default' | 'strong';
 }) {
   const visibleLabel = isLoading && loadingLabel ? loadingLabel : label;
+  const className = `toolbar-button toolbar-button--${variant}${subtle ? ' toolbar-button--subtle' : ''}${isLoading ? ' toolbar-button--loading' : ''}`;
+
+  if (isLoading && onCancelLoading) {
+    return (
+      <div
+        aria-busy="true"
+        aria-label={visibleLabel}
+        className={`${className} toolbar-button--cancelable`}
+        role="group"
+      >
+        {icon ? (
+          <span className="toolbar-button-icon toolbar-button-icon--loading" aria-hidden="true">
+            <NavIcon icon={icon} />
+          </span>
+        ) : null}
+        <span>{variant === 'strong' ? `+ ${visibleLabel}` : visibleLabel}</span>
+        <button
+          aria-label={cancelLoadingLabel ?? `Cancel ${visibleLabel}`}
+          className="toolbar-button-cancel"
+          type="button"
+          onClick={onCancelLoading}
+        >
+          <X aria-hidden="true" />
+        </button>
+      </div>
+    );
+  }
 
   return (
     <button
       aria-busy={isLoading || undefined}
-      className={`toolbar-button toolbar-button--${variant}${subtle ? ' toolbar-button--subtle' : ''}${isLoading ? ' toolbar-button--loading' : ''}`}
+      className={className}
       disabled={disabled || isLoading}
       type="button"
       onClick={onClick}
@@ -230,17 +261,21 @@ export function ToolbarButton({
 
 export function RescanToolbarButton({
   isRescanning,
+  onCancel,
   onRescan,
 }: {
   isRescanning: boolean;
+  onCancel?: () => void;
   onRescan: () => Promise<void>;
 }) {
   return (
     <ToolbarButton
+      cancelLoadingLabel="Cancel MCP connectivity test"
       icon="rescan"
       isLoading={isRescanning}
       label="Rescan"
-      loadingLabel="Testing MCP connectivity…"
+      loadingLabel={onCancel ? 'Testing MCP connectivity…' : 'Rescanning…'}
+      onCancelLoading={onCancel}
       onClick={() => {
         void onRescan();
       }}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -5722,6 +5722,35 @@ body {
   opacity: 0.72;
 }
 
+.toolbar-button--cancelable {
+  padding-right: 3px;
+  cursor: default;
+}
+
+.toolbar-button-cancel {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-left: 2px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.toolbar-button-cancel:hover {
+  background: var(--bg-panel-muted);
+  color: var(--text-primary);
+}
+
+.toolbar-button-cancel svg {
+  width: 12px;
+  height: 12px;
+}
+
 .toolbar-button--subtle {
   background: #ffffff;
 }

--- a/src/renderer/src/views/AgentsWorkspaceView.test.tsx
+++ b/src/renderer/src/views/AgentsWorkspaceView.test.tsx
@@ -50,11 +50,11 @@ function renderAgentsView(rows: AgentRecord[], options: { isRescanning?: boolean
 }
 
 describe('AgentsWorkspaceView', () => {
-  it('uses MCP connectivity loading copy for the global rescan action', () => {
+  it('uses rescan loading copy for the global rescan action', () => {
     renderAgentsView([createAgent()], { isRescanning: true });
 
-    expect(screen.getByRole('button', { name: 'Testing MCP connectivity…' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Rescanning…' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rescanning…' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Testing MCP connectivity…' })).not.toBeInTheDocument();
   });
 
   it('groups agents by installed state and shows location headers in the section header', () => {

--- a/src/renderer/src/views/AgentsWorkspaceView.tsx
+++ b/src/renderer/src/views/AgentsWorkspaceView.tsx
@@ -11,6 +11,7 @@ export function AgentsWorkspaceView({
   errorMessage,
   inventorySnapshot,
   isRescanning,
+  onCancelMcpConnectivityTest,
   onRescan,
   onSearchQueryChange,
   rows,
@@ -20,6 +21,7 @@ export function AgentsWorkspaceView({
   errorMessage: string | null;
   inventorySnapshot: SkillInventorySnapshot | null;
   isRescanning: boolean;
+  onCancelMcpConnectivityTest?: () => void;
   onRescan: () => Promise<void>;
   onSearchQueryChange: (query: string) => void;
   rows: AgentRecord[];
@@ -66,7 +68,7 @@ export function AgentsWorkspaceView({
     <main className="workspace-view">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onRescan={onRescan} />
+          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
         )}
         search={(
           <HeaderSearch

--- a/src/renderer/src/views/AuditWorkspaceView.tsx
+++ b/src/renderer/src/views/AuditWorkspaceView.tsx
@@ -18,6 +18,7 @@ export function AuditWorkspaceView({
   auditOperations,
   isRescanning,
   isUndoingOperation,
+  onCancelMcpConnectivityTest,
   onUndoOperation,
   onRescan,
   searchInputRef,
@@ -27,6 +28,7 @@ export function AuditWorkspaceView({
   auditOperations: AuditOperation[];
   isRescanning: boolean;
   isUndoingOperation: boolean;
+  onCancelMcpConnectivityTest?: () => void;
   onUndoOperation: (operationId: string) => void;
   onRescan: () => Promise<void>;
   searchInputRef?: RefObject<HTMLInputElement | null>;
@@ -76,7 +78,7 @@ export function AuditWorkspaceView({
     <main className="workspace-view workspace-view--audit">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onRescan={onRescan} />
+          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
         )}
         title="Audit Log"
         search={(

--- a/src/renderer/src/views/HomeDashboard.test.tsx
+++ b/src/renderer/src/views/HomeDashboard.test.tsx
@@ -15,11 +15,11 @@ const safeRepairRequest: ResolveIssueRequest = {
 };
 
 describe('HomeDashboard', () => {
-  it('uses MCP connectivity loading copy for the global rescan action', () => {
+  it('uses rescan loading copy for the global rescan action', () => {
     renderDashboard({ isRescanning: true });
 
-    expect(screen.getByRole('button', { name: 'Testing MCP connectivity…' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Rescanning…' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rescanning…' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Testing MCP connectivity…' })).not.toBeInTheDocument();
   });
 
   it('renders the Home header without a home directory subtitle', () => {

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -256,6 +256,7 @@ export function HomeDashboard({
   isAutoResolving,
   isRescanning,
   onAutoResolve,
+  onCancelMcpConnectivityTest,
   onNavigateToSkills,
   onRescan,
   onSelectMcp,
@@ -268,6 +269,7 @@ export function HomeDashboard({
   isAutoResolving: boolean;
   isRescanning: boolean;
   onAutoResolve: () => void;
+  onCancelMcpConnectivityTest?: () => void;
   onNavigateToSkills: () => void;
   onRescan: () => Promise<void>;
   onSelectMcp: (mcpName: string) => void;
@@ -287,7 +289,7 @@ export function HomeDashboard({
     <main className="workspace-view">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onRescan={onRescan} />
+          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
         )}
         title="Home"
       />

--- a/src/renderer/src/views/InventoryViewChrome.test.tsx
+++ b/src/renderer/src/views/InventoryViewChrome.test.tsx
@@ -167,11 +167,11 @@ describe('inventory view chrome', () => {
     expect(screen.getByRole('button', { name: /healthy-mcp/i }).querySelector('p')).toBeNull();
   });
 
-  it('uses MCP-specific rescan loading copy while connectivity checks run', () => {
+  it('uses rescan loading copy in the MCP workspace', () => {
     renderMcpWorkspaceView({ isRescanning: true });
 
-    expect(screen.getByRole('button', { name: 'Testing MCP connectivity…' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Rescanning…' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rescanning…' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Testing MCP connectivity…' })).not.toBeInTheDocument();
   });
 
   it('shows the plugin indicator for MCP rows with mixed plugin and manual locations', () => {
@@ -252,11 +252,11 @@ describe('inventory view chrome', () => {
     expect(pluginSkillRow).toHaveAccessibleName(/This skill was installed via one or more plugins/i);
   });
 
-  it('uses MCP connectivity loading copy in the Skills workspace', () => {
+  it('uses rescan loading copy in the Skills workspace', () => {
     renderSkillsWorkspaceView({ isRescanning: true });
 
-    expect(screen.getByRole('button', { name: 'Testing MCP connectivity…' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Rescanning…' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rescanning…' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Testing MCP connectivity…' })).not.toBeInTheDocument();
   });
 
   it('keeps the Plugins list inside the shared split scroll container', () => {

--- a/src/renderer/src/views/McpWorkspaceView.tsx
+++ b/src/renderer/src/views/McpWorkspaceView.tsx
@@ -43,6 +43,7 @@ export function McpWorkspaceView({
   mcpInspectorModel,
   sandboxRoot,
   onAddMcpServer,
+  onCancelMcpConnectivityTest,
   onClearSelection,
   onDismissDrift,
   onResolveIssue,
@@ -67,6 +68,7 @@ export function McpWorkspaceView({
   mcpInspectorModel: InspectorModel | null;
   sandboxRoot: string | null;
   onAddMcpServer: (request: AddMcpServerRequest) => Promise<void>;
+  onCancelMcpConnectivityTest?: () => void;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
   onResolveIssue: (request: ResolveIssueRequest) => Promise<void>;
@@ -112,7 +114,7 @@ export function McpWorkspaceView({
         <PageTopBar
           actions={(
             <div className="header-action-cluster">
-              <RescanToolbarButton isRescanning={isRescanning} onRescan={onRescan} />
+              <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
               <ToolbarButton
                 label="Add Server"
                 variant="strong"

--- a/src/renderer/src/views/PluginsWorkspaceView.tsx
+++ b/src/renderer/src/views/PluginsWorkspaceView.tsx
@@ -21,6 +21,7 @@ export function PluginsWorkspaceView({
   errorMessage,
   inventorySnapshot,
   isRescanning,
+  onCancelMcpConnectivityTest,
   onRescan,
   onSearchQueryChange,
   onSelectMcpAsset,
@@ -37,6 +38,7 @@ export function PluginsWorkspaceView({
   errorMessage: string | null;
   inventorySnapshot: SkillInventorySnapshot | null;
   isRescanning: boolean;
+  onCancelMcpConnectivityTest?: () => void;
   onRescan: () => Promise<void>;
   onSearchQueryChange: (query: string) => void;
   onSelectMcpAsset: (mcpName: string) => void;
@@ -61,7 +63,7 @@ export function PluginsWorkspaceView({
     <main className="workspace-view">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onRescan={onRescan} />
+          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
         )}
         search={(
           <HeaderSearch

--- a/src/renderer/src/views/SettingsWorkspaceView.tsx
+++ b/src/renderer/src/views/SettingsWorkspaceView.tsx
@@ -29,6 +29,7 @@ export function SettingsWorkspaceView({
   isUpdatingSettings,
   inventorySnapshot,
   onOpenOnboarding,
+  onCancelMcpConnectivityTest,
   onRescan,
   pendingInventoryOperation,
   preferredCanonicalSourcePathInput,
@@ -55,6 +56,7 @@ export function SettingsWorkspaceView({
   isUpdatingSettings: boolean;
   inventorySnapshot: SkillInventorySnapshot | null;
   onOpenOnboarding: () => void;
+  onCancelMcpConnectivityTest?: () => void;
   onRescan: () => Promise<void>;
   pendingInventoryOperation: PendingInventoryOperation | null;
   preferredCanonicalSourcePathInput: string;
@@ -72,7 +74,7 @@ export function SettingsWorkspaceView({
     <main className="workspace-view">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onRescan={onRescan} />
+          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
         )}
         title="Settings"
       />

--- a/src/renderer/src/views/SkillsWorkspaceView.tsx
+++ b/src/renderer/src/views/SkillsWorkspaceView.tsx
@@ -43,6 +43,7 @@ export function SkillsWorkspaceView({
   isResolvingIssue,
   isRescanning,
   onAddSkill,
+  onCancelMcpConnectivityTest,
   onClearSelection,
   onDismissDrift,
   onApplyCapabilityAction,
@@ -73,6 +74,7 @@ export function SkillsWorkspaceView({
   isResolvingIssue: boolean;
   isRescanning: boolean;
   onAddSkill: (request: AddSkillRequest) => Promise<void>;
+  onCancelMcpConnectivityTest?: () => void;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
   onApplyCapabilityAction: (request: CapabilityActionRequest) => Promise<void>;
@@ -127,7 +129,7 @@ export function SkillsWorkspaceView({
         <PageTopBar
           actions={(
             <div className="header-action-cluster">
-              <RescanToolbarButton isRescanning={isRescanning} onRescan={onRescan} />
+              <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
               <ToolbarButton
                 label="Add Skill"
                 variant="strong"

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -14,6 +14,7 @@ export const IPC_CHANNELS = {
   scanInventory: 'inventory:scan',
   rescanInventory: 'inventory:rescan',
   testMcpConnectivity: 'inventory:test-mcp-connectivity',
+  cancelMcpConnectivityTest: 'inventory:cancel-mcp-connectivity-test',
   addSkill: 'inventory:add-skill',
   addMcpServer: 'inventory:add-mcp-server',
   resolveIssue: 'inventory:resolve-issue',
@@ -811,6 +812,7 @@ export interface SkillIndexDesktopApi {
   scanInventory(): Promise<SkillInventorySnapshot>;
   rescanInventory(request?: RescanInventoryRequest): Promise<SkillInventorySnapshot>;
   testMcpConnectivity(): Promise<SkillInventorySnapshot>;
+  cancelMcpConnectivityTest(): Promise<void>;
   addSkill(request: AddSkillRequest): Promise<SkillInventorySnapshot>;
   addMcpServer(request: AddMcpServerRequest): Promise<SkillInventorySnapshot>;
   resolveIssue(request: ResolveIssueRequest): Promise<SkillInventorySnapshot>;
@@ -880,6 +882,9 @@ export function createSkillIndexDesktopApi(invoke: InvokeLike, subscribe: Subscr
     },
     async testMcpConnectivity() {
       return invoke(IPC_CHANNELS.testMcpConnectivity) as Promise<SkillInventorySnapshot>;
+    },
+    async cancelMcpConnectivityTest() {
+      await invoke(IPC_CHANNELS.cancelMcpConnectivityTest);
     },
     async addSkill(request) {
       return invoke(IPC_CHANNELS.addSkill, request) as Promise<SkillInventorySnapshot>;


### PR DESCRIPTION
Changes:

Adds a cancel affordance to the MCP connectivity loading state, propagates cancellation through IPC and runtime abort handling, and keeps manual rescans structural before starting a cancelable live connectivity test. Canceled connectivity results are ignored so late failures do not create Connection Failed issues.

Validation:
pnpm typecheck
pnpm test -- src/main/inventory-runtime.test.ts src/main/mcp-connectivity-transport.test.ts src/main/skill-inventory.test.ts src/main/ipc.test.ts src/preload/bridge.test.ts src/renderer/src/app-shell.test.tsx src/renderer/src/app-search.test.tsx src/renderer/src/views/HomeDashboard.test.tsx src/renderer/src/views/AgentsWorkspaceView.test.tsx src/renderer/src/views/InventoryViewChrome.test.tsx
