### PR TITLE
Show onboarding scan failure traces

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -75,6 +75,11 @@ function getAutoResolvableRequestsForSnapshot(snapshot: SkillInventorySnapshot):
   ];
 }
 
+interface OnboardingPreferredSourceSelection {
+  didChangePreferredSource: boolean;
+  preferredSourcePath: string | null;
+}
+
 function getResolveIssueRequestKey(request: ResolveIssueRequest): string {
   return [
     request.entity,
@@ -1332,7 +1337,10 @@ export default function App() {
     }
   }, [desktopApi]);
 
-  const completeOnboarding = useCallback(async (preferredSourcePath: string | null) => {
+  const completeOnboarding = useCallback(async ({
+    didChangePreferredSource,
+    preferredSourcePath,
+  }: OnboardingPreferredSourceSelection) => {
     setIsCompletingOnboarding(true);
     setOnboardingErrorMessage(null);
     setOnboardingErrorTrace(null);
@@ -1344,8 +1352,12 @@ export default function App() {
         await devApi.setInventoryMode(shellState.devTools.inventoryMode);
       }
 
-      if (preferredSourcePath) {
-        await desktopApi.setPreferredCanonicalSourcePath(preferredSourcePath);
+      if (didChangePreferredSource) {
+        if (preferredSourcePath) {
+          await desktopApi.setPreferredCanonicalSourcePath(preferredSourcePath);
+        } else {
+          await desktopApi.clearPreferredCanonicalSourcePath();
+        }
       }
       let nextInventorySnapshot: SkillInventorySnapshot;
       try {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -91,6 +91,20 @@ function comparePluginsForTable(left: PluginRecord, right: PluginRecord): number
     || left.rootPath.localeCompare(right.rootPath);
 }
 
+function getErrorTrace(error: unknown): string | null {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const stack = 'stack' in error && typeof error.stack === 'string' ? error.stack : null;
+    const message = 'message' in error && typeof error.message === 'string' ? error.message : null;
+    return stack ?? message;
+  }
+
+  return typeof error === 'string' ? error : null;
+}
+
 function getPluginSelectionKey(plugin: PluginRecord): string {
   return [
     plugin.host,
@@ -174,6 +188,7 @@ export default function App() {
   const [isPreviewingOnboarding, setIsPreviewingOnboarding] = useState(false);
   const [isCompletingOnboarding, setIsCompletingOnboarding] = useState(false);
   const [onboardingErrorMessage, setOnboardingErrorMessage] = useState<string | null>(null);
+  const [onboardingErrorTrace, setOnboardingErrorTrace] = useState<string | null>(null);
 
   const applyInventorySnapshot = useCallback(
     (nextInventorySnapshot: SkillInventorySnapshot, preferredSkillName?: string | null) => {
@@ -1294,6 +1309,7 @@ export default function App() {
 
   const chooseOnboardingPreferredSource = useCallback(async () => {
     setOnboardingErrorMessage(null);
+    setOnboardingErrorTrace(null);
     try {
       return await desktopApi.chooseDirectory({
         title: 'Choose a preferred skills source',
@@ -1301,6 +1317,17 @@ export default function App() {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to open the folder picker.';
       setOnboardingErrorMessage(message);
+      setOnboardingErrorTrace(getErrorTrace(error));
+      return null;
+    }
+  }, [desktopApi]);
+
+  const readLatestFailedAuditTrace = useCallback(async () => {
+    try {
+      const latestOperations = await desktopApi.readAuditLog({ limit: 1 });
+      return latestOperations.find((operation) => operation.status === 'failed' && operation.failure?.trace)
+        ?.failure?.trace ?? null;
+    } catch {
       return null;
     }
   }, [desktopApi]);
@@ -1308,19 +1335,26 @@ export default function App() {
   const completeOnboarding = useCallback(async (preferredSourcePath: string | null) => {
     setIsCompletingOnboarding(true);
     setOnboardingErrorMessage(null);
+    setOnboardingErrorTrace(null);
     setErrorMessage(null);
+    let failureTrace: string | null = null;
 
     try {
       if (shellState?.devTools && devApi) {
         await devApi.setInventoryMode(shellState.devTools.inventoryMode);
       }
 
-      const nextSettingsState = await desktopApi.completeOnboarding(
-        preferredSourcePath
-          ? { preferredCanonicalSourcePath: preferredSourcePath }
-          : {},
-      );
-      const nextInventorySnapshot = await desktopApi.scanInventory();
+      if (preferredSourcePath) {
+        await desktopApi.setPreferredCanonicalSourcePath(preferredSourcePath);
+      }
+      let nextInventorySnapshot: SkillInventorySnapshot;
+      try {
+        nextInventorySnapshot = await desktopApi.rescanInventory();
+      } catch (scanError) {
+        failureTrace = await readLatestFailedAuditTrace() ?? getErrorTrace(scanError);
+        throw scanError;
+      }
+      const nextSettingsState = await desktopApi.completeOnboarding({});
 
       setSettingsState(nextSettingsState);
       setIsPreviewingOnboarding(false);
@@ -1329,14 +1363,16 @@ export default function App() {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to complete onboarding.';
       setOnboardingErrorMessage(message);
+      setOnboardingErrorTrace(failureTrace ?? getErrorTrace(error));
       setErrorMessage(message);
     } finally {
       setIsCompletingOnboarding(false);
     }
-  }, [applyInventorySnapshot, desktopApi, devApi, shellState?.devTools]);
+  }, [applyInventorySnapshot, desktopApi, devApi, readLatestFailedAuditTrace, shellState?.devTools]);
 
   const openOnboardingFromDevelopment = useCallback(() => {
     setOnboardingErrorMessage(null);
+    setOnboardingErrorTrace(null);
     setIsPreviewingOnboarding(true);
   }, []);
 
@@ -1524,6 +1560,7 @@ export default function App() {
       <>
         <OnboardingFlow
           errorMessage={onboardingErrorMessage}
+          errorTrace={onboardingErrorTrace}
           isCompleting={isCompletingOnboarding}
           universalSkillsPath={CANONICAL_USER_SKILLS_DISPLAY_PATH}
           onChoosePreferredSource={chooseOnboardingPreferredSource}

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -301,6 +301,11 @@ describe('App shell inventory views', () => {
     const preferredSourcePath = '/Users/arjitjaiswal/repos/published-skills';
     readSettingsMock.mockResolvedValueOnce(createSettingsState([], null, null));
     chooseDirectoryMock.mockResolvedValueOnce(preferredSourcePath);
+    setPreferredCanonicalSourcePathMock.mockResolvedValueOnce(createSettingsState(
+      [preferredSourcePath],
+      preferredSourcePath,
+      null,
+    ));
     completeOnboardingMock.mockResolvedValueOnce(createSettingsState(
       [preferredSourcePath],
       preferredSourcePath,
@@ -332,15 +337,96 @@ describe('App shell inventory views', () => {
     fireEvent.click(screen.getByRole('button', { name: /^Scan my machine$/i }));
 
     await waitFor(() => {
-      expect(completeOnboardingMock).toHaveBeenCalledWith({
-        preferredCanonicalSourcePath: preferredSourcePath,
-      });
+      expect(setPreferredCanonicalSourcePathMock).toHaveBeenCalledWith(preferredSourcePath);
     });
     await waitFor(() => {
-      expect(scanInventoryMock).toHaveBeenCalledTimes(1);
+      expect(rescanInventoryMock).toHaveBeenCalledTimes(1);
     });
-    expect(completeOnboardingMock.mock.invocationCallOrder[0]).toBeLessThan(scanInventoryMock.mock.invocationCallOrder[0]);
+    await waitFor(() => {
+      expect(completeOnboardingMock).toHaveBeenCalledWith({});
+    });
+    expect(setPreferredCanonicalSourcePathMock.mock.invocationCallOrder[0]).toBeLessThan(rescanInventoryMock.mock.invocationCallOrder[0]);
+    expect(rescanInventoryMock.mock.invocationCallOrder[0]).toBeLessThan(completeOnboardingMock.mock.invocationCallOrder[0]);
     expect(await screen.findByRole('navigation', { name: /Primary/i })).toBeInTheDocument();
+  });
+
+  it('keeps first-run onboarding incomplete when the initial scan fails', async () => {
+    readSettingsMock.mockResolvedValueOnce(createSettingsState([], null, null));
+    rescanInventoryMock.mockRejectedValueOnce(new Error('Scan failed during onboarding.'));
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: /^How it fits together$/i, level: 1 })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Continue/i }));
+    expect(await screen.findByRole('heading', { name: /^Where your skills live$/i, level: 1 })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Scan my machine$/i }));
+
+    await waitFor(() => {
+      expect(rescanInventoryMock).toHaveBeenCalledTimes(1);
+    });
+    expect(completeOnboardingMock).not.toHaveBeenCalled();
+    expect(await screen.findByRole('alert')).toHaveTextContent('Scan failed during onboarding.');
+    expect(screen.queryByRole('navigation', { name: /Primary/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^Where your skills live$/i, level: 1 })).toBeInTheDocument();
+  });
+
+  it('shows, expands, and copies the failed first-run scan trace from the audit log', async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: writeTextMock,
+      },
+    });
+    readSettingsMock.mockResolvedValueOnce(createSettingsState([], null, null));
+    rescanInventoryMock.mockRejectedValueOnce(new Error('Failed to parse Skill Index config.'));
+    readAuditLogMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(createAuditOperations({
+        kind: 'inventory-rescan',
+        title: 'Inventory rescan failed',
+        summary: 'Manual inventory rescan failed before the latest snapshot could be saved.',
+        status: 'failed',
+        undoState: 'not-undoable',
+        actionCount: 0,
+        actions: [],
+        failure: {
+          message: 'Failed to parse Skill Index config.',
+          trace: 'Error: Failed to parse Skill Index config.\\n    at scanSkillInventory (src/main/skill-inventory.ts:1:1)',
+        },
+      }));
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: /^How it fits together$/i, level: 1 })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Continue/i }));
+    expect(await screen.findByRole('heading', { name: /^Where your skills live$/i, level: 1 })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Scan my machine$/i }));
+
+    await waitFor(() => {
+      expect(readAuditLogMock).toHaveBeenCalledWith({ limit: 1 });
+    });
+    expect(screen.queryByText(/scanSkillInventory/)).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: /^Show failure trace$/i }));
+
+    const inlineTrace = await screen.findByText(/scanSkillInventory/);
+    expect(inlineTrace.textContent).toBe(
+      'Error: Failed to parse Skill Index config.\n    at scanSkillInventory (src/main/skill-inventory.ts:1:1)',
+    );
+    expect(inlineTrace.textContent).not.toContain('\\n');
+    expect(screen.getByRole('button', { name: /^Hide failure trace$/i })).toBeInTheDocument();
+
+    const copyTraceButton = await screen.findByRole('button', { name: /^Copy failure trace$/i });
+    fireEvent.click(copyTraceButton);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining(
+        'Error: Failed to parse Skill Index config.\n    at scanSkillInventory',
+      ));
+    });
+    expect(screen.getByRole('button', { name: /^Failure trace copied$/i })).toBeInTheDocument();
   });
 
   it('holds startup UI instead of flashing the app shell while first-run settings load', async () => {

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -429,6 +429,53 @@ describe('App shell inventory views', () => {
     expect(screen.getByRole('button', { name: /^Failure trace copied$/i })).toBeInTheDocument();
   });
 
+  it('clears a persisted onboarding preferred source before retrying without one', async () => {
+    const preferredSourcePath = '/Users/arjitjaiswal/repos/problem-skills';
+    readSettingsMock.mockResolvedValueOnce(createSettingsState([], null, null));
+    chooseDirectoryMock.mockResolvedValueOnce(preferredSourcePath);
+    setPreferredCanonicalSourcePathMock.mockResolvedValueOnce(createSettingsState(
+      [preferredSourcePath],
+      preferredSourcePath,
+      null,
+    ));
+    clearPreferredCanonicalSourcePathMock.mockResolvedValueOnce(createSettingsState([], null, null));
+    rescanInventoryMock
+      .mockRejectedValueOnce(new Error('Scan failed during onboarding.'))
+      .mockResolvedValueOnce(createInventorySnapshot());
+    completeOnboardingMock.mockResolvedValueOnce(createSettingsState(
+      [],
+      null,
+      '2026-05-19T06:30:00.000Z',
+    ));
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: /^How it fits together$/i, level: 1 })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Continue/i }));
+    expect(await screen.findByRole('heading', { name: /^Where your skills live$/i, level: 1 })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Browse/i }));
+    expect(await screen.findByText(preferredSourcePath)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Scan my machine$/i }));
+
+    await waitFor(() => {
+      expect(rescanInventoryMock).toHaveBeenCalledTimes(1);
+    });
+    expect(completeOnboardingMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Remove preferred source$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Scan my machine$/i }));
+
+    await waitFor(() => {
+      expect(clearPreferredCanonicalSourcePathMock).toHaveBeenCalledTimes(1);
+      expect(rescanInventoryMock).toHaveBeenCalledTimes(2);
+      expect(completeOnboardingMock).toHaveBeenCalledWith({});
+    });
+    expect(setPreferredCanonicalSourcePathMock.mock.invocationCallOrder[0]).toBeLessThan(rescanInventoryMock.mock.invocationCallOrder[0]);
+    expect(clearPreferredCanonicalSourcePathMock.mock.invocationCallOrder[0]).toBeLessThan(rescanInventoryMock.mock.invocationCallOrder[1]);
+  });
+
   it('holds startup UI instead of flashing the app shell while first-run settings load', async () => {
     let resolveSettings: (settingsState: SettingsState) => void = () => undefined;
     readSettingsMock.mockReturnValueOnce(new Promise<SettingsState>((resolve) => {

--- a/src/renderer/src/app/browser-preview-adapter.ts
+++ b/src/renderer/src/app/browser-preview-adapter.ts
@@ -105,8 +105,23 @@ const browserPreviewApi: SkillIndexDesktopApi = {
   onAuditUpdated: () => () => undefined,
   addCustomScanPath: () => Promise.resolve(cloneSettingsState(browserPreviewSettingsState)),
   removeCustomScanPath: () => Promise.resolve(cloneSettingsState(browserPreviewSettingsState)),
-  setPreferredCanonicalSourcePath: () => Promise.resolve(cloneSettingsState(browserPreviewSettingsState)),
-  clearPreferredCanonicalSourcePath: () => Promise.resolve(cloneSettingsState(browserPreviewSettingsState)),
+  setPreferredCanonicalSourcePath: (scanPath) => {
+    browserPreviewSettingsState = {
+      ...browserPreviewSettingsState,
+      customScanPaths: browserPreviewSettingsState.customScanPaths.includes(scanPath)
+        ? browserPreviewSettingsState.customScanPaths
+        : [...browserPreviewSettingsState.customScanPaths, scanPath],
+      preferredCanonicalSourcePath: scanPath,
+    };
+    return Promise.resolve(cloneSettingsState(browserPreviewSettingsState));
+  },
+  clearPreferredCanonicalSourcePath: () => {
+    browserPreviewSettingsState = {
+      ...browserPreviewSettingsState,
+      preferredCanonicalSourcePath: null,
+    };
+    return Promise.resolve(cloneSettingsState(browserPreviewSettingsState));
+  },
   setDevSidebarInventorySourceSwitcherVisible: (visible) => {
     browserPreviewSettingsState = {
       ...browserPreviewSettingsState,
@@ -115,11 +130,20 @@ const browserPreviewApi: SkillIndexDesktopApi = {
     return Promise.resolve(cloneSettingsState(browserPreviewSettingsState));
   },
   completeOnboarding: (request) => {
+    const hasPreferredCanonicalSourcePathRequest = Object.hasOwn(request, 'preferredCanonicalSourcePath');
+    const preferredCanonicalSourcePath = hasPreferredCanonicalSourcePathRequest
+      ? request.preferredCanonicalSourcePath ?? null
+      : browserPreviewSettingsState.preferredCanonicalSourcePath;
+    const customScanPaths = hasPreferredCanonicalSourcePathRequest
+      && preferredCanonicalSourcePath
+      && !browserPreviewSettingsState.customScanPaths.includes(preferredCanonicalSourcePath)
+      ? [...browserPreviewSettingsState.customScanPaths, preferredCanonicalSourcePath]
+      : browserPreviewSettingsState.customScanPaths;
     browserPreviewSettingsState = {
       ...browserPreviewSettingsState,
-      customScanPaths: request.preferredCanonicalSourcePath ? [request.preferredCanonicalSourcePath] : [],
+      customScanPaths,
       onboardingCompletedAt: new Date().toISOString(),
-      preferredCanonicalSourcePath: request.preferredCanonicalSourcePath ?? null,
+      preferredCanonicalSourcePath,
     };
     return Promise.resolve(cloneSettingsState(browserPreviewSettingsState));
   },

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -5097,6 +5097,8 @@ body {
 }
 
 .onboarding-error {
+  display: grid;
+  gap: 12px;
   margin: 12px 0 0;
   padding: 10px 12px;
   border: 1px solid #f3d4cf;
@@ -5107,10 +5109,97 @@ body {
   line-height: 17px;
 }
 
+.onboarding-error-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.onboarding-error-message {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.onboarding-error-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.onboarding-copy-trace-button {
+  flex: 0 0 auto;
+  border-color: rgba(186, 26, 26, 0.2);
+  background: rgba(255, 255, 255, 0.72);
+  color: #8f1717;
+}
+
+.onboarding-copy-trace-button:hover {
+  border-color: rgba(186, 26, 26, 0.34);
+  background: rgba(255, 255, 255, 0.92);
+  color: #6f1111;
+}
+
+.onboarding-trace-toggle-button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 5px;
+  min-height: 22px;
+  padding: 0 8px 0 7px;
+  border: 1px solid rgba(186, 26, 26, 0.2);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #8f1717;
+  cursor: pointer;
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 1;
+  transition:
+    background-color 160ms cubic-bezier(0.25, 1, 0.5, 1),
+    border-color 160ms cubic-bezier(0.25, 1, 0.5, 1),
+    color 160ms cubic-bezier(0.25, 1, 0.5, 1),
+    transform 120ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.onboarding-trace-toggle-button:hover {
+  border-color: rgba(186, 26, 26, 0.34);
+  background: rgba(255, 255, 255, 0.92);
+  color: #6f1111;
+}
+
+.onboarding-trace-toggle-button:focus-visible {
+  outline: 2px solid rgba(186, 26, 26, 0.22);
+  outline-offset: 2px;
+}
+
+.onboarding-trace-toggle-button:active {
+  transform: translateY(1px);
+}
+
+.onboarding-error-trace {
+  max-height: 156px;
+  margin: 0;
+  padding: 10px;
+  overflow: auto;
+  border: 1px solid rgba(186, 26, 26, 0.12);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.58);
+  color: #6f1111;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .onboarding-flow-lines path,
   .onboarding-progress div,
-  .onboarding-button {
+  .onboarding-button,
+  .onboarding-trace-toggle-button {
     animation: none;
     transition: none;
   }

--- a/src/renderer/src/views/OnboardingFlow.tsx
+++ b/src/renderer/src/views/OnboardingFlow.tsx
@@ -3,6 +3,11 @@ import { ArrowRight, Check, ChevronDown, ChevronUp, Copy, Folder, GitBranch, Inf
 
 import skillIndexMarkCream from '../assets/skill-index-mark-cream.svg';
 
+export interface OnboardingPreferredSourceSelection {
+  didChangePreferredSource: boolean;
+  preferredSourcePath: string | null;
+}
+
 export function OnboardingFlow({
   errorMessage,
   errorTrace,
@@ -15,11 +20,12 @@ export function OnboardingFlow({
   errorTrace: string | null;
   isCompleting: boolean;
   onChoosePreferredSource: () => Promise<string | null>;
-  onComplete: (preferredSourcePath: string | null) => Promise<void>;
+  onComplete: (selection: OnboardingPreferredSourceSelection) => Promise<void>;
   universalSkillsPath: string;
 }) {
   const [step, setStep] = useState<1 | 2>(1);
   const [preferredSourcePath, setPreferredSourcePath] = useState<string | null>(null);
+  const [didChangePreferredSource, setDidChangePreferredSource] = useState(false);
   const [isChoosingPreferredSource, setIsChoosingPreferredSource] = useState(false);
 
   const choosePreferredSource = async () => {
@@ -28,6 +34,7 @@ export function OnboardingFlow({
       const chosenPath = await onChoosePreferredSource();
       if (chosenPath) {
         setPreferredSourcePath(chosenPath);
+        setDidChangePreferredSource(true);
       }
     } finally {
       setIsChoosingPreferredSource(false);
@@ -60,9 +67,15 @@ export function OnboardingFlow({
               onChoosePreferredSource={() => {
                 void choosePreferredSource();
               }}
-              onClearPreferredSource={() => setPreferredSourcePath(null)}
+              onClearPreferredSource={() => {
+                setPreferredSourcePath(null);
+                setDidChangePreferredSource(true);
+              }}
               onComplete={() => {
-                void onComplete(preferredSourcePath);
+                void onComplete({
+                  didChangePreferredSource,
+                  preferredSourcePath,
+                });
               }}
             />
           )}

--- a/src/renderer/src/views/OnboardingFlow.tsx
+++ b/src/renderer/src/views/OnboardingFlow.tsx
@@ -1,16 +1,18 @@
-import { useState, type ReactNode } from 'react';
-import { ArrowRight, Check, Folder, GitBranch, Info, X } from 'lucide-react';
+import { useEffect, useId, useState, type ReactNode } from 'react';
+import { ArrowRight, Check, ChevronDown, ChevronUp, Copy, Folder, GitBranch, Info, X } from 'lucide-react';
 
 import skillIndexMarkCream from '../assets/skill-index-mark-cream.svg';
 
 export function OnboardingFlow({
   errorMessage,
+  errorTrace,
   isCompleting,
   onChoosePreferredSource,
   onComplete,
   universalSkillsPath,
 }: {
   errorMessage: string | null;
+  errorTrace: string | null;
   isCompleting: boolean;
   onChoosePreferredSource: () => Promise<string | null>;
   onComplete: (preferredSourcePath: string | null) => Promise<void>;
@@ -49,6 +51,7 @@ export function OnboardingFlow({
           ) : (
             <StepTwo
               errorMessage={errorMessage}
+              errorTrace={errorTrace}
               isChoosingPreferredSource={isChoosingPreferredSource}
               isCompleting={isCompleting}
               preferredSourcePath={preferredSourcePath}
@@ -142,6 +145,7 @@ function StepOne({ onContinue }: { onContinue: () => void }) {
 
 function StepTwo({
   errorMessage,
+  errorTrace,
   isChoosingPreferredSource,
   isCompleting,
   preferredSourcePath,
@@ -152,6 +156,7 @@ function StepTwo({
   onComplete,
 }: {
   errorMessage: string | null;
+  errorTrace: string | null;
   isChoosingPreferredSource: boolean;
   isCompleting: boolean;
   preferredSourcePath: string | null;
@@ -245,7 +250,7 @@ function StepTwo({
         <span>Manage these later in <strong>Settings {'->'} Custom scan paths</strong>. Skill Index never moves files without your approval.</span>
       </div>
 
-      {errorMessage ? <p className="onboarding-error" role="alert">{errorMessage}</p> : null}
+      {errorMessage ? <OnboardingError message={errorMessage} trace={errorTrace} /> : null}
 
       <div className="onboarding-pane-spacer" />
 
@@ -261,6 +266,102 @@ function StepTwo({
       </footer>
     </>
   );
+}
+
+function OnboardingError({ message, trace }: { message: string; trace: string | null }) {
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [isTraceExpanded, setIsTraceExpanded] = useState(false);
+  const traceId = useId();
+  const normalizedTrace = trace ? normalizeTraceText(trace) : null;
+
+  useEffect(() => {
+    setCopyState('idle');
+    setIsTraceExpanded(false);
+  }, [trace]);
+
+  useEffect(() => {
+    if (copyState === 'idle') {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setCopyState('idle');
+    }, copyState === 'copied' ? 1800 : 2400);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [copyState]);
+
+  const copyTrace = () => {
+    if (!normalizedTrace) {
+      return;
+    }
+    if (!navigator.clipboard?.writeText) {
+      setCopyState('failed');
+      return;
+    }
+
+    void navigator.clipboard.writeText(normalizedTrace)
+      .then(() => setCopyState('copied'))
+      .catch(() => setCopyState('failed'));
+  };
+
+  return (
+    <div className="onboarding-error" role="alert">
+      <div className="onboarding-error-header">
+        <span className="onboarding-error-message">{message}</span>
+        {normalizedTrace ? (
+          <span className="onboarding-error-actions">
+            <button
+              aria-expanded={isTraceExpanded}
+              aria-label={isTraceExpanded ? 'Hide failure trace' : 'Show failure trace'}
+              aria-controls={traceId}
+              className="onboarding-trace-toggle-button"
+              title={isTraceExpanded ? 'Hide failure trace' : 'Show failure trace'}
+              type="button"
+              onClick={() => setIsTraceExpanded((currentValue) => !currentValue)}
+            >
+              {isTraceExpanded ? <ChevronUp aria-hidden="true" size={13} /> : <ChevronDown aria-hidden="true" size={13} />}
+              <span>{isTraceExpanded ? 'Hide trace' : 'Show trace'}</span>
+            </button>
+            <button
+              aria-label={copyState === 'copied'
+                ? 'Failure trace copied'
+                : copyState === 'failed'
+                  ? 'Copy failure trace failed'
+                  : 'Copy failure trace'}
+              className={[
+                'audit-copy-trace-button',
+                'onboarding-copy-trace-button',
+                copyState === 'copied' ? 'audit-copy-trace-button--copied' : '',
+                copyState === 'failed' ? 'audit-copy-trace-button--failed' : '',
+              ].filter(Boolean).join(' ')}
+              title="Copy failure trace"
+              type="button"
+              onClick={copyTrace}
+            >
+              <span className="audit-copy-trace-button__icon" aria-hidden="true">
+                <Copy className="audit-copy-trace-button__glyph audit-copy-trace-button__glyph--copy" strokeWidth={2} />
+                <Check className="audit-copy-trace-button__glyph audit-copy-trace-button__glyph--check" strokeWidth={2.3} />
+              </span>
+              <span>{copyState === 'failed' ? 'Copy failed' : 'Copy trace'}</span>
+            </button>
+          </span>
+        ) : null}
+      </div>
+      {normalizedTrace && isTraceExpanded ? (
+        <pre className="onboarding-error-trace" id={traceId}>{normalizedTrace}</pre>
+      ) : null}
+    </div>
+  );
+}
+
+function normalizeTraceText(trace: string): string {
+  return trace
+    .replace(/\\r\\n/g, '\n')
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t');
 }
 
 function StepHeader({


### PR DESCRIPTION
Changes:

- Keep first-run onboarding incomplete until the audited initial rescan succeeds.
- Show failed onboarding scan traces inline with expand/collapse and copy actions.
- Normalize escaped trace newlines before rendering or copying.

Validation:
- pnpm typecheck
- pnpm test -- src/renderer/src/app-shell.test.tsx
