### PR TITLE
Support subagent inventory and resolution

### DIFF
--- a/src/main/inventory-runtime.ts
+++ b/src/main/inventory-runtime.ts
@@ -414,7 +414,9 @@ export function createInventoryRuntime(options: CreateInventoryRuntimeOptions = 
           sourceMode: resolveAuditSourceMode(lastScanOptions),
           entity: 'skillName' in request
             ? { type: 'skill', name: request.skillName }
-            : { type: 'mcp', name: request.mcpName },
+            : 'mcpName' in request
+              ? { type: 'mcp', name: request.mcpName }
+              : { type: 'subagent', name: request.subagentName },
           paths: resolveAuditPaths(lastScanOptions),
           includeCache: true,
         }),
@@ -493,6 +495,23 @@ function buildResolveIssueAuditRequest(
       summary: `${affectedPaths.length} ${affectedPaths.length === 1 ? 'config' : 'configs'} changed.`,
       sourceMode,
       entity: { type: 'mcp', name: request.mcpName },
+      affectedPaths,
+      undoable: affectedPaths.length > 0,
+    };
+  }
+
+  if (request.entity === 'subagent') {
+    const subagent = (snapshot.subagents ?? []).find((entry) => entry.name === request.subagentName);
+    const affectedPaths = subagent
+      ? getSubagentResolutionAffectedPaths(request, subagent, snapshot, options)
+      : [];
+
+    return {
+      kind: 'resolve-subagent-issue',
+      title: `Resolved ${formatIssueLabel(request.issue)} for ${request.subagentName}`,
+      summary: `${affectedPaths.length} ${affectedPaths.length === 1 ? 'path' : 'paths'} changed.`,
+      sourceMode,
+      entity: { type: 'subagent', name: request.subagentName },
       affectedPaths,
       undoable: affectedPaths.length > 0,
     };
@@ -640,6 +659,55 @@ function getMcpResolutionAffectedPaths(
   );
 }
 
+function getSubagentResolutionAffectedPaths(
+  request: Extract<ResolveIssueRequest, { entity: 'subagent' }>,
+  subagent: NonNullable<SkillInventorySnapshot['subagents']>[number],
+  snapshot: SkillInventorySnapshot,
+  options: ScanSkillInventoryOptions,
+): string[] {
+  const canonicalPath = resolveCanonicalSubagentPathForAudit(subagent, request.selectedVariantPath, options);
+
+  switch (request.issue) {
+    case 'missing-universal':
+      return dedupePaths([canonicalPath]);
+    case 'missing-from-agents':
+      return dedupePaths((subagent.missingLocations ?? [])
+        .filter((location) => isWritableSubagentTarget(location.agentId, snapshot))
+        .map((location) => location.path)
+        .filter((targetPath): targetPath is string => Boolean(targetPath)));
+    case 'definition-mismatch':
+      return dedupePaths([
+        canonicalPath,
+        ...subagent.locations
+          .filter((location) => !location.canonical && !location.agentId.startsWith('plugin:') && location.mutability === 'writable')
+          .map((location) => location.path),
+        ...(subagent.missingLocations ?? [])
+          .filter((location) => isWritableSubagentTarget(location.agentId, snapshot))
+          .map((location) => location.path)
+          .filter((targetPath): targetPath is string => Boolean(targetPath)),
+      ]);
+    case 'identical-copies':
+      return dedupePaths(subagent.locations
+        .filter((location) =>
+          location.fileType === 'real-file'
+          && !location.canonical
+          && !location.agentId.startsWith('plugin:')
+          && location.mutability === 'writable')
+        .map((location) => location.path));
+    case 'broken-symlink':
+      return dedupePaths(subagent.locations
+        .filter((location) => location.fileType === 'symlink' && location.resolvedPath === undefined)
+        .map((location) => location.path));
+    case 'wrong-symlink-target':
+      return dedupePaths(subagent.locations
+        .filter((location) =>
+          location.fileType === 'symlink'
+          && location.resolvedPath !== undefined
+          && path.normalize(location.resolvedPath) !== path.normalize(canonicalPath))
+        .map((location) => location.path));
+  }
+}
+
 function getSkillResolutionAffectedPaths(
   request: Extract<ResolveIssueRequest, { entity: 'skill' }>,
   skill: SkillRecord,
@@ -684,6 +752,34 @@ function getSkillResolutionAffectedPaths(
       return dedupePaths([canonicalPath, ...duplicatePaths]);
     }
   }
+}
+
+function resolveCanonicalSubagentPathForAudit(
+  subagent: NonNullable<SkillInventorySnapshot['subagents']>[number],
+  selectedVariantPath: string | undefined,
+  options: ScanSkillInventoryOptions,
+): string {
+  const existingCanonicalLocation = subagent.locations.find((location) => location.canonical);
+  if (existingCanonicalLocation) {
+    return existingCanonicalLocation.path;
+  }
+
+  const selectedScope = selectedVariantPath
+    ? subagent.locations.find((location) => location.path === selectedVariantPath)?.scope
+    : undefined;
+  const scope = selectedScope
+    ?? subagent.locations[0]?.scope
+    ?? 'live';
+  const paths = resolveAuditPathsForOptions(options);
+  const canonicalSkillsDir = scope === 'sandbox'
+    ? paths.sandboxCanonicalUserSkillsDir
+    : paths.liveCanonicalUserSkillsDir;
+  return path.join(path.dirname(canonicalSkillsDir), 'agents', `${subagent.name.replace(/[^A-Za-z0-9._-]+/gu, '-')}.md`);
+}
+
+function isWritableSubagentTarget(agentId: string, snapshot: SkillInventorySnapshot): boolean {
+  const agent = (snapshot.agents ?? []).find((entry) => entry.id === agentId);
+  return Boolean(agent?.writable && agent.subagentsLocation?.state === 'available' && agent.subagentsLocation.path);
 }
 
 function shouldAuditSkillUniversalDecisionConfig(skill: SkillRecord): boolean {

--- a/src/main/inventory-source-model.ts
+++ b/src/main/inventory-source-model.ts
@@ -88,6 +88,7 @@ export async function buildInventoryAgents(
     supportedAgents.map(async (agent) => {
       const skillsExists = await pathExists(agent.skillsLocation.path);
       const mcpExists = await pathExists(agent.mcpConfigLocation.path);
+      const subagentsExists = await pathExists(agent.subagentsLocation?.path);
       const configExists = await pathExists(agent.configLocation?.path);
       const executablePath = await resolveExecutablePath(agent.executableLocation?.path, options.env);
       const executableExists = Boolean(executablePath);
@@ -101,6 +102,12 @@ export async function buildInventoryAgents(
             exists: mcpExists,
           }
         : agent.mcpConfigLocation;
+      const subagentsLocation: AgentLocationRecord | undefined = agent.subagentsLocation
+        ? {
+            ...agent.subagentsLocation,
+            exists: subagentsExists,
+          }
+        : undefined;
       const configLocation: AgentLocationRecord | undefined = agent.configLocation
         ? {
             ...agent.configLocation,
@@ -120,6 +127,7 @@ export async function buildInventoryAgents(
         installState: agent.installState,
         skillsLocation,
         mcpConfigLocation,
+        subagentsLocation,
         configLocation,
         executableLocation,
       };
@@ -135,6 +143,7 @@ export function buildInventoryAgentsSync(
   return supportedAgents.map((agent) => {
     const skillsExists = pathExistsSync(agent.skillsLocation.path);
     const mcpExists = pathExistsSync(agent.mcpConfigLocation.path);
+    const subagentsExists = pathExistsSync(agent.subagentsLocation?.path);
     const configExists = pathExistsSync(agent.configLocation?.path);
     const executablePath = resolveExecutablePathSync(agent.executableLocation?.path, options.env);
     const executableExists = Boolean(executablePath);
@@ -148,6 +157,12 @@ export function buildInventoryAgentsSync(
           exists: mcpExists,
         }
       : agent.mcpConfigLocation;
+    const subagentsLocation: AgentLocationRecord | undefined = agent.subagentsLocation
+      ? {
+          ...agent.subagentsLocation,
+          exists: subagentsExists,
+        }
+      : undefined;
     const configLocation: AgentLocationRecord | undefined = agent.configLocation
       ? {
           ...agent.configLocation,
@@ -167,6 +182,7 @@ export function buildInventoryAgentsSync(
       installState: agent.installState,
       skillsLocation,
       mcpConfigLocation,
+      subagentsLocation,
       configLocation,
       executableLocation,
     };
@@ -439,6 +455,12 @@ function createAgentRecord(
           ? path.join(displayHomeDir, ...family.agentConfigRelativeParts)
           : undefined);
   const executablePath = sandboxRuntimePaths?.executablePath ?? family.expectedExecutableNames?.[0];
+  const subagentsPath = sandboxRuntimePaths?.subagentsDir
+    ?? (family.resolveLiveSubagentsDir
+        ? family.resolveLiveSubagentsDir(liveResolutionContext)
+        : family.subagentGlobalDirRelativeParts
+          ? path.join(displayHomeDir, ...family.subagentGlobalDirRelativeParts)
+          : undefined);
   const skillsPath = family.skillStorageKind === 'local-directory'
     ? resolvePhysicalSkillsDir(
         scope,
@@ -465,6 +487,9 @@ function createAgentRecord(
     mcpParserKind: family.mcpParserKind,
     mcpWriteDialect: family.mcpWriteDialect,
     mcpSupportedTransports: family.mcpSupportedTransports,
+    subagentConfigKind: family.subagentConfigKind,
+    subagentParserKind: family.subagentParserKind,
+    subagentWriteDialect: family.subagentWriteDialect,
     metadataSources: family.metadataSources,
     icon: family.icon,
     skillsLocation: skillsPath
@@ -490,6 +515,18 @@ function createAgentRecord(
           state: 'unavailable',
           exists: false,
           reason: 'not-supported',
+        },
+    subagentsLocation: subagentsPath
+      ? {
+          state: 'available',
+          path: subagentsPath,
+          displayPath: collapseHomePath(subagentsPath, displayHomeDir),
+          exists: false,
+        }
+      : {
+          state: 'unavailable',
+          exists: false,
+          reason: family.subagentConfigKind === 'account-managed' ? 'account-managed' : 'not-supported',
         },
     configLocation: configPath
       ? {

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -5,6 +5,7 @@ import type {
   AddMcpServerRequest,
   AgentRecord,
   AgentMcpWriteDialect,
+  AgentSubagentParserKind,
   McpConfiguredTransportKind,
   McpDefinitionObject,
   McpDefinitionValue,
@@ -15,6 +16,9 @@ import type {
   SkillInventorySnapshot,
   SkillLocationRecord,
   SkillRecord,
+  SubagentExpectedLocationRecord,
+  SubagentLocationRecord,
+  SubagentRecord,
 } from '@shared/contracts';
 import { buildPortableMcpDefinition, isMcpDefinitionObject, isMcpServerDefinitions } from '@shared/mcp-definition';
 import {
@@ -22,6 +26,10 @@ import {
   resolveSkillIndexPaths,
   type SkillIndexPaths,
 } from '@shared/skill-index-paths';
+import {
+  getSubagentFileNameForFormat,
+  isMarkdownSubagentSymlinkCompatible,
+} from '@shared/subagent-format-policy';
 import {
   parseTomlMcpServerArray,
   parseTomlMcpServers,
@@ -32,6 +40,11 @@ import {
 import { sanitizeJsonc, sortRecordValue } from '@main/json-utils';
 import { makeSkillCanonical } from '@main/skill-canonicalization';
 import { scanSkillInventory, type ScanSkillInventoryOptions } from '@main/skill-inventory';
+import {
+  readPortableSubagentDefinitionFromFile,
+  renderPortableSubagentDefinition,
+  type PortableSubagentDefinition,
+} from '@main/subagent-inventory';
 import { persistSkillUniversalDecisionForSelection } from '@main/skill-universal-decisions';
 
 export interface ResolveIssueOptions extends ScanSkillInventoryOptions {
@@ -61,6 +74,19 @@ interface CanonicalSkillPackage {
   location: SkillLocationRecord;
 }
 
+interface CanonicalSubagentPackage {
+  path: string;
+  definition: PortableSubagentDefinition;
+}
+
+interface SubagentWriteTarget {
+  agentId: string;
+  family?: string;
+  format: AgentSubagentParserKind;
+  localExtrasKeys?: string[];
+  path: string;
+}
+
 export async function resolveInventoryIssue(
   request: ResolveIssueRequest,
   options: ResolveIssueOptions = {},
@@ -80,8 +106,13 @@ export async function resolveInventoryIssue(
       ...options,
       paths,
     });
-  } else {
+  } else if (request.entity === 'mcp') {
     await resolveMcpIssueIfCurrent(snapshot, request);
+  } else {
+    await resolveSubagentIssueIfCurrent(snapshot, request, {
+      ...options,
+      paths,
+    });
   }
 
   const nextSnapshot = await scanSkillInventory({
@@ -147,13 +178,25 @@ function assertResolutionIssueIsCurrent(snapshot: SkillInventorySnapshot, reques
     return;
   }
 
-  const mcp = (snapshot.mcps ?? []).find((entry) => entry.name === request.mcpName);
-  if (!mcp) {
-    throw new Error(`MCP "${request.mcpName}" was not found in the current inventory.`);
+  if (request.entity === 'mcp') {
+    const mcp = (snapshot.mcps ?? []).find((entry) => entry.name === request.mcpName);
+    if (!mcp) {
+      throw new Error(`MCP "${request.mcpName}" was not found in the current inventory.`);
+    }
+
+    if (!mcp.issueReasons.includes(request.issue)) {
+      throw new Error(`MCP "${request.mcpName}" no longer has ${formatIssueLabel(request.issue)}. Refresh inventory and try again if it still needs attention.`);
+    }
+    return;
   }
 
-  if (!mcp.issueReasons.includes(request.issue)) {
-    throw new Error(`MCP "${request.mcpName}" no longer has ${formatIssueLabel(request.issue)}. Refresh inventory and try again if it still needs attention.`);
+  const subagent = (snapshot.subagents ?? []).find((entry) => entry.name === request.subagentName);
+  if (!subagent) {
+    throw new Error(`Subagent "${request.subagentName}" was not found in the current inventory.`);
+  }
+
+  if (!subagent.issueReasons.includes(request.issue)) {
+    throw new Error(`Subagent "${request.subagentName}" no longer has ${formatIssueLabel(request.issue)}. Refresh inventory and try again if it still needs attention.`);
   }
 }
 
@@ -166,9 +209,17 @@ function assertResolutionIssueWasResolved(snapshot: SkillInventorySnapshot, requ
     return;
   }
 
-  const mcp = (snapshot.mcps ?? []).find((entry) => entry.name === request.mcpName);
-  if (mcp && mcp.issueReasons.includes(request.issue)) {
-    throw new Error(`MCP "${request.mcpName}" still has ${formatIssueLabel(request.issue)} after resolution.`);
+  if (request.entity === 'mcp') {
+    const mcp = (snapshot.mcps ?? []).find((entry) => entry.name === request.mcpName);
+    if (mcp && mcp.issueReasons.includes(request.issue)) {
+      throw new Error(`MCP "${request.mcpName}" still has ${formatIssueLabel(request.issue)} after resolution.`);
+    }
+    return;
+  }
+
+  const subagent = (snapshot.subagents ?? []).find((entry) => entry.name === request.subagentName);
+  if (subagent && subagent.issueReasons.includes(request.issue)) {
+    throw new Error(`Subagent "${request.subagentName}" still has ${formatIssueLabel(request.issue)} after resolution.`);
   }
 }
 
@@ -396,6 +447,400 @@ async function resolveMcpIssueIfCurrent(
       await writeMcpDefinitions(target.configPath, target.parserKind, target.definitions, target.writeDialect);
     }),
   );
+}
+
+async function resolveSubagentIssueIfCurrent(
+  snapshot: SkillInventorySnapshot,
+  request: Extract<ResolveIssueRequest, { entity: 'subagent' }>,
+  options: ResolveIssueOptions & { paths: SkillIndexPaths },
+): Promise<void> {
+  const subagent = (snapshot.subagents ?? []).find((entry) => entry.name === request.subagentName);
+  if (!subagent) {
+    throw new Error(`Subagent "${request.subagentName}" was not found in the current inventory.`);
+  }
+
+  if (!subagent.issueReasons.includes(request.issue)) {
+    throw new Error(`Subagent "${request.subagentName}" no longer has ${formatIssueLabel(request.issue)}. Refresh inventory and try again if it still needs attention.`);
+  }
+
+  assertSubagentResolutionScopeAllowed(subagent);
+
+  switch (request.issue) {
+    case 'missing-universal': {
+      const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
+        preferExisting: false,
+        requireSelectionOnAmbiguous: true,
+      });
+      const selectedLocation = pickSubagentSelection(subagent, request.selectedVariantPath, {
+        requireSelectionOnAmbiguous: true,
+      });
+      const duplicateTargets = collectIdenticalMarkdownSubagentCopyTargets(subagent, snapshot, selectedLocation.definitionComparisonKey);
+      await Promise.all(dedupeSubagentTargets(duplicateTargets).map((target) =>
+        replaceWithCanonicalSymlink(target.path, canonicalPackage.path)));
+      return;
+    }
+    case 'missing-from-agents': {
+      const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
+        preferExisting: true,
+        requireSelectionOnAmbiguous: true,
+      });
+      const targets = collectWritableMissingSubagentTargets(snapshot, subagent.missingLocations ?? []);
+      await Promise.all(dedupeSubagentTargets(targets).map((target) =>
+        writeSubagentTarget(target, canonicalPackage, canonicalPackage.definition, snapshot)));
+      return;
+    }
+    case 'identical-copies': {
+      const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
+        preferExisting: true,
+        requireSelectionOnAmbiguous: false,
+      });
+      const duplicateTargets = collectIdenticalMarkdownSubagentCopyTargets(
+        subagent,
+        snapshot,
+        findCanonicalSubagentLocation(subagent)?.definitionComparisonKey,
+      );
+      await Promise.all(dedupeSubagentTargets(duplicateTargets).map((target) =>
+        replaceWithCanonicalSymlink(target.path, canonicalPackage.path)));
+      return;
+    }
+    case 'broken-symlink':
+    case 'wrong-symlink-target': {
+      const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
+        preferExisting: true,
+        requireSelectionOnAmbiguous: false,
+      });
+      const targets = subagent.locations
+        .filter((location) =>
+          location.fileType === 'symlink'
+          && !location.canonical
+          && location.mutability === 'writable'
+          && (request.issue === 'broken-symlink'
+            ? location.resolvedPath === undefined
+            : location.resolvedPath !== undefined && path.normalize(location.resolvedPath) !== path.normalize(canonicalPackage.path)))
+        .map((location) => locationToSubagentWriteTarget(location, snapshot));
+      await Promise.all(dedupeSubagentTargets(targets).map((target) =>
+        writeSubagentTarget(target, canonicalPackage, canonicalPackage.definition, snapshot)));
+      return;
+    }
+    case 'definition-mismatch': {
+      const selectedLocation = pickSubagentSelection(subagent, request.selectedVariantPath, {
+        requireSelectionOnAmbiguous: true,
+      });
+      const selectedDefinition = readPortableDefinitionForSubagentLocation(snapshot, subagent.name, selectedLocation);
+      const canonicalPath = resolveCanonicalSubagentPath(subagent, selectedLocation, options.paths);
+      const canonicalPackage: CanonicalSubagentPackage = {
+        path: canonicalPath,
+        definition: selectedDefinition,
+      };
+      const canonicalLocation = findCanonicalSubagentLocation(subagent);
+      const targets = [
+        ...(!canonicalLocation || canonicalLocation.definitionComparisonKey !== selectedLocation.definitionComparisonKey
+          ? [{
+              agentId: 'universal-subagents',
+              path: canonicalPath,
+              format: 'markdown-frontmatter' as const,
+            }]
+          : []),
+        ...subagent.locations
+          .filter((location) =>
+            !location.canonical
+            && location.fileType === 'real-file'
+            && isWritableSubagentLocation(location)
+            && location.definitionComparisonKey !== selectedLocation.definitionComparisonKey)
+          .map((location) => locationToSubagentWriteTarget(location, snapshot)),
+      ];
+      await Promise.all(dedupeSubagentTargets(targets).map((target) =>
+        writeSubagentTarget(target, canonicalPackage, selectedDefinition, snapshot)));
+      return;
+    }
+  }
+}
+
+function assertSubagentResolutionScopeAllowed(subagent: SubagentRecord): void {
+  const scopes = new Set([
+    ...subagent.locations.map((location) => location.scope),
+    ...(subagent.missingLocations ?? []).map((location) => location.scope),
+  ]);
+  if (scopes.size > 1) {
+    throw new Error('Subagent resolution currently requires every affected location to stay within one scope.');
+  }
+}
+
+async function ensureCanonicalSubagentPackage(
+  subagent: SubagentRecord,
+  snapshot: SkillInventorySnapshot,
+  selectedVariantPath: string | undefined,
+  options: ResolveIssueOptions & { paths: SkillIndexPaths },
+  behavior: {
+    preferExisting: boolean;
+    requireSelectionOnAmbiguous: boolean;
+  },
+): Promise<CanonicalSubagentPackage> {
+  const canonicalLocation = behavior.preferExisting ? findCanonicalSubagentLocation(subagent) : null;
+  if (canonicalLocation) {
+    const definition = stripSubagentLocalExtras(
+      readPortableDefinitionForSubagentLocation(snapshot, subagent.name, canonicalLocation),
+    );
+    return {
+      path: canonicalLocation.path,
+      definition,
+    };
+  }
+
+  const selectedLocation = pickSubagentSelection(subagent, selectedVariantPath, {
+    requireSelectionOnAmbiguous: behavior.requireSelectionOnAmbiguous,
+  });
+  const definition = stripSubagentLocalExtras(
+    readPortableDefinitionForSubagentLocation(snapshot, subagent.name, selectedLocation),
+  );
+  const canonicalPath = resolveCanonicalSubagentPath(subagent, selectedLocation, options.paths);
+  await writeSubagentDefinitionFile(canonicalPath, 'markdown-frontmatter', definition);
+  return {
+    path: canonicalPath,
+    definition,
+  };
+}
+
+function findCanonicalSubagentLocation(subagent: SubagentRecord): SubagentLocationRecord | null {
+  return subagent.locations.find((location) =>
+    location.canonical
+    && location.fileType === 'real-file'
+    && (location.invalidDetails?.length ?? 0) === 0) ?? null;
+}
+
+function pickSubagentSelection(
+  subagent: SubagentRecord,
+  selectedVariantPath: string | undefined,
+  options: { requireSelectionOnAmbiguous: boolean },
+): SubagentLocationRecord {
+  const selectableLocations = subagent.locations.filter((location) =>
+    location.fileType === 'real-file'
+    && (location.invalidDetails?.length ?? 0) === 0);
+  if (selectableLocations.length === 0) {
+    throw new Error(`Subagent "${subagent.name}" has no valid definition to use for resolution.`);
+  }
+
+  if (selectedVariantPath) {
+    const selectedLocation = selectableLocations.find((location) => location.path === selectedVariantPath);
+    if (!selectedLocation) {
+      throw new Error('Choose one of the available subagent definitions before resolving this issue.');
+    }
+
+    return selectedLocation;
+  }
+
+  const groups = new Map<string, SubagentLocationRecord[]>();
+  for (const location of selectableLocations) {
+    const key = location.definitionComparisonKey ?? location.definitionText ?? `path:${location.path}`;
+    const existing = groups.get(key) ?? [];
+    existing.push(location);
+    groups.set(key, existing);
+  }
+
+  if (groups.size === 1) {
+    return [...groups.values()][0][0];
+  }
+
+  if (options.requireSelectionOnAmbiguous) {
+    throw new Error('Choose a subagent definition before resolving this issue.');
+  }
+
+  const canonicalLocation = selectableLocations.find((location) => location.canonical);
+  if (canonicalLocation) {
+    return canonicalLocation;
+  }
+
+  return selectableLocations[0];
+}
+
+function readPortableDefinitionForSubagentLocation(
+  snapshot: SkillInventorySnapshot,
+  fallbackName: string,
+  location: SubagentLocationRecord,
+): PortableSubagentDefinition {
+  return readPortableSubagentDefinitionFromFile({
+    family: findSubagentLocationFamily(snapshot, location.agentId),
+    filePath: location.path,
+    format: location.format,
+    fallbackName,
+  });
+}
+
+function findSubagentLocationFamily(snapshot: SkillInventorySnapshot, agentId: string): string | undefined {
+  return (snapshot.agents ?? []).find((agent) => agent.id === agentId)?.family;
+}
+
+function resolveCanonicalSubagentPath(
+  subagent: SubagentRecord,
+  selectedLocation: SubagentLocationRecord,
+  paths: SkillIndexPaths,
+): string {
+  const existingCanonicalLocation = findCanonicalSubagentLocation(subagent);
+  if (existingCanonicalLocation) {
+    return existingCanonicalLocation.path;
+  }
+
+  const canonicalSkillsDir = selectedLocation.scope === 'sandbox'
+    ? paths.sandboxCanonicalUserSkillsDir
+    : paths.liveCanonicalUserSkillsDir;
+  return path.join(
+    path.dirname(canonicalSkillsDir),
+    'agents',
+    getSubagentFileName(subagent.name, 'markdown-frontmatter'),
+  );
+}
+
+function collectWritableMissingSubagentTargets(
+  snapshot: SkillInventorySnapshot,
+  locations: SubagentExpectedLocationRecord[],
+): SubagentWriteTarget[] {
+  return locations
+    .filter((location) =>
+      location.path
+      && location.format
+      && location.supportStatus !== 'unsupported'
+      && isWritableSubagentAgent(snapshot, location.agentId))
+    .map((location) => ({
+      agentId: location.agentId,
+      family: findSubagentLocationFamily(snapshot, location.agentId),
+      format: location.format ?? 'markdown-frontmatter',
+      path: location.path ?? '',
+    }))
+    .filter((target) => target.path.length > 0);
+}
+
+function isWritableSubagentAgent(snapshot: SkillInventorySnapshot, agentId: string): boolean {
+  const agent = (snapshot.agents ?? []).find((entry) => entry.id === agentId);
+  return Boolean(agent?.writable && agent.subagentsLocation?.state === 'available' && agent.subagentsLocation.path);
+}
+
+function isWritableSubagentLocation(location: SubagentLocationRecord): boolean {
+  return !location.agentId.startsWith('plugin:')
+    && (location.canonical || location.mutability === 'writable')
+    && (location.invalidDetails?.length ?? 0) === 0;
+}
+
+function locationToSubagentWriteTarget(
+  location: SubagentLocationRecord,
+  snapshot: SkillInventorySnapshot,
+): SubagentWriteTarget {
+  return {
+    agentId: location.agentId,
+    family: findSubagentLocationFamily(snapshot, location.agentId),
+    format: location.format,
+    localExtrasKeys: location.localExtrasKeys,
+    path: location.path,
+  };
+}
+
+function collectIdenticalMarkdownSubagentCopyTargets(
+  subagent: SubagentRecord,
+  snapshot: SkillInventorySnapshot,
+  definitionComparisonKey: string | undefined,
+): SubagentWriteTarget[] {
+  if (!definitionComparisonKey) {
+    return [];
+  }
+
+  return subagent.locations
+    .filter((location) => {
+      const family = findSubagentLocationFamily(snapshot, location.agentId);
+      return location.fileType === 'real-file'
+        && !location.canonical
+        && location.mutability === 'writable'
+        && location.format === 'markdown-frontmatter'
+        && isMarkdownSubagentSymlinkCompatible(family)
+        && !hasSubagentLocalExtras(location)
+        && location.definitionComparisonKey === definitionComparisonKey;
+    })
+    .map((location) => locationToSubagentWriteTarget(location, snapshot));
+}
+
+function dedupeSubagentTargets(targets: SubagentWriteTarget[]): SubagentWriteTarget[] {
+  const seen = new Set<string>();
+  return targets.filter((target) => {
+    const key = path.normalize(target.path);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+async function writeSubagentTarget(
+  target: SubagentWriteTarget,
+  canonicalPackage: CanonicalSubagentPackage,
+  definition: PortableSubagentDefinition,
+  snapshot: SkillInventorySnapshot,
+): Promise<void> {
+  if (path.normalize(target.path) === path.normalize(canonicalPackage.path)) {
+    await writeSubagentDefinitionFile(target.path, 'markdown-frontmatter', stripSubagentLocalExtras(definition));
+    return;
+  }
+
+  const family = target.family ?? findSubagentLocationFamily(snapshot, target.agentId);
+  if (
+    target.format === 'markdown-frontmatter'
+    && isMarkdownSubagentSymlinkCompatible(family)
+    && !hasSubagentLocalExtras(target)
+  ) {
+    await replaceWithCanonicalSymlink(target.path, canonicalPackage.path);
+    return;
+  }
+
+  await writeSubagentDefinitionFile(
+    target.path,
+    target.format,
+    mergeExistingSubagentTargetExtras(target, stripSubagentLocalExtras(definition)),
+    { family },
+  );
+}
+
+async function writeSubagentDefinitionFile(
+  filePath: string,
+  format: AgentSubagentParserKind,
+  definition: PortableSubagentDefinition,
+  options: { family?: string } = {},
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await rm(filePath, { recursive: true, force: true });
+  await writeFile(filePath, renderPortableSubagentDefinition(definition, format, options), 'utf8');
+}
+
+function stripSubagentLocalExtras(definition: PortableSubagentDefinition): PortableSubagentDefinition {
+  return {
+    ...definition,
+    extras: {},
+  };
+}
+
+function mergeExistingSubagentTargetExtras(
+  target: SubagentWriteTarget,
+  definition: PortableSubagentDefinition,
+): PortableSubagentDefinition {
+  try {
+    const existing = readPortableSubagentDefinitionFromFile({
+      family: target.family,
+      filePath: target.path,
+      format: target.format,
+      fallbackName: definition.name,
+    });
+    return {
+      ...definition,
+      extras: existing.extras,
+    };
+  } catch {
+    return definition;
+  }
+}
+
+function getSubagentFileName(name: string, format: AgentSubagentParserKind): string {
+  return getSubagentFileNameForFormat({ name, format });
+}
+
+function hasSubagentLocalExtras(location: Pick<SubagentLocationRecord | SubagentWriteTarget, 'localExtrasKeys'>): boolean {
+  return (location.localExtrasKeys?.length ?? 0) > 0;
 }
 
 function getMcpDefinitionNameForWrite(requestedMcpName: string, selectedVariant: McpLocationRecord): string {

--- a/src/main/plugin-inventory.test.ts
+++ b/src/main/plugin-inventory.test.ts
@@ -28,8 +28,20 @@ async function writeSkill(rootPath: string, name: string, description: string): 
   ].join('\n'), 'utf8');
 }
 
+async function writeSubagent(filePath: string, name: string, description: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, [
+    '---',
+    `name: ${name}`,
+    `description: ${description}`,
+    '---',
+    '',
+    `Use ${name}.`,
+  ].join('\n'), 'utf8');
+}
+
 describe('plugin inventory', () => {
-  it('discovers installed Codex and Claude plugin bundles with skills and MCPs', async () => {
+  it('discovers installed Codex and Claude plugin bundles with skills, MCPs, and subagents', async () => {
     const homeDir = await mkdtemp(path.join(tmpdir(), 'skillindex-plugins-home-'));
     const codexRoot = path.join(homeDir, '.codex', 'plugins', 'cache', 'openai-curated', 'github-tools', 'abc123');
     const claudeRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'anthropic', 'jira-tools', '1.0.0');
@@ -48,6 +60,8 @@ describe('plugin inventory', () => {
         },
       },
     });
+    await writeSubagent(path.join(codexRoot, 'agents', 'reviewer.md'), 'reviewer', 'Reviews GitHub changes');
+    await writeFile(path.join(codexRoot, 'agents', 'yaml-runner.yaml'), 'name: yaml-runner\n', 'utf8');
     await writeJson(path.join(codexRoot, 'hooks', 'hooks.json'), {
       hooks: {
         SessionStart: [{ hooks: [{ type: 'command', command: 'node hook.js' }] }],
@@ -69,11 +83,17 @@ describe('plugin inventory', () => {
         },
       },
     });
+    await writeSubagent(path.join(claudeRoot, 'agents', 'jira-triage.md'), 'jira-triage', 'Triage Jira issues');
 
     const plugins = await scanPluginInventory({ homeDir });
+    const githubPlugin = plugins.find((plugin) => plugin.pluginId === 'github-tools@openai-curated');
+    if (!githubPlugin) {
+      throw new Error('Expected github-tools plugin to be discovered.');
+    }
 
     expect(plugins).toHaveLength(2);
-    expect(plugins.find((plugin) => plugin.pluginId === 'github-tools@openai-curated')).toMatchObject({
+    expect(githubPlugin.bundledSubagents?.map((subagent) => subagent.name)).toEqual(['reviewer', 'yaml-runner']);
+    expect(githubPlugin).toMatchObject({
       host: 'codex',
       pluginName: 'github-tools',
       version: 'abc123',
@@ -92,6 +112,16 @@ describe('plugin inventory', () => {
         expect.objectContaining({
           name: 'github',
           configPath: path.join(codexRoot, '.mcp.json'),
+        }),
+      ],
+      bundledSubagents: [
+        expect.objectContaining({
+          name: 'reviewer',
+          path: path.join(codexRoot, 'agents', 'reviewer.md'),
+        }),
+        expect.objectContaining({
+          name: 'yaml-runner',
+          path: path.join(codexRoot, 'agents', 'yaml-runner.yaml'),
         }),
       ],
       unsupportedAssets: [
@@ -113,6 +143,7 @@ describe('plugin inventory', () => {
       pluginName: 'jira-tools',
       bundledSkills: [expect.objectContaining({ name: 'jira' })],
       bundledMcps: [expect.objectContaining({ name: 'jira' })],
+      bundledSubagents: [expect.objectContaining({ name: 'jira-triage' })],
     });
   });
 

--- a/src/main/plugin-inventory.test.ts
+++ b/src/main/plugin-inventory.test.ts
@@ -239,6 +239,30 @@ describe('plugin inventory', () => {
     });
   });
 
+  it('uses manifest agents paths for plugin subagents when declared', async () => {
+    const homeDir = await mkdtemp(path.join(tmpdir(), 'skillindex-plugins-custom-agents-'));
+    const pluginRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'anthropic', 'review-tools', '1.0.0');
+
+    await writeJson(path.join(pluginRoot, '.claude-plugin', 'plugin.json'), {
+      name: 'review-tools',
+      version: '1.0.0',
+      agents: ['./custom-agents/reviewer.md'],
+    });
+    await writeSubagent(path.join(pluginRoot, 'agents', 'ignored-default.md'), 'ignored-default', 'Default agent ignored by manifest override');
+    await writeSubagent(path.join(pluginRoot, 'custom-agents', 'reviewer.md'), 'reviewer', 'Reviews changes from a custom manifest path');
+
+    const plugins = await scanPluginInventory({ homeDir });
+
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].bundledSubagents).toEqual([
+      expect.objectContaining({
+        name: 'reviewer',
+        path: path.join(pluginRoot, 'custom-agents', 'reviewer.md'),
+      }),
+    ]);
+    expect(plugins[0].bundledSubagents?.map((subagent) => subagent.name)).not.toContain('ignored-default');
+  });
+
   it('reads Claude plugin enabled state from user settings', async () => {
     const homeDir = await mkdtemp(path.join(tmpdir(), 'skillindex-plugins-claude-state-'));
     const enabledRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'anthropic', 'jira-tools', '1.0.0');

--- a/src/main/plugin-inventory.ts
+++ b/src/main/plugin-inventory.ts
@@ -8,6 +8,7 @@ import type {
   PluginHost,
   PluginMcpRef,
   PluginRecord,
+  PluginSubagentRef,
   PluginUnsupportedAssetRef,
   SkillSourceScope,
   PluginSkillRef,
@@ -30,6 +31,7 @@ interface PluginManifest {
   repository?: string | { url?: string };
   skills?: string | string[];
   mcpServers?: string | string[] | McpServerDefinitions;
+  agents?: string | string[];
   hooks?: string | string[];
 }
 
@@ -247,6 +249,7 @@ async function readPluginRecord(
     version,
   });
   const bundledMcps = await collectPluginMcps(candidate.rootPath, manifest, sourceId);
+  const bundledSubagents = await collectPluginSubagents(candidate.rootPath, manifest, sourceId);
   const unsupportedAssets = await collectPluginHooks(candidate.rootPath, manifest, sourceId);
 
   return {
@@ -261,6 +264,7 @@ async function readPluginRecord(
     skillRoots: skillInventory.skillRoots,
     bundledSkills: skillInventory.skills,
     bundledMcps,
+    bundledSubagents,
     unsupportedAssets,
     unsupportedHooksCount: unsupportedAssets.length,
     source: {
@@ -674,10 +678,168 @@ async function readMcpNames(configPath: string): Promise<string[]> {
             ? parsed
             : null;
 
-    return definitions ? Object.keys(definitions).sort((left, right) => left.localeCompare(right)) : [];
+  return definitions ? Object.keys(definitions).sort((left, right) => left.localeCompare(right)) : [];
   } catch {
     return [];
   }
+}
+
+async function collectPluginSubagents(
+  rootPath: string,
+  manifest: PluginManifest,
+  sourceId: string,
+): Promise<PluginSubagentRef[]> {
+  const agentPaths = await resolvePluginSubagentPaths(rootPath, manifest);
+  const refs = await Promise.all(agentPaths.map(async (agentPath) => ({
+    name: await readPluginSubagentName(agentPath),
+    path: agentPath,
+    sourceId,
+  })));
+
+  return dedupeBy(refs, (ref) => ref.path)
+    .sort((left, right) => left.name.localeCompare(right.name, undefined, { sensitivity: 'base' }));
+}
+
+async function resolvePluginSubagentPaths(rootPath: string, manifest: PluginManifest): Promise<string[]> {
+  const declaredPaths = normalizeManifestPaths(manifest.agents, 'agents').map((relativeAgentPath) =>
+    path.resolve(rootPath, relativeAgentPath));
+  const paths: string[] = [];
+
+  for (const agentPath of declaredPaths) {
+    paths.push(...await collectSubagentFiles(agentPath));
+  }
+
+  return paths.sort((left, right) => left.localeCompare(right));
+}
+
+async function collectSubagentFiles(targetPath: string): Promise<string[]> {
+  let stats;
+  try {
+    stats = await stat(targetPath);
+  } catch {
+    return [];
+  }
+
+  if (stats.isFile()) {
+    return isSubagentFileName(path.basename(targetPath)) ? [targetPath] : [];
+  }
+
+  if (!stats.isDirectory()) {
+    return [];
+  }
+
+  let entries: Dirent[];
+  try {
+    entries = await readdir(targetPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isFile() && isSubagentFileName(entry.name)) {
+      files.push(path.join(targetPath, entry.name));
+    }
+  }
+
+  return files;
+}
+
+function isSubagentFileName(fileName: string): boolean {
+  return /\.(?:md|toml|json|jsonc|ya?ml)$/iu.test(fileName);
+}
+
+async function readPluginSubagentName(agentPath: string): Promise<string> {
+  try {
+    const raw = await readFile(agentPath, 'utf8');
+    const frontMatterName = readFrontMatterField(raw, 'name');
+    if (frontMatterName) {
+      return frontMatterName;
+    }
+
+    const tomlName = readTomlStringField(raw, 'name');
+    if (tomlName) {
+      return tomlName;
+    }
+
+    const yamlName = readYamlStringField(raw, 'name');
+    if (yamlName) {
+      return yamlName;
+    }
+
+    const parsedJson = JSON.parse(sanitizeJsonc(raw)) as unknown;
+    if (isRecord(parsedJson) && typeof parsedJson.name === 'string' && parsedJson.name.trim().length > 0) {
+      return parsedJson.name.trim();
+    }
+  } catch {
+    // Fall back to the filename below.
+  }
+
+  return path.basename(agentPath).replace(/(?:\.agent)?\.(?:md|toml|jsonc?|ya?ml)$/iu, '');
+}
+
+function readFrontMatterField(raw: string, field: string): string | null {
+  const lines = raw.split(/\r?\n/u);
+  if (lines[0] !== '---') {
+    return null;
+  }
+
+  const closingIndex = lines.findIndex((line, index) => index > 0 && (line === '---' || line === '...'));
+  if (closingIndex < 0) {
+    return null;
+  }
+
+  const fieldPattern = new RegExp(`^${field}:\\s*(.*)$`, 'u');
+  for (const line of lines.slice(1, closingIndex)) {
+    const match = fieldPattern.exec(line);
+    const value = match?.[1]?.trim();
+    if (value) {
+      return unquoteScalar(value);
+    }
+  }
+
+  return null;
+}
+
+function readYamlStringField(raw: string, field: string): string | null {
+  const fieldPattern = new RegExp(`^${field}:\\s*(.*)$`, 'u');
+  for (const line of raw.split(/\r?\n/u)) {
+    const match = fieldPattern.exec(stripYamlComment(line).trim());
+    const value = match?.[1]?.trim();
+    if (value && value !== '|' && value !== '>') {
+      return unquoteScalar(value);
+    }
+  }
+
+  return null;
+}
+
+function stripYamlComment(line: string): string {
+  let inQuote: '"' | "'" | null = null;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if ((character === '"' || character === "'") && line[index - 1] !== '\\') {
+      inQuote = inQuote === character ? null : inQuote ?? character;
+    }
+    if (character === '#' && !inQuote) {
+      return line.slice(0, index);
+    }
+  }
+  return line;
+}
+
+function readTomlStringField(raw: string, field: string): string | null {
+  const fieldPattern = new RegExp(`^\\s*${field}\\s*=\\s*(.+?)\\s*$`, 'mu');
+  const value = fieldPattern.exec(raw)?.[1]?.trim();
+  return value ? unquoteScalar(value) : null;
+}
+
+function unquoteScalar(value: string): string {
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+
+  return value;
 }
 
 async function collectPluginHooks(

--- a/src/main/plugin-inventory.ts
+++ b/src/main/plugin-inventory.ts
@@ -701,6 +701,8 @@ async function collectPluginSubagents(
 }
 
 async function resolvePluginSubagentPaths(rootPath: string, manifest: PluginManifest): Promise<string[]> {
+  // Claude Code documents plugin subagents under the `agents` manifest key and
+  // both Claude and Codex plugin bundles use `agents/` as the default root.
   const declaredPaths = normalizeManifestPaths(manifest.agents, 'agents').map((relativeAgentPath) =>
     path.resolve(rootPath, relativeAgentPath));
   const paths: string[] = [];

--- a/src/main/sandbox-fixtures.ts
+++ b/src/main/sandbox-fixtures.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdir, rm, symlink, utimes, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { McpServerDefinition, SeedRepresentativeFixturesResult, SkillStructuralState } from '@shared/contracts';
+import type { AgentRecord, McpServerDefinition, SeedRepresentativeFixturesResult, SkillStructuralState } from '@shared/contracts';
 import {
   defaultConfig,
   ensureSkillIndexSandboxLayout,
@@ -34,6 +34,13 @@ interface SkillMarkdownOptions {
   includeName?: boolean;
   frontMatterName?: string;
   frontMatterDescription?: string;
+}
+
+interface SubagentMarkdownOptions {
+  name: string;
+  description?: string;
+  bodyLines: string[];
+  extraFields?: Record<string, string | boolean | number>;
 }
 
 type McpDefinition = McpServerDefinition;
@@ -124,6 +131,9 @@ const INITIALLY_DISMISSED_SKILL_NAMES = new Set([
 const INITIALLY_DISMISSED_MCP_NAMES = new Set([
   'muted-mcp',
   'muted-extra-mcp',
+]);
+const INITIALLY_DISMISSED_SUBAGENT_NAMES = new Set([
+  'dismissed-subagent',
 ]);
 const INVALID_SKILL_NAME_TOO_LONG = 'a'.repeat(65);
 const INVALID_SKILL_DESCRIPTION_TOO_LONG = `Too long: ${'x'.repeat(1016)}`;
@@ -1370,6 +1380,7 @@ export async function seedRepresentativeFixtures(
     ...representativeMcpAgentIds.map((agentId) =>
       writeAgentMcpConfig(sandboxAgents, agentId, representativeMcpConfigs[agentId])),
   ]);
+  await writeSandboxSubagentFixtures(paths.sandboxRoot, sandboxAgents);
   if (includeParserMatrix) {
     await writeGeneratedHealthySkillSymlinksForAgents(sourceById, sandboxAgents, REPRESENTATIVE_SKILL_AGENT_IDS);
   }
@@ -1385,10 +1396,14 @@ export async function seedRepresentativeFixtures(
   const dismissedMcpSignatures = (seededInventory.mcps ?? [])
     .filter((mcp) => INITIALLY_DISMISSED_MCP_NAMES.has(mcp.name) && mcp.signature)
     .map((mcp) => mcp.signature as string);
+  const dismissedSubagentSignatures = (seededInventory.subagents ?? [])
+    .filter((subagent) => INITIALLY_DISMISSED_SUBAGENT_NAMES.has(subagent.name) && subagent.signature)
+    .map((subagent) => subagent.signature as string);
   await writeSkillIndexConfig(paths.configFile, {
     ...defaultConfig,
     dismissedDriftSignatures,
     dismissedMcpSignatures,
+    dismissedSubagentSignatures,
   });
 
   return {
@@ -1666,6 +1681,309 @@ async function writeSandboxCodexConfig(configPath: string): Promise<void> {
   await writeFile(configPath, 'model = "gpt-5"\n', 'utf8');
 }
 
+async function writeSandboxSubagentFixtures(sandboxRoot: string, agents: AgentRecord[]): Promise<void> {
+  const canonicalDir = path.join(sandboxRoot, '.agents', 'agents');
+  const claudeDir = getSandboxAgentSubagentsDir(agents, 'sandbox-claude');
+  const codexDir = getSandboxAgentSubagentsDir(agents, 'sandbox-codex');
+  const factoryDir = getSandboxAgentSubagentsDir(agents, 'sandbox-factory');
+  const canonicalPath = (name: string) => path.join(canonicalDir, `${name}.md`);
+  const claudePath = (name: string) => path.join(claudeDir ?? canonicalDir, `${name}.md`);
+  const factoryPath = (name: string) => path.join(factoryDir ?? canonicalDir, `${name}.md`);
+  const codexPath = (name: string) => path.join(codexDir ?? canonicalDir, `${name}.toml`);
+  const writeMarkdown = (
+    filePath: string,
+    name: string,
+    description: string | undefined,
+    bodyLines: string[],
+    extraFields?: Record<string, string | boolean | number>,
+  ) =>
+    writeFileWithParents(
+      filePath,
+      buildSubagentMarkdown({
+        name,
+        description,
+        bodyLines,
+        ...(extraFields ? { extraFields } : {}),
+      }),
+    );
+  const writeCodex = (
+    filePath: string,
+    name: string,
+    description: string,
+    developerInstructions: string,
+  ) =>
+    writeFileWithParents(
+      filePath,
+      buildCodexSubagentToml({ name, description, developerInstructions }),
+    );
+
+  const canonicalDefinitions: Array<Promise<void>> = [
+    writeMarkdown(
+      canonicalPath('healthy-subagent'),
+      'healthy-subagent',
+      'Healthy across Universal, Claude, Codex, and Factory.',
+      ['Use the shared healthy behavior everywhere.'],
+    ),
+    writeMarkdown(
+      canonicalPath('reviewer'),
+      'reviewer',
+      'Reviews implementation changes across supported agents.',
+      ['Inspect diffs, note risks, and keep recommendations grounded in repository behavior.'],
+    ),
+    writeMarkdown(
+      canonicalPath('missing-from-agents-subagent'),
+      'missing-from-agents-subagent',
+      'Universal copy exists but supported agent locations are absent.',
+      ['This should show the Missing From Agents issue by itself.'],
+    ),
+    writeMarkdown(
+      canonicalPath('dismissed-subagent'),
+      'dismissed-subagent',
+      'Universal copy exists, but its missing agent copies start dismissed in Sandbox.',
+      ['This should show the same issue as Missing From Agents with dismissed presentation.'],
+    ),
+    writeMarkdown(
+      canonicalPath('identical-copies-subagent'),
+      'identical-copies-subagent',
+      'Has an agent-local Markdown copy that exactly matches Universal.',
+      ['This duplicate should be replaced with a symlink.'],
+    ),
+    writeMarkdown(
+      canonicalPath('definition-mismatch-subagent'),
+      'definition-mismatch-subagent',
+      'Canonical definition used for mismatch resolution.',
+      ['Use the canonical mismatch fixture behavior.'],
+    ),
+    writeMarkdown(
+      canonicalPath('broken-symlink-subagent'),
+      'broken-symlink-subagent',
+      'Exercises repair for a broken agent-local subagent link.',
+      ['This canonical copy should replace the broken agent-local link.'],
+    ),
+    writeMarkdown(
+      canonicalPath('wrong-symlink-target-subagent'),
+      'wrong-symlink-target-subagent',
+      'Exercises repair for a symlink pointing at a different subagent.',
+      ['This canonical copy is the correct target for the agent-local symlink.'],
+    ),
+    writeMarkdown(
+      canonicalPath('wrong-symlink-target-decoy'),
+      'wrong-symlink-target-decoy',
+      'A healthy decoy subagent used as the wrong symlink target.',
+      ['This file intentionally receives an unrelated symlink from another subagent.'],
+    ),
+    writeMarkdown(
+      canonicalPath('invalid-universal-subagent'),
+      'invalid-universal-subagent',
+      undefined,
+      ['This Universal definition intentionally omits the required description field.'],
+    ),
+    writeMarkdown(
+      canonicalPath('multi-mismatch-missing-subagent'),
+      'multi-mismatch-missing-subagent',
+      'Canonical definition that also lacks some supported agent targets.',
+      ['Use the canonical multi-issue mismatch behavior.'],
+    ),
+    writeMarkdown(
+      canonicalPath('multi-identical-missing-subagent'),
+      'multi-identical-missing-subagent',
+      'Canonical definition with a duplicate and missing supported agent targets.',
+      ['This duplicate is intentionally missing other agent renderings.'],
+    ),
+    writeMarkdown(
+      canonicalPath('multi-broken-missing-subagent'),
+      'multi-broken-missing-subagent',
+      'Canonical definition with a broken link and missing supported agent targets.',
+      ['Repair the broken link while still showing absent agent locations.'],
+    ),
+  ];
+
+  await Promise.all(canonicalDefinitions);
+
+  const writes: Array<Promise<void>> = [];
+  if (claudeDir) {
+    writes.push(
+      writeSubagentFixtureSymlink(
+        claudePath('healthy-subagent'),
+        canonicalPath('healthy-subagent'),
+      ),
+      writeFileWithParents(
+        claudePath('identical-copies-subagent'),
+        buildSubagentMarkdown({
+          name: 'identical-copies-subagent',
+          description: 'Has an agent-local Markdown copy that exactly matches Universal.',
+          bodyLines: ['This duplicate should be replaced with a symlink.'],
+        }),
+      ),
+      writeFileWithParents(
+        claudePath('definition-mismatch-subagent'),
+        buildSubagentMarkdown({
+          name: 'definition-mismatch-subagent',
+          description: 'Claude-local definition used for mismatch resolution.',
+          bodyLines: ['Use the Claude-local mismatch fixture behavior.'],
+        }),
+      ),
+      writeSubagentFixtureSymlink(
+        claudePath('broken-symlink-subagent'),
+        path.join(canonicalDir, 'missing-broken-symlink-target.md'),
+      ),
+      writeSubagentFixtureSymlink(
+        claudePath('wrong-symlink-target-subagent'),
+        canonicalPath('wrong-symlink-target-decoy'),
+      ),
+      writeSubagentFixtureSymlink(
+        claudePath('wrong-symlink-target-decoy'),
+        canonicalPath('wrong-symlink-target-decoy'),
+      ),
+      writeFileWithParents(
+        claudePath('multi-mismatch-missing-subagent'),
+        buildSubagentMarkdown({
+          name: 'multi-mismatch-missing-subagent',
+          description: 'Claude definition that differs while other agents are missing.',
+          bodyLines: ['Use the Claude-local multi-issue behavior.'],
+        }),
+      ),
+      writeFileWithParents(
+        claudePath('multi-identical-missing-subagent'),
+        buildSubagentMarkdown({
+          name: 'multi-identical-missing-subagent',
+          description: 'Canonical definition with a duplicate and missing supported agent targets.',
+          bodyLines: ['This duplicate is intentionally missing other agent renderings.'],
+        }),
+      ),
+      writeSubagentFixtureSymlink(
+        claudePath('multi-broken-missing-subagent'),
+        path.join(canonicalDir, 'missing-multi-broken-target.md'),
+      ),
+      writeFileWithParents(
+        claudePath('missing-universal-claude-subagent'),
+        buildSubagentMarkdown({
+          name: 'missing-universal-claude-subagent',
+          description: 'Claude-local subagent without a Universal copy.',
+          bodyLines: ['Promote this into Universal before syncing elsewhere.'],
+        }),
+      ),
+      writeFileWithParents(
+        claudePath('invalid-definition-subagent'),
+        [
+          '---',
+          'name: invalid-definition-subagent',
+          '---',
+          'This intentionally omits Claude Code\'s required description field.',
+          '',
+        ].join('\n'),
+      ),
+    );
+  }
+
+  if (codexDir) {
+    writes.push(
+      writeCodex(
+        codexPath('healthy-subagent'),
+        'healthy-subagent',
+        'Healthy across Universal, Claude, Codex, and Factory.',
+        'Use the shared healthy behavior everywhere.',
+      ),
+      writeCodex(
+        codexPath('identical-copies-subagent'),
+        'identical-copies-subagent',
+        'Has an agent-local Markdown copy that exactly matches Universal.',
+        'This duplicate should be replaced with a symlink.',
+      ),
+      writeCodex(
+        codexPath('definition-mismatch-subagent'),
+        'definition-mismatch-subagent',
+        'Canonical definition used for mismatch resolution.',
+        'Use the canonical mismatch fixture behavior.',
+      ),
+      writeCodex(
+        codexPath('broken-symlink-subagent'),
+        'broken-symlink-subagent',
+        'Exercises repair for a broken agent-local subagent link.',
+        'This canonical copy should replace the broken agent-local link.',
+      ),
+      writeCodex(
+        codexPath('wrong-symlink-target-subagent'),
+        'wrong-symlink-target-subagent',
+        'Exercises repair for a symlink pointing at a different subagent.',
+        'This canonical copy is the correct target for the agent-local symlink.',
+      ),
+      writeCodex(
+        codexPath('wrong-symlink-target-decoy'),
+        'wrong-symlink-target-decoy',
+        'A healthy decoy subagent used as the wrong symlink target.',
+        'This file intentionally receives an unrelated symlink from another subagent.',
+      ),
+      writeCodex(
+        codexPath('missing-universal-codex-subagent'),
+        'missing-universal-codex-subagent',
+        'Codex TOML subagent without a Universal copy.',
+        'Promote this Codex TOML definition into Universal.',
+      ),
+      writeFileWithParents(
+        codexPath('codex-multiline-subagent'),
+        [
+          'name = "codex-multiline-subagent"',
+          'description = "Exercises Codex TOML multiline instructions."',
+          'developer_instructions = """',
+          'Review release health before proceeding.',
+          'Confirm rollback ownership.',
+          '"""',
+          '',
+        ].join('\n'),
+      ),
+    );
+  }
+
+  if (factoryDir) {
+    writes.push(
+      writeSubagentFixtureSymlink(
+        factoryPath('healthy-subagent'),
+        canonicalPath('healthy-subagent'),
+      ),
+      writeSubagentFixtureSymlink(
+        factoryPath('identical-copies-subagent'),
+        canonicalPath('identical-copies-subagent'),
+      ),
+      writeSubagentFixtureSymlink(
+        factoryPath('definition-mismatch-subagent'),
+        canonicalPath('definition-mismatch-subagent'),
+      ),
+      writeSubagentFixtureSymlink(
+        factoryPath('broken-symlink-subagent'),
+        canonicalPath('broken-symlink-subagent'),
+      ),
+      writeSubagentFixtureSymlink(
+        factoryPath('wrong-symlink-target-subagent'),
+        canonicalPath('wrong-symlink-target-subagent'),
+      ),
+      writeSubagentFixtureSymlink(
+        factoryPath('wrong-symlink-target-decoy'),
+        canonicalPath('wrong-symlink-target-decoy'),
+      ),
+      writeFileWithParents(
+        factoryPath('factory-name-only-droid'),
+        buildSubagentMarkdown({
+          name: 'factory-name-only-droid',
+          bodyLines: ['Factory droids document name as the required frontmatter field.'],
+        }),
+      ),
+    );
+  }
+
+  await Promise.all(writes);
+}
+
+function getSandboxAgentSubagentsDir(agents: AgentRecord[], agentId: string): string | null {
+  const subagentsPath = agents.find((agent) => agent.id === agentId)?.subagentsLocation?.path;
+  return subagentsPath && subagentsPath.length > 0 ? subagentsPath : null;
+}
+
+async function writeSubagentFixtureSymlink(linkPath: string, targetPath: string): Promise<void> {
+  await mkdir(path.dirname(linkPath), { recursive: true });
+  await symlink(targetPath, linkPath);
+}
+
 async function writeSandboxClaudePluginState(sandboxRoot: string): Promise<void> {
   const pluginRoot = path.join(sandboxRoot, '.claude', 'plugins', 'sandbox-plugin-pack');
   await Promise.all([
@@ -1682,6 +2000,14 @@ async function writeSandboxClaudePluginState(sandboxRoot: string): Promise<void>
       version: '0.1.0',
       repository: 'https://github.com/example/sandbox-plugin-pack',
     }),
+    writeFileWithParents(
+      path.join(pluginRoot, 'agents', 'deployment-expert.md'),
+      buildSubagentMarkdown({
+        name: 'deployment-expert',
+        description: 'Specializes in deployment strategies and production rollouts.',
+        bodyLines: ['Check release gates, rollback ownership, and production rollout sequencing.'],
+      }),
+    ),
   ]);
 }
 
@@ -2031,6 +2357,41 @@ function buildSkillMarkdown({
     '',
     `# ${title}`,
     ...bodyLines,
+    '',
+  ].join('\n');
+}
+
+function buildSubagentMarkdown({
+  name,
+  description,
+  bodyLines,
+  extraFields = {},
+}: SubagentMarkdownOptions): string {
+  return [
+    '---',
+    `name: ${JSON.stringify(name)}`,
+    ...(description ? [`description: ${JSON.stringify(description)}`] : []),
+    ...Object.entries(extraFields).map(([key, value]) =>
+      `${key}: ${typeof value === 'string' ? JSON.stringify(value) : String(value)}`),
+    '---',
+    ...bodyLines,
+    '',
+  ].join('\n');
+}
+
+function buildCodexSubagentToml({
+  name,
+  description,
+  developerInstructions,
+}: {
+  name: string;
+  description: string;
+  developerInstructions: string;
+}): string {
+  return [
+    `name = ${JSON.stringify(name)}`,
+    `description = ${JSON.stringify(description)}`,
+    `developer_instructions = ${JSON.stringify(developerInstructions)}`,
     '',
   ].join('\n');
 }

--- a/src/main/sandbox-inventory-adapter.ts
+++ b/src/main/sandbox-inventory-adapter.ts
@@ -30,12 +30,14 @@ export function resolveSandboxAgentRuntimePaths(
   installResolutionContext: { cwd: string; env: NodeJS.ProcessEnv; homeDir: string };
   mcpConfigPath?: string;
   configPath?: string;
+  subagentsDir?: string;
   executablePath?: string;
 } {
   return {
     installResolutionContext: { cwd: rootDir, env: {}, homeDir: rootDir },
     mcpConfigPath: family.mcpConfigRelativeParts ? path.join(rootDir, ...family.mcpConfigRelativeParts) : undefined,
     configPath: family.agentConfigRelativeParts ? path.join(rootDir, ...family.agentConfigRelativeParts) : undefined,
+    subagentsDir: family.subagentGlobalDirRelativeParts ? path.join(rootDir, ...family.subagentGlobalDirRelativeParts) : undefined,
     executablePath: family.expectedExecutableNames?.[0]
       ? path.join(rootDir, 'bin', family.expectedExecutableNames[0])
       : undefined,

--- a/src/main/skill-inventory-config-remediation.test.ts
+++ b/src/main/skill-inventory-config-remediation.test.ts
@@ -39,6 +39,7 @@ describe('dismissed drift config remediation', () => {
       onboardingCompletedAt: null,
       dismissedDriftSignatures: ['stale-dismissed-signature'],
       dismissedMcpSignatures: [],
+      dismissedSubagentSignatures: [],
     };
     const latestConfig: SkillIndexConfig = {
       customScanPaths: [path.join(root, 'custom-skills')],
@@ -47,6 +48,7 @@ describe('dismissed drift config remediation', () => {
       onboardingCompletedAt: null,
       dismissedDriftSignatures: ['stale-dismissed-signature'],
       dismissedMcpSignatures: ['dismissed-mcp-signature'],
+      dismissedSubagentSignatures: ['dismissed-subagent-signature'],
     };
     const mockedReadSkillIndexConfig = vi.mocked(readSkillIndexConfig);
     const mockedWriteSkillIndexConfig = vi.mocked(writeSkillIndexConfig);

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -4332,6 +4332,7 @@ function isSubagentLocationRecord(value: unknown): value is SubagentRecord['loca
     && isString(value.modifiedAt)
     && typeof value.canonical === 'boolean'
     && isSubagentParserKind(value.format)
+    && (value.description === undefined || value.description === null || isString(value.description))
     && (value.definitionText === undefined || isString(value.definitionText))
     && (value.definitionComparisonKey === undefined || isString(value.definitionComparisonKey))
     && (value.localExtrasKeys === undefined || (Array.isArray(value.localExtrasKeys) && value.localExtrasKeys.every(isString)))

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -47,6 +47,8 @@ import type {
   SkillStructuralState,
   SkillUniversalAlternate,
   SkillUniversalDecision,
+  SubagentInventoryCounts,
+  SubagentRecord,
 } from '@shared/contracts';
 import { buildTextDiffLines } from '@shared/text-diff';
 import { parseTomlMcpServerArray, parseTomlMcpServers } from '@shared/toml-mcp';
@@ -72,6 +74,7 @@ import {
 import { sanitizeJsonc, stableStringify } from '@main/json-utils';
 import { verifyMcpConnection } from '@main/mcp-connectivity';
 import { buildPluginSkillScanSources, scanPluginInventory } from '@main/plugin-inventory';
+import { collectSubagentRecords, countSubagents } from '@main/subagent-inventory';
 
 export interface ScanSkillInventoryOptions extends ScanInventoryOptions, ResolveSkillIndexPathOptions {
   paths?: SkillIndexPaths;
@@ -182,6 +185,14 @@ export async function scanSkillInventory(options: ScanSkillInventoryOptions = {}
   const mcps = (await collectMcpRecords(agents, sources, plugins, scanOptions)).map((mcp) =>
     applyMcpPresentation(mcp, config.dismissedMcpSignatures)).sort(compareMcps);
   const mcpCounts = countMcps(mcps);
+  const subagents = collectSubagentRecords({
+    agents,
+    plugins,
+    paths,
+    includeLiveSources: scanOptions.includeLiveSources,
+    includeSandboxSources: scanOptions.includeSandboxSources,
+  }).map((subagent) => applySubagentPresentation(subagent, config.dismissedSubagentSignatures));
+  const subagentCounts = countSubagents(subagents);
   const agentCounts = countAgents(agents);
 
   const snapshot: SkillInventorySnapshot = {
@@ -193,6 +204,8 @@ export async function scanSkillInventory(options: ScanSkillInventoryOptions = {}
     counts: countSkills(skills),
     mcps,
     mcpCounts,
+    subagents,
+    subagentCounts,
     agents,
     agentCounts,
     homeSummary: buildHomeSummary(countSkills(skills), mcpCounts, agentCounts),
@@ -233,6 +246,7 @@ export async function readCachedSkillInventory(
     config.skillUniversalDecisions ?? [],
     config.dismissedDriftSignatures,
     config.dismissedMcpSignatures,
+    config.dismissedSubagentSignatures,
   );
 }
 
@@ -271,6 +285,7 @@ export function readCachedSkillInventorySync(
     config.skillUniversalDecisions ?? [],
     config.dismissedDriftSignatures,
     config.dismissedMcpSignatures,
+    config.dismissedSubagentSignatures,
   );
 }
 
@@ -318,6 +333,35 @@ export async function dismissSkillDrift(
       ...snapshot,
       scannedAt: new Date().toISOString(),
     }, dismissedDriftSignatures, snapshot.sources);
+    await writeSkillInventoryCache(paths.cacheFile, nextSnapshot);
+
+    return nextSnapshot;
+  }
+
+  if ('subagentName' in request) {
+    const subagent = (snapshot.subagents ?? []).find((candidate) => candidate.name === request.subagentName);
+
+    if (!subagent || subagent.status !== 'needs-attention' || !subagent.signature) {
+      throw new Error(`Only attention subagents can be dismissed or undismissed: ${request.subagentName}`);
+    }
+
+    const dismissedSubagentSignatures = subagent.presentation === 'dismissed'
+      ? config.dismissedSubagentSignatures.filter((signature) => signature !== subagent.signature)
+      : [...new Set([...config.dismissedSubagentSignatures, subagent.signature])];
+
+    await writeSkillIndexConfig(paths.configFile, {
+      ...config,
+      dismissedSubagentSignatures,
+    });
+
+    const subagents = applyDismissedSubagentState(snapshot.subagents ?? [], dismissedSubagentSignatures);
+    const subagentCounts = countSubagents(subagents);
+    const nextSnapshot: SkillInventorySnapshot = {
+      ...snapshot,
+      scannedAt: new Date().toISOString(),
+      subagents,
+      subagentCounts,
+    };
     await writeSkillInventoryCache(paths.cacheFile, nextSnapshot);
 
     return nextSnapshot;
@@ -1191,6 +1235,24 @@ function applyDismissedMcpState(mcps: McpRecord[], dismissedMcpSignatures: strin
   return mcps.map((mcp) => applyMcpPresentation(mcp, dismissedMcpSignatures));
 }
 
+function applySubagentPresentation(subagent: SubagentRecord, dismissedSubagentSignatures: string[]): SubagentRecord {
+  if (subagent.status !== 'needs-attention' || !subagent.signature) {
+    return subagent;
+  }
+
+  return {
+    ...subagent,
+    presentation: dismissedSubagentSignatures.includes(subagent.signature) ? 'dismissed' : 'active',
+  };
+}
+
+function applyDismissedSubagentState(
+  subagents: SubagentRecord[],
+  dismissedSubagentSignatures: string[],
+): SubagentRecord[] {
+  return subagents.map((subagent) => applySubagentPresentation(subagent, dismissedSubagentSignatures));
+}
+
 function countMcps(mcps: McpRecord[]): McpInventoryCounts {
   return mcps.reduce<McpInventoryCounts>(
     (counts, mcp) => {
@@ -1617,6 +1679,7 @@ function reconcileSkillInventorySnapshot(
   universalDecisions: SkillUniversalDecision[],
   dismissedDriftSignatures: string[],
   dismissedMcpSignatures: string[],
+  dismissedSubagentSignatures: string[],
 ): SkillInventorySnapshot {
   const activeSources = sources ?? registeredSources;
   const activeAgents = agents ?? [];
@@ -1627,12 +1690,16 @@ function reconcileSkillInventorySnapshot(
   ) {
     const mcps = applyDismissedMcpState(snapshot.mcps ?? [], dismissedMcpSignatures);
     const mcpCounts = countMcps(mcps);
+    const subagents = applyDismissedSubagentState(snapshot.subagents ?? [], dismissedSubagentSignatures);
+    const subagentCounts = countSubagents(subagents);
     const agentCounts = countAgents(activeAgents);
 
     return applyDismissedDriftState({
       ...snapshot,
       mcps,
       mcpCounts,
+      subagents,
+      subagentCounts,
       agents: activeAgents,
       plugins,
       agentCounts,
@@ -3836,6 +3903,8 @@ function isSkillInventorySnapshot(value: unknown): value is SkillInventorySnapsh
     && isSkillInventoryCounts(value.counts)
     && (value.mcps === undefined || (Array.isArray(value.mcps) && value.mcps.every(isMcpRecord)))
     && (value.mcpCounts === undefined || isMcpInventoryCounts(value.mcpCounts))
+    && (value.subagents === undefined || (Array.isArray(value.subagents) && value.subagents.every(isSubagentRecord)))
+    && (value.subagentCounts === undefined || isSubagentInventoryCounts(value.subagentCounts))
     && (value.agents === undefined || (Array.isArray(value.agents) && value.agents.every(isAgentRecord)))
     && (value.agentCounts === undefined || isAgentInventoryCounts(value.agentCounts))
     && (value.homeSummary === undefined || isHomeSummary(value.homeSummary));
@@ -3881,6 +3950,13 @@ function isPluginRecord(value: unknown): value is PluginRecord {
       && isString(mcp.name)
       && isString(mcp.configPath)
       && isString(mcp.sourceId))
+    && (value.bundledSubagents === undefined
+      || (Array.isArray(value.bundledSubagents)
+        && value.bundledSubagents.every((subagent) =>
+          isRecord(subagent)
+          && isString(subagent.name)
+          && isString(subagent.path)
+          && isString(subagent.sourceId))))
     && (value.unsupportedHooksCount === undefined || isNumber(value.unsupportedHooksCount))
     && (value.source === undefined
       || (isRecord(value.source)
@@ -4045,6 +4121,31 @@ function isAgentRecord(value: unknown): value is AgentRecord {
       || value.mcpWriteDialect === 'yaml-typed'
       || value.mcpWriteDialect === 'none'
       || value.mcpWriteDialect === 'unknown')
+    && (value.subagentConfigKind === undefined
+      || value.subagentConfigKind === 'directory'
+      || value.subagentConfigKind === 'agent-config'
+      || value.subagentConfigKind === 'plugin-only'
+      || value.subagentConfigKind === 'account-managed'
+      || value.subagentConfigKind === 'none'
+      || value.subagentConfigKind === 'unknown')
+    && (value.subagentParserKind === undefined
+      || value.subagentParserKind === 'markdown-frontmatter'
+      || value.subagentParserKind === 'codex-toml'
+      || value.subagentParserKind === 'json'
+      || value.subagentParserKind === 'jsonc'
+      || value.subagentParserKind === 'toml'
+      || value.subagentParserKind === 'yaml'
+      || value.subagentParserKind === 'none'
+      || value.subagentParserKind === 'unknown')
+    && (value.subagentWriteDialect === undefined
+      || value.subagentWriteDialect === 'markdown-frontmatter'
+      || value.subagentWriteDialect === 'codex-toml'
+      || value.subagentWriteDialect === 'json'
+      || value.subagentWriteDialect === 'jsonc'
+      || value.subagentWriteDialect === 'toml'
+      || value.subagentWriteDialect === 'yaml'
+      || value.subagentWriteDialect === 'none'
+      || value.subagentWriteDialect === 'unknown')
     && (value.metadataSources === undefined
       || (Array.isArray(value.metadataSources)
         && value.metadataSources.every((source) => isRecord(source) && isString(source.url) && (source.note === undefined || isString(source.note)))))
@@ -4056,6 +4157,7 @@ function isAgentRecord(value: unknown): value is AgentRecord {
         && (value.icon.note === undefined || isString(value.icon.note))))
     && isAgentLocationRecord(value.skillsLocation)
     && isAgentLocationRecord(value.mcpConfigLocation)
+    && (value.subagentsLocation === undefined || isAgentLocationRecord(value.subagentsLocation))
     && (value.configLocation === undefined || isAgentLocationRecord(value.configLocation))
     && (value.executableLocation === undefined || isAgentLocationRecord(value.executableLocation));
 }
@@ -4140,6 +4242,88 @@ function isMcpInventoryCounts(value: unknown): value is McpInventoryCounts {
     && isNumber(value.attentionMcps)
     && isNumber(value.healthyMcps)
     && isNumber(value.dismissedAttentionMcps);
+}
+
+function isSubagentLocationRecord(value: unknown): value is SubagentRecord['locations'][number] {
+  return isRecord(value)
+    && isString(value.agentId)
+    && isString(value.agentLabel)
+    && (value.scope === 'sandbox' || value.scope === 'live' || value.scope === 'custom')
+    && isString(value.path)
+    && isString(value.directoryPath)
+    && (value.fileType === 'real-file' || value.fileType === 'symlink')
+    && isString(value.modifiedAt)
+    && typeof value.canonical === 'boolean'
+    && isSubagentParserKind(value.format)
+    && (value.definitionText === undefined || isString(value.definitionText))
+    && (value.definitionComparisonKey === undefined || isString(value.definitionComparisonKey))
+    && (value.localExtrasKeys === undefined || (Array.isArray(value.localExtrasKeys) && value.localExtrasKeys.every(isString)))
+    && (value.invalidDetails === undefined || (Array.isArray(value.invalidDetails) && value.invalidDetails.every(isString)))
+    && (value.resolvedPath === undefined || isString(value.resolvedPath))
+    && (value.symlinkTarget === undefined || isString(value.symlinkTarget))
+    && (value.provenance === undefined || isSkillProvenance(value.provenance))
+    && (value.canonicalRole === undefined || isCanonicalRole(value.canonicalRole))
+    && (value.mutability === undefined || isMutability(value.mutability));
+}
+
+function isSubagentExpectedLocationRecord(value: unknown): value is NonNullable<SubagentRecord['expectedLocations']>[number] {
+  return isRecord(value)
+    && isString(value.agentId)
+    && isString(value.agentLabel)
+    && (value.scope === 'sandbox' || value.scope === 'live' || value.scope === 'custom')
+    && (value.directoryPath === undefined || isString(value.directoryPath))
+    && (value.path === undefined || isString(value.path))
+    && (value.format === undefined || isSubagentParserKind(value.format))
+    && (value.supportStatus === undefined || value.supportStatus === 'supported' || value.supportStatus === 'unsupported')
+    && (value.unsupportedReason === undefined
+      || value.unsupportedReason === 'not-documented'
+      || value.unsupportedReason === 'unsupported-format'
+      || value.unsupportedReason === 'account-managed');
+}
+
+function isSubagentRecord(value: unknown): value is SubagentRecord {
+  return isRecord(value)
+    && isString(value.name)
+    && (value.displayName === undefined || value.displayName === null || isString(value.displayName))
+    && (value.description === undefined || value.description === null || isString(value.description))
+    && (value.status === 'healthy' || value.status === 'needs-attention')
+    && (value.presentation === 'none' || value.presentation === 'active' || value.presentation === 'dismissed')
+    && Array.isArray(value.locations)
+    && value.locations.every(isSubagentLocationRecord)
+    && (value.expectedLocations === undefined || (Array.isArray(value.expectedLocations) && value.expectedLocations.every(isSubagentExpectedLocationRecord)))
+    && (value.missingLocations === undefined || (Array.isArray(value.missingLocations) && value.missingLocations.every(isSubagentExpectedLocationRecord)))
+    && Array.isArray(value.issueReasons)
+    && value.issueReasons.every(isSubagentIssueReason)
+    && (value.signature === undefined || isString(value.signature));
+}
+
+function isSubagentInventoryCounts(value: unknown): value is SubagentInventoryCounts {
+  return isRecord(value)
+    && isNumber(value.totalSubagents)
+    && isNumber(value.attentionSubagents)
+    && isNumber(value.healthySubagents)
+    && isNumber(value.dismissedAttentionSubagents);
+}
+
+function isSubagentParserKind(value: unknown): boolean {
+  return value === 'markdown-frontmatter'
+    || value === 'codex-toml'
+    || value === 'json'
+    || value === 'jsonc'
+    || value === 'toml'
+    || value === 'yaml'
+    || value === 'none'
+    || value === 'unknown';
+}
+
+function isSubagentIssueReason(value: unknown): boolean {
+  return value === 'missing-universal'
+    || value === 'missing-from-agents'
+    || value === 'definition-mismatch'
+    || value === 'identical-copies'
+    || value === 'broken-symlink'
+    || value === 'wrong-symlink-target'
+    || value === 'invalid-definition';
 }
 
 function isHomeSummaryMetric(value: unknown): boolean {

--- a/src/main/subagent-inventory.test.ts
+++ b/src/main/subagent-inventory.test.ts
@@ -1,0 +1,743 @@
+// @vitest-environment node
+
+import { lstat, mkdir, mkdtemp, readFile, realpath, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveInventoryIssue } from '@main/issue-resolution';
+import { seedRepresentativeFixtures } from '@main/sandbox-fixtures';
+import { dismissSkillDrift, scanSkillInventory } from '@main/skill-inventory';
+import {
+  readPortableSubagentDefinitionFromFile,
+  renderPortableSubagentDefinition,
+} from '@main/subagent-inventory';
+import { readSkillIndexConfig, resolveSandboxSkillIndexPaths, resolveSkillIndexPaths } from '@shared/skill-index-paths';
+
+async function writeMarkdownSubagent(
+  filePath: string,
+  name: string,
+  description: string,
+  prompt: string,
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, [
+    '---',
+    `name: ${JSON.stringify(name)}`,
+    `description: ${JSON.stringify(description)}`,
+    '---',
+    prompt,
+    '',
+  ].join('\n'), 'utf8');
+}
+
+async function writeCodexSubagent(
+  filePath: string,
+  name: string,
+  description: string,
+  prompt: string,
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, [
+    `name = ${JSON.stringify(name)}`,
+    `description = ${JSON.stringify(description)}`,
+    `developer_instructions = ${JSON.stringify(prompt)}`,
+    '',
+  ].join('\n'), 'utf8');
+}
+
+async function writeRawFile(filePath: string, content: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, 'utf8');
+}
+
+async function createSubagentTestPaths() {
+  const root = await mkdtemp(path.join(tmpdir(), 'skillindex-subagents-'));
+  const homeDir = path.join(root, 'home');
+  const dataDir = path.join(root, 'data');
+  const paths = resolveSkillIndexPaths({
+    env: { SKILL_INDEX_DATA_DIR: dataDir },
+    homeDir,
+  });
+  await mkdir(path.join(homeDir, '.codex'), { recursive: true });
+  await mkdir(path.join(homeDir, '.claude'), { recursive: true });
+
+  return {
+    homeDir,
+    paths,
+    scanOptions: {
+      paths,
+      homeDir,
+      includeLiveSources: true,
+      includeSandboxSources: false,
+    },
+  };
+}
+
+describe('subagent inventory', () => {
+  it('normalizes Markdown and Codex TOML definitions and identifies duplicate Markdown copies', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'reviewer.md');
+    const claudePath = path.join(homeDir, '.claude', 'agents', 'reviewer.md');
+    const codexPath = path.join(homeDir, '.codex', 'agents', 'reviewer.toml');
+
+    await writeMarkdownSubagent(canonicalPath, 'reviewer', 'Reviews code changes.', 'Review the diff carefully.');
+    await writeMarkdownSubagent(claudePath, 'reviewer', 'Reviews code changes.', 'Review the diff carefully.');
+    await writeCodexSubagent(codexPath, 'reviewer', 'Reviews code changes.', 'Review the diff carefully.');
+
+    const inventory = await scanSkillInventory(scanOptions);
+    const reviewer = inventory.subagents?.find((subagent) => subagent.name === 'reviewer');
+
+    expect(reviewer).toMatchObject({
+      status: 'needs-attention',
+      issueReasons: ['identical-copies'],
+    });
+    expect(reviewer?.locations.map((location) => location.agentLabel).sort()).toEqual([
+      'Claude Code',
+      'Codex',
+      'Live .agents',
+    ]);
+  });
+
+  it('repairs subagent drift by symlinking Markdown agents and rendering Codex TOML', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'planner.md');
+    const claudePath = path.join(homeDir, '.claude', 'agents', 'planner.md');
+    const codexPath = path.join(homeDir, '.codex', 'agents', 'planner.toml');
+
+    await writeMarkdownSubagent(canonicalPath, 'planner', 'Plans implementation work.', 'Plan carefully.');
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'missing-from-agents',
+      selectedVariantPath: canonicalPath,
+      subagentName: 'planner',
+    }, scanOptions);
+
+    const planner = repaired.subagents?.find((subagent) => subagent.name === 'planner');
+    expect(planner?.issueReasons).not.toContain('missing-from-agents');
+    expect((await lstat(claudePath)).isSymbolicLink()).toBe(true);
+    expect(await realpath(claudePath)).toBe(await realpath(canonicalPath));
+    expect(await readFile(codexPath, 'utf8')).toContain('developer_instructions = "Plan carefully."');
+  });
+
+  it('promotes a discovered subagent into the universal agents directory', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'deployer.md');
+    const claudePath = path.join(homeDir, '.claude', 'agents', 'deployer.md');
+
+    await writeMarkdownSubagent(claudePath, 'deployer', 'Handles deployment rollout checks.', 'Check rollout safety.');
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'missing-universal',
+      selectedVariantPath: claudePath,
+      subagentName: 'deployer',
+    }, scanOptions);
+
+    const deployer = repaired.subagents?.find((subagent) => subagent.name === 'deployer');
+    expect(deployer?.issueReasons).not.toContain('missing-universal');
+    expect(deployer?.issueReasons).not.toContain('identical-copies');
+    expect(await readFile(canonicalPath, 'utf8')).toContain('Check rollout safety.');
+    expect((await lstat(claudePath)).isSymbolicLink()).toBe(true);
+    expect(await realpath(claudePath)).toBe(await realpath(canonicalPath));
+  });
+
+  it('applies documented required fields per Markdown subagent family', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+
+    await writeRawFile(path.join(homeDir, '.copilot', 'agents', 'copilot-reviewer.agent.md'), [
+      '---',
+      'description: Reviews pull request changes.',
+      '---',
+      'Review the current pull request.',
+      '',
+    ].join('\n'));
+    await writeRawFile(path.join(homeDir, '.augment', 'agents', 'augment-planner.md'), [
+      '---',
+      'name: augment-planner',
+      '---',
+      'Plan the task.',
+      '',
+    ].join('\n'));
+    await writeRawFile(path.join(homeDir, '.mux', 'agents', 'mux-runner.md'), [
+      '---',
+      'name: mux-runner',
+      'subagent.runnable: true',
+      '---',
+      'Run delegated work.',
+      '',
+    ].join('\n'));
+    await writeRawFile(path.join(homeDir, '.claude', 'agents', 'missing-description.md'), [
+      '---',
+      'name: missing-description',
+      '---',
+      'This Claude subagent is missing its required description.',
+      '',
+    ].join('\n'));
+
+    const inventory = await scanSkillInventory(scanOptions);
+    const copilot = inventory.subagents?.find((subagent) => subagent.name === 'copilot-reviewer');
+    const augment = inventory.subagents?.find((subagent) => subagent.name === 'augment-planner');
+    const mux = inventory.subagents?.find((subagent) => subagent.name === 'mux-runner');
+    const claude = inventory.subagents?.find((subagent) => subagent.name === 'missing-description');
+
+    expect(copilot?.issueReasons).not.toContain('invalid-definition');
+    expect(augment?.issueReasons).not.toContain('invalid-definition');
+    expect(mux?.issueReasons).not.toContain('invalid-definition');
+    expect(claude?.issueReasons).toContain('invalid-definition');
+    expect(claude?.locations[0]?.invalidDetails).toContain('Missing required field: description');
+  });
+
+  it('groups symlinks by link filename so wrong subagent targets are visible', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const reviewerPath = path.join(homeDir, '.agents', 'agents', 'reviewer.md');
+    const plannerPath = path.join(homeDir, '.agents', 'agents', 'planner.md');
+    const claudeReviewerPath = path.join(homeDir, '.claude', 'agents', 'reviewer.md');
+
+    await writeMarkdownSubagent(reviewerPath, 'reviewer', 'Reviews code.', 'Review the diff.');
+    await writeMarkdownSubagent(plannerPath, 'planner', 'Plans work.', 'Plan the change.');
+    await mkdir(path.dirname(claudeReviewerPath), { recursive: true });
+    await symlink(plannerPath, claudeReviewerPath);
+
+    const inventory = await scanSkillInventory(scanOptions);
+    const reviewer = inventory.subagents?.find((subagent) => subagent.name === 'reviewer');
+
+    expect(reviewer?.issueReasons).toContain('wrong-symlink-target');
+    expect(reviewer?.issueReasons).not.toContain('definition-mismatch');
+    expect(inventory.subagents?.find((subagent) => subagent.name === 'planner')?.locations)
+      .toHaveLength(1);
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'wrong-symlink-target',
+      selectedVariantPath: reviewerPath,
+      subagentName: 'reviewer',
+    }, scanOptions);
+    const repairedReviewer = repaired.subagents?.find((subagent) => subagent.name === 'reviewer');
+
+    expect(repairedReviewer?.issueReasons).not.toContain('wrong-symlink-target');
+    expect(await realpath(claudeReviewerPath)).toBe(await realpath(reviewerPath));
+  });
+
+  it('reports broken subagent symlinks without hiding them behind invalid-definition', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'broken-link.md');
+    const claudePath = path.join(homeDir, '.claude', 'agents', 'broken-link.md');
+
+    await writeMarkdownSubagent(canonicalPath, 'broken-link', 'Covers broken symlink repair.', 'Repair safely.');
+    await mkdir(path.dirname(claudePath), { recursive: true });
+    await symlink(path.join(homeDir, '.agents', 'agents', 'missing-target.md'), claudePath);
+
+    const inventory = await scanSkillInventory(scanOptions);
+    const brokenLink = inventory.subagents?.find((subagent) => subagent.name === 'broken-link');
+
+    expect(brokenLink?.issueReasons).toContain('broken-symlink');
+    expect(brokenLink?.issueReasons).not.toContain('invalid-definition');
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'broken-symlink',
+      selectedVariantPath: canonicalPath,
+      subagentName: 'broken-link',
+    }, scanOptions);
+    const repairedBrokenLink = repaired.subagents?.find((subagent) => subagent.name === 'broken-link');
+
+    expect(repairedBrokenLink?.issueReasons).not.toContain('broken-symlink');
+    expect(await realpath(claudePath)).toBe(await realpath(canonicalPath));
+  });
+
+  it('rejects symlink paths as selected subagent definitions', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'reviewer.md');
+    const claudePath = path.join(homeDir, '.claude', 'agents', 'reviewer.md');
+    const codexPath = path.join(homeDir, '.codex', 'agents', 'reviewer.toml');
+
+    await writeMarkdownSubagent(canonicalPath, 'reviewer', 'Reviews code.', 'Use canonical review rules.');
+    await writeCodexSubagent(codexPath, 'reviewer', 'Reviews code differently.', 'Use Codex review rules.');
+    await mkdir(path.dirname(claudePath), { recursive: true });
+    await symlink(canonicalPath, claudePath);
+
+    await expect(resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'definition-mismatch',
+      selectedVariantPath: claudePath,
+      subagentName: 'reviewer',
+    }, scanOptions)).rejects.toThrow('Choose one of the available subagent definitions before resolving this issue.');
+  });
+
+  it('renders markdown subagents with incompatible required fields as materialized copies', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'mux-runner.md');
+    const muxPath = path.join(homeDir, '.mux', 'agents', 'mux-runner.md');
+
+    await mkdir(path.dirname(muxPath), { recursive: true });
+    await writeMarkdownSubagent(canonicalPath, 'mux-runner', 'Runs delegated work.', 'Run the delegated task.');
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'missing-from-agents',
+      selectedVariantPath: canonicalPath,
+      subagentName: 'mux-runner',
+    }, scanOptions);
+    const repairedMuxRunner = repaired.subagents?.find((subagent) => subagent.name === 'mux-runner');
+    const muxContent = await readFile(muxPath, 'utf8');
+
+    expect((await lstat(muxPath)).isSymbolicLink()).toBe(false);
+    expect(muxContent).toContain('subagent.runnable: true');
+    expect(repairedMuxRunner?.locations.find((location) => location.path === muxPath)?.invalidDetails).toBeUndefined();
+  });
+
+  it('ignores local-only subagent fields when comparing portable definitions', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'mux-runner.md');
+    const muxPath = path.join(homeDir, '.mux', 'agents', 'mux-runner.md');
+
+    await writeMarkdownSubagent(canonicalPath, 'mux-runner', 'Runs delegated work.', 'Run the delegated task.');
+    await writeRawFile(muxPath, [
+      '---',
+      'name: mux-runner',
+      'description: Runs delegated work.',
+      'subagent.runnable: true',
+      '---',
+      'Run the delegated task.',
+      '',
+    ].join('\n'));
+
+    const inventory = await scanSkillInventory(scanOptions);
+    const muxRunner = inventory.subagents?.find((subagent) => subagent.name === 'mux-runner');
+
+    expect(muxRunner?.issueReasons).not.toContain('definition-mismatch');
+    expect(muxRunner?.issueReasons).not.toContain('identical-copies');
+  });
+
+  it('blocks subagent resolution across mixed inventory scopes', async () => {
+    const { homeDir, paths } = await createSubagentTestPaths();
+    const livePath = path.join(homeDir, '.agents', 'agents', 'scope-split.md');
+    const sandboxPath = path.join(paths.sandboxRoot, '.agents', 'agents', 'scope-split.md');
+    const scanOptions = {
+      paths,
+      homeDir,
+      includeLiveSources: true,
+      includeSandboxSources: true,
+    };
+
+    await writeMarkdownSubagent(livePath, 'scope-split', 'Live definition.', 'Use live behavior.');
+    await writeMarkdownSubagent(sandboxPath, 'scope-split', 'Sandbox definition.', 'Use sandbox behavior.');
+
+    await expect(resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'definition-mismatch',
+      selectedVariantPath: livePath,
+      subagentName: 'scope-split',
+    }, scanOptions)).rejects.toThrow('Subagent resolution currently requires every affected location to stay within one scope.');
+  });
+
+  it('reads Codex multiline TOML instructions before promoting to the universal directory', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const codexPath = path.join(homeDir, '.codex', 'agents', 'release-planner.toml');
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'release-planner.md');
+
+    await writeRawFile(codexPath, [
+      'name = "release-planner"',
+      'description = "Plans release rollouts."',
+      'developer_instructions = """',
+      'Check staged rollout health.',
+      'Verify rollback ownership.',
+      '"""',
+      '',
+    ].join('\n'));
+
+    await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'missing-universal',
+      selectedVariantPath: codexPath,
+      subagentName: 'release-planner',
+    }, scanOptions);
+
+    const canonicalContent = await readFile(canonicalPath, 'utf8');
+    expect(canonicalContent).toContain('Check staged rollout health.');
+    expect(canonicalContent).toContain('Verify rollback ownership.');
+  });
+
+  it('marks generic TOML subagents invalid when required prompt metadata is missing', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const vibePath = path.join(homeDir, '.vibe', 'agents', 'bare.toml');
+
+    await writeRawFile(vibePath, [
+      'agent_type = "subagent"',
+      'name = "bare"',
+      '',
+    ].join('\n'));
+
+    const inventory = await scanSkillInventory(scanOptions);
+    const bare = inventory.subagents?.find((subagent) => subagent.name === 'bare');
+
+    expect(bare?.issueReasons).toContain('invalid-definition');
+    expect(bare?.locations[0]?.invalidDetails).toEqual(expect.arrayContaining([
+      'Missing required field: description',
+      'Missing required field: instructions',
+    ]));
+  });
+
+  it('keeps plugin subagents namespaced and promotes them without overwriting local names', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const localPath = path.join(homeDir, '.agents', 'agents', 'reviewer.md');
+    const pluginPath = path.join(
+      homeDir,
+      '.codex',
+      'plugins',
+      'cache',
+      'sandbox-curated',
+      'github-tools',
+      'abc123',
+      'agents',
+      'reviewer.md',
+    );
+    const manifestPath = path.join(
+      homeDir,
+      '.codex',
+      'plugins',
+      'cache',
+      'sandbox-curated',
+      'github-tools',
+      'abc123',
+      '.codex-plugin',
+      'plugin.json',
+    );
+
+    await writeMarkdownSubagent(localPath, 'reviewer', 'Local review helper.', 'Use local review rules.');
+    await writeMarkdownSubagent(pluginPath, 'reviewer', 'Plugin review helper.', 'Use plugin review rules.');
+    await writeRawFile(manifestPath, `${JSON.stringify({ name: 'github-tools', version: 'abc123' }, null, 2)}\n`);
+
+    const inventory = await scanSkillInventory(scanOptions);
+    const localReviewer = inventory.subagents?.find((subagent) => subagent.name === 'reviewer');
+    const pluginReviewer = inventory.subagents?.find((subagent) => subagent.name === 'github-tools:reviewer');
+
+    expect(localReviewer?.locations.some((location) => location.provenance?.kind === 'plugin')).toBe(false);
+    expect(pluginReviewer?.displayName).toBe('reviewer');
+    expect(pluginReviewer?.issueReasons).toContain('missing-universal');
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'missing-universal',
+      selectedVariantPath: pluginPath,
+      subagentName: 'github-tools:reviewer',
+    }, scanOptions);
+    const repairedPlugin = repaired.subagents?.find((subagent) => subagent.name === 'github-tools:reviewer');
+
+    expect(repairedPlugin?.issueReasons).not.toContain('missing-universal');
+    expect(repairedPlugin?.issueReasons).not.toContain('definition-mismatch');
+    const universalDefinition = await readFile(path.join(homeDir, '.agents', 'agents', 'github-tools-reviewer.md'), 'utf8');
+    expect(universalDefinition).toContain('name: "reviewer"');
+    expect(universalDefinition).not.toContain('github-tools:reviewer');
+    expect(await readFile(localPath, 'utf8')).toContain('Local review helper.');
+  });
+
+  it('repairs legacy plugin subagent Universal files without keeping the scoped name in frontmatter', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const universalPath = path.join(homeDir, '.agents', 'agents', 'github-tools-reviewer.md');
+    const pluginPath = path.join(
+      homeDir,
+      '.codex',
+      'plugins',
+      'cache',
+      'sandbox-curated',
+      'github-tools',
+      'abc123',
+      'agents',
+      'reviewer.md',
+    );
+    const manifestPath = path.join(
+      homeDir,
+      '.codex',
+      'plugins',
+      'cache',
+      'sandbox-curated',
+      'github-tools',
+      'abc123',
+      '.codex-plugin',
+      'plugin.json',
+    );
+
+    await writeMarkdownSubagent(universalPath, 'github-tools:reviewer', 'Plugin review helper.', 'Use plugin review rules.');
+    await writeMarkdownSubagent(pluginPath, 'reviewer', 'Plugin review helper.', 'Use plugin review rules.');
+    await writeRawFile(manifestPath, `${JSON.stringify({ name: 'github-tools', version: 'abc123' }, null, 2)}\n`);
+
+    const inventory = await scanSkillInventory(scanOptions);
+    expect(inventory.subagents?.find((subagent) => subagent.name === 'github-tools:reviewer')?.issueReasons)
+      .toContain('definition-mismatch');
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'definition-mismatch',
+      selectedVariantPath: pluginPath,
+      subagentName: 'github-tools:reviewer',
+    }, scanOptions);
+    const repairedPlugin = repaired.subagents?.find((subagent) => subagent.name === 'github-tools:reviewer');
+    const universalDefinition = await readFile(universalPath, 'utf8');
+
+    expect(repairedPlugin?.issueReasons).not.toContain('definition-mismatch');
+    expect(repairedPlugin?.issueReasons).not.toContain('missing-universal');
+    expect(universalDefinition).toContain('name: "reviewer"');
+    expect(universalDefinition).not.toContain('github-tools:reviewer');
+  });
+
+  it('requires an explicit definition choice for ambiguous subagent mismatch repair', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'ambiguous.md');
+    const claudePath = path.join(homeDir, '.claude', 'agents', 'ambiguous.md');
+
+    await writeMarkdownSubagent(canonicalPath, 'ambiguous', 'Canonical description.', 'Use canonical behavior.');
+    await writeMarkdownSubagent(claudePath, 'ambiguous', 'Claude description.', 'Use Claude behavior.');
+
+    await expect(resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'definition-mismatch',
+      subagentName: 'ambiguous',
+    }, scanOptions)).rejects.toThrow('Choose a subagent definition before resolving this issue.');
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'definition-mismatch',
+      selectedVariantPath: canonicalPath,
+      subagentName: 'ambiguous',
+    }, scanOptions);
+    const ambiguous = repaired.subagents?.find((subagent) => subagent.name === 'ambiguous');
+
+    expect(ambiguous?.issueReasons).not.toContain('definition-mismatch');
+    expect((await lstat(claudePath)).isSymbolicLink()).toBe(true);
+    expect(await realpath(claudePath)).toBe(await realpath(canonicalPath));
+  });
+
+  it('dismisses and undismisses attention subagents by signature', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'quiet-planner.md');
+
+    await writeMarkdownSubagent(canonicalPath, 'quiet-planner', 'Plans quietly.', 'Prepare the implementation plan.');
+
+    const inventory = await scanSkillInventory(scanOptions);
+    const initialSubagent = inventory.subagents?.find((subagent) => subagent.name === 'quiet-planner');
+    expect(initialSubagent).toMatchObject({
+      status: 'needs-attention',
+      presentation: 'active',
+    });
+    expect(initialSubagent?.signature).toBeDefined();
+
+    const dismissedSnapshot = await dismissSkillDrift({ subagentName: 'quiet-planner' }, {
+      ...scanOptions,
+      snapshot: inventory,
+    });
+    const dismissedSubagent = dismissedSnapshot.subagents?.find((subagent) => subagent.name === 'quiet-planner');
+    expect(dismissedSubagent).toMatchObject({
+      status: 'needs-attention',
+      presentation: 'dismissed',
+    });
+    expect(dismissedSnapshot.subagentCounts?.dismissedAttentionSubagents).toBe(1);
+
+    const configAfterDismiss = await readSkillIndexConfig(scanOptions.paths.configFile, { homeDir });
+    expect(configAfterDismiss.dismissedSubagentSignatures).toContain(initialSubagent?.signature);
+
+    const restoredSnapshot = await dismissSkillDrift({ subagentName: 'quiet-planner' }, {
+      ...scanOptions,
+      snapshot: dismissedSnapshot,
+    });
+    expect(restoredSnapshot.subagents?.find((subagent) => subagent.name === 'quiet-planner')?.presentation).toBe('active');
+
+    const configAfterRestore = await readSkillIndexConfig(scanOptions.paths.configFile, { homeDir });
+    expect(configAfterRestore.dismissedSubagentSignatures).not.toContain(initialSubagent?.signature);
+  });
+
+  it('seeds representative sandbox subagents across documented issue combinations', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-subagents-sandbox-'));
+    const homeDir = path.join(root, 'home');
+    const rootPaths = resolveSkillIndexPaths({
+      env: { SKILL_INDEX_DATA_DIR: path.join(root, 'data') },
+      homeDir,
+    });
+    const sandboxPaths = resolveSandboxSkillIndexPaths({ paths: rootPaths });
+
+    await seedRepresentativeFixtures({ paths: rootPaths, homeDir });
+
+    const inventory = await scanSkillInventory({
+      paths: sandboxPaths,
+      homeDir,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+    const byName = new Map((inventory.subagents ?? []).map((subagent) => [subagent.name, subagent]));
+
+    expect(byName.get('healthy-subagent')).toMatchObject({
+      status: 'healthy',
+      issueReasons: [],
+      presentation: 'none',
+    });
+    expect(byName.get('missing-from-agents-subagent')?.issueReasons).toEqual(['missing-from-agents']);
+    expect(byName.get('dismissed-subagent')).toMatchObject({
+      issueReasons: ['missing-from-agents'],
+      presentation: 'dismissed',
+    });
+    expect(byName.get('missing-universal-claude-subagent')?.issueReasons).toEqual(['missing-universal']);
+    expect(byName.get('missing-universal-codex-subagent')?.issueReasons).toEqual(['missing-universal']);
+    expect(byName.get('identical-copies-subagent')?.issueReasons).toEqual(['identical-copies']);
+    expect(byName.get('definition-mismatch-subagent')?.issueReasons).toEqual(['definition-mismatch']);
+    expect(byName.get('broken-symlink-subagent')?.issueReasons).toEqual(expect.arrayContaining(['broken-symlink']));
+    expect(byName.get('wrong-symlink-target-subagent')?.issueReasons)
+      .toEqual(expect.arrayContaining(['wrong-symlink-target']));
+    expect(byName.get('wrong-symlink-target-subagent')?.issueReasons)
+      .not.toContain('definition-mismatch');
+    expect(byName.get('invalid-universal-subagent')?.issueReasons)
+      .toEqual(expect.arrayContaining(['invalid-definition', 'missing-from-agents']));
+    expect(byName.get('invalid-definition-subagent')?.issueReasons)
+      .toEqual(expect.arrayContaining(['invalid-definition', 'missing-universal']));
+    expect(byName.get('multi-mismatch-missing-subagent')?.issueReasons)
+      .toEqual(expect.arrayContaining(['definition-mismatch', 'missing-from-agents']));
+    expect(byName.get('multi-identical-missing-subagent')?.issueReasons)
+      .toEqual(expect.arrayContaining(['identical-copies', 'missing-from-agents']));
+    expect(byName.get('multi-broken-missing-subagent')?.issueReasons)
+      .toEqual(expect.arrayContaining(['broken-symlink', 'missing-from-agents']));
+    expect(byName.get('multi-broken-missing-subagent')?.issueReasons)
+      .not.toContain('definition-mismatch');
+    expect(byName.get('sandbox-plugin-pack:deployment-expert')?.issueReasons).toEqual(['missing-universal']);
+    expect(inventory.subagentCounts).toMatchObject({
+      dismissedAttentionSubagents: 1,
+    });
+    expect(inventory.subagentCounts?.totalSubagents ?? 0).toBeGreaterThanOrEqual(16);
+  });
+
+  it('resolves sandbox subagent definition mismatches without filling missing agent targets', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-subagents-sandbox-resolution-'));
+    const homeDir = path.join(root, 'home');
+    const rootPaths = resolveSkillIndexPaths({
+      env: { SKILL_INDEX_DATA_DIR: path.join(root, 'data') },
+      homeDir,
+    });
+    const sandboxPaths = resolveSandboxSkillIndexPaths({ paths: rootPaths });
+    const scanOptions = {
+      paths: sandboxPaths,
+      homeDir,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    };
+    const subagentName = 'multi-mismatch-missing-subagent';
+    const canonicalPath = path.join(rootPaths.sandboxRoot, '.agents', 'agents', `${subagentName}.md`);
+    const claudePath = path.join(rootPaths.sandboxRoot, '.claude', 'agents', `${subagentName}.md`);
+
+    await seedRepresentativeFixtures({ paths: rootPaths, homeDir });
+
+    const before = await scanSkillInventory(scanOptions);
+    const beforeSubagent = before.subagents?.find((subagent) => subagent.name === subagentName);
+    expect(beforeSubagent?.issueReasons).toEqual(expect.arrayContaining(['definition-mismatch', 'missing-from-agents']));
+    expect(beforeSubagent?.missingLocations ?? []).not.toHaveLength(0);
+
+    const resolved = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'definition-mismatch',
+      selectedVariantPath: claudePath,
+      subagentName,
+    }, scanOptions);
+    const resolvedSubagent = resolved.subagents?.find((subagent) => subagent.name === subagentName);
+
+    expect(await readFile(canonicalPath, 'utf8')).toContain('Use the Claude-local multi-issue behavior.');
+    expect(resolvedSubagent?.issueReasons).not.toContain('definition-mismatch');
+    expect(resolvedSubagent?.issueReasons).toContain('missing-from-agents');
+    expect(resolvedSubagent?.missingLocations ?? []).not.toHaveLength(0);
+  });
+
+  it('preserves local-only Markdown fields when resolving subagent mismatches', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'colored-reviewer.md');
+    const claudePath = path.join(homeDir, '.claude', 'agents', 'colored-reviewer.md');
+
+    await writeMarkdownSubagent(canonicalPath, 'colored-reviewer', 'Reviews code with color metadata.', 'Use canonical behavior.');
+    await writeRawFile(claudePath, [
+      '---',
+      'name: colored-reviewer',
+      'description: Reviews code with color metadata.',
+      'color: blue',
+      '---',
+      'Use Claude-local behavior.',
+      '',
+    ].join('\n'));
+
+    const before = await scanSkillInventory(scanOptions);
+    const beforeSubagent = before.subagents?.find((subagent) => subagent.name === 'colored-reviewer');
+    expect(beforeSubagent?.issueReasons).toContain('definition-mismatch');
+    expect(beforeSubagent?.locations.find((location) => location.path === claudePath)?.localExtrasKeys).toEqual(['color']);
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'definition-mismatch',
+      selectedVariantPath: canonicalPath,
+      subagentName: 'colored-reviewer',
+    }, scanOptions);
+    const repairedSubagent = repaired.subagents?.find((subagent) => subagent.name === 'colored-reviewer');
+    const claudeContent = await readFile(claudePath, 'utf8');
+
+    expect((await lstat(claudePath)).isSymbolicLink()).toBe(false);
+    expect(claudeContent).toContain('color: "blue"');
+    expect(claudeContent).toContain('Use canonical behavior.');
+    expect(repairedSubagent?.issueReasons).not.toContain('definition-mismatch');
+    expect(repairedSubagent?.issueReasons).not.toContain('identical-copies');
+  });
+
+  it('round-trips documented JSON, JSONC, generic TOML, Codex TOML, and YAML subagent formats', async () => {
+    const { homeDir } = await createSubagentTestPaths();
+    const markdownPath = path.join(homeDir, '.agents', 'agents', 'format-matrix.md');
+    const yamlPath = path.join(homeDir, '.agents', 'agents', 'format-matrix.yaml');
+
+    await writeMarkdownSubagent(markdownPath, 'format-matrix', 'Exercises supported renderers.', 'Render every format.');
+
+    const portable = readPortableSubagentDefinitionFromFile({
+      filePath: markdownPath,
+      format: 'markdown-frontmatter',
+    });
+
+    expect(renderPortableSubagentDefinition(portable, 'json')).toContain('"prompt": "Render every format."');
+    expect(renderPortableSubagentDefinition(portable, 'jsonc')).toContain('"prompt": "Render every format."');
+    expect(renderPortableSubagentDefinition(portable, 'toml')).toContain('agent_type = "subagent"');
+    expect(renderPortableSubagentDefinition(portable, 'toml')).toContain('instructions = "Render every format."');
+    expect(renderPortableSubagentDefinition(portable, 'codex-toml')).toContain('developer_instructions = "Render every format."');
+    expect(renderPortableSubagentDefinition(portable, 'yaml')).toContain('prompt: "Render every format."');
+
+    await writeRawFile(yamlPath, renderPortableSubagentDefinition(portable, 'yaml'));
+    expect(readPortableSubagentDefinitionFromFile({
+      filePath: yamlPath,
+      format: 'yaml',
+    })).toMatchObject({
+      name: 'format-matrix',
+      description: 'Exercises supported renderers.',
+      prompt: 'Render every format.',
+    });
+  });
+
+  it('reads YAML block prompt strings and local list metadata', async () => {
+    const { homeDir } = await createSubagentTestPaths();
+    const yamlPath = path.join(homeDir, '.agents', 'agents', 'yaml-block.yaml');
+
+    await writeRawFile(yamlPath, [
+      'name: yaml-block',
+      'description: Reads YAML block strings.',
+      'tools:',
+      '  - read',
+      '  - write',
+      'prompt: |',
+      '  Read YAML carefully.',
+      '  Preserve block content.',
+      '',
+    ].join('\n'));
+
+    expect(readPortableSubagentDefinitionFromFile({
+      filePath: yamlPath,
+      format: 'yaml',
+    })).toMatchObject({
+      name: 'yaml-block',
+      description: 'Reads YAML block strings.',
+      prompt: 'Read YAML carefully.\nPreserve block content.',
+      extras: {
+        tools: ['read', 'write'],
+      },
+    });
+  });
+});

--- a/src/main/subagent-inventory.ts
+++ b/src/main/subagent-inventory.ts
@@ -33,6 +33,7 @@ interface SubagentOwnerRecord {
   family?: string;
   scope: SkillSourceScope;
   directoryPath: string;
+  exists?: boolean;
   format: AgentSubagentParserKind;
   writable: boolean;
   canonical: boolean;
@@ -103,7 +104,7 @@ export function collectSubagentRecords({
       agentLabel: `${plugin.host === 'codex' ? 'Codex' : 'Claude'} Plugin ${plugin.pluginName}`,
       scope: plugin.scope ?? 'live',
       directoryPath: plugin.rootPath,
-      format: plugin.host === 'codex' ? 'markdown-frontmatter' : 'markdown-frontmatter',
+      format: 'unknown',
       writable: false,
       canonical: false,
       plugin: pluginSource,
@@ -210,6 +211,7 @@ function collectSubagentOwners({
       family: agent.family,
       scope: agent.scope,
       directoryPath: agent.subagentsLocation.path,
+      exists: agent.subagentsLocation.exists,
       format,
       writable: agent.writable,
       canonical: false,
@@ -221,6 +223,10 @@ function collectSubagentOwners({
 }
 
 function collectSubagentFilePaths(owner: SubagentOwnerRecord): string[] {
+  if (owner.exists === false) {
+    return [];
+  }
+
   let entries;
   try {
     entries = readdirSync(owner.directoryPath, { withFileTypes: true });
@@ -294,6 +300,7 @@ function buildSubagentLocation(
     modifiedAt,
     canonical: owner.canonical,
     format: owner.format,
+    description: parsed.description,
     definitionText: parsed.definitionText,
     definitionComparisonKey,
     localExtrasKeys: localExtrasKeys.length > 0 ? localExtrasKeys : undefined,
@@ -1136,21 +1143,8 @@ function hasRequiredMarkdownField(fields: Record<string, unknown>, field: string
 
 function getSubagentDescription(locations: SubagentLocationRecord[]): string | null {
   for (const location of [...locations].sort((left, right) => Number(right.canonical) - Number(left.canonical))) {
-    try {
-      const parsed = readSubagentDefinition(location.path, {
-        agentId: location.agentId,
-        agentLabel: location.agentLabel,
-        scope: location.scope,
-        directoryPath: location.directoryPath,
-        format: location.format,
-        writable: location.mutability === 'writable',
-        canonical: location.canonical,
-      });
-      if (parsed.description) {
-        return parsed.description;
-      }
-    } catch {
-      continue;
+    if (location.description) {
+      return location.description;
     }
   }
 

--- a/src/main/subagent-inventory.ts
+++ b/src/main/subagent-inventory.ts
@@ -1,0 +1,1345 @@
+import { lstatSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import type {
+  AgentRecord,
+  AgentSubagentParserKind,
+  PluginRecord,
+  PluginSourceRef,
+  SkillLocationType,
+  SkillProvenance,
+  SkillSourceScope,
+  SubagentExpectedLocationRecord,
+  SubagentInventoryCounts,
+  SubagentIssueReason,
+  SubagentLocationRecord,
+  SubagentRecord,
+} from '@shared/contracts';
+import type { SkillIndexPaths } from '@shared/skill-index-paths';
+
+import { sanitizeJsonc, stableStringify } from '@main/json-utils';
+import {
+  getRequiredMarkdownSubagentFields,
+  getSubagentFileNameForFormat,
+  inferSubagentParserKindFromPath,
+  isMarkdownSubagentSymlinkCompatible,
+  isSubagentFormatRenderableFromUniversal,
+  isSupportedSubagentDirectoryFormat,
+} from '@shared/subagent-format-policy';
+
+interface SubagentOwnerRecord {
+  agentId: string;
+  agentLabel: string;
+  family?: string;
+  scope: SkillSourceScope;
+  directoryPath: string;
+  format: AgentSubagentParserKind;
+  writable: boolean;
+  canonical: boolean;
+  plugin?: PluginSourceRef;
+}
+
+interface ParsedSubagentDefinition {
+  name: string;
+  displayName?: string | null;
+  description?: string | null;
+  prompt?: string;
+  definition: Record<string, unknown>;
+  invalidDetails: string[];
+  definitionText?: string;
+}
+
+export interface PortableSubagentDefinition {
+  name: string;
+  description: string | null;
+  prompt: string;
+  extras: Record<string, unknown>;
+}
+
+export function collectSubagentRecords({
+  agents,
+  plugins,
+  paths,
+  includeLiveSources = true,
+  includeSandboxSources = false,
+}: {
+  agents: AgentRecord[];
+  plugins: PluginRecord[];
+  paths: SkillIndexPaths;
+  includeLiveSources?: boolean;
+  includeSandboxSources?: boolean;
+}): SubagentRecord[] {
+  const owners = collectSubagentOwners({
+    agents,
+    paths,
+    includeLiveSources,
+    includeSandboxSources,
+  });
+  const pluginSubagentAliases = buildPluginSubagentAliases(plugins);
+  const groupedLocations = new Map<string, SubagentLocationRecord[]>();
+
+  for (const owner of owners) {
+    for (const filePath of collectSubagentFilePaths(owner)) {
+      const fallbackName = getSubagentNameFromPath(filePath);
+      const parsed = readSubagentDefinition(filePath, owner, fallbackName);
+      const name = getGroupedSubagentName(filePath, parsed, owner, pluginSubagentAliases);
+      const existing = groupedLocations.get(name) ?? [];
+      existing.push(buildSubagentLocation(filePath, owner, parsed));
+      groupedLocations.set(name, existing);
+    }
+  }
+
+  for (const plugin of plugins) {
+    const pluginSource: PluginSourceRef = {
+      host: plugin.host,
+      pluginId: plugin.pluginId,
+      pluginName: plugin.pluginName,
+      version: plugin.version,
+      rootPath: plugin.rootPath,
+      manifestPath: plugin.manifestPath,
+    };
+    const owner: SubagentOwnerRecord = {
+      agentId: createPluginSubagentOwnerId(plugin),
+      agentLabel: `${plugin.host === 'codex' ? 'Codex' : 'Claude'} Plugin ${plugin.pluginName}`,
+      scope: plugin.scope ?? 'live',
+      directoryPath: plugin.rootPath,
+      format: plugin.host === 'codex' ? 'markdown-frontmatter' : 'markdown-frontmatter',
+      writable: false,
+      canonical: false,
+      plugin: pluginSource,
+    };
+
+    for (const subagent of plugin.bundledSubagents ?? []) {
+      const format = inferSubagentParserKindFromPath(subagent.path, owner.format);
+      const parsed = readSubagentDefinition(subagent.path, {
+        ...owner,
+        format,
+      }, subagent.name);
+      const name = getGroupedSubagentName(subagent.path, parsed, {
+        ...owner,
+        format,
+      }, pluginSubagentAliases);
+      const existing = groupedLocations.get(name) ?? [];
+      existing.push(buildSubagentLocation(subagent.path, {
+        ...owner,
+        format,
+      }, parsed));
+      groupedLocations.set(name, existing);
+    }
+  }
+
+  const expectedOwners = owners.filter((owner) => !owner.canonical && !owner.plugin);
+  return [...groupedLocations.entries()]
+    .map(([name, locations]) => classifySubagentLocations(name, locations, expectedOwners))
+    .sort(compareSubagents);
+}
+
+export function countSubagents(subagents: SubagentRecord[]): SubagentInventoryCounts {
+  return subagents.reduce<SubagentInventoryCounts>(
+    (counts, subagent) => {
+      counts.totalSubagents += 1;
+      if (subagent.status === 'healthy') {
+        counts.healthySubagents += 1;
+      } else if (subagent.presentation === 'dismissed') {
+        counts.dismissedAttentionSubagents += 1;
+      } else {
+        counts.attentionSubagents += 1;
+      }
+
+      return counts;
+    },
+    {
+      totalSubagents: 0,
+      attentionSubagents: 0,
+      healthySubagents: 0,
+      dismissedAttentionSubagents: 0,
+    },
+  );
+}
+
+function collectSubagentOwners({
+  agents,
+  paths,
+  includeLiveSources,
+  includeSandboxSources,
+}: {
+  agents: AgentRecord[];
+  paths: SkillIndexPaths;
+  includeLiveSources: boolean;
+  includeSandboxSources: boolean;
+}): SubagentOwnerRecord[] {
+  const owners: SubagentOwnerRecord[] = [];
+  if (includeLiveSources) {
+    owners.push({
+      agentId: 'live-agents-subagents',
+      agentLabel: 'Live .agents',
+      scope: 'live',
+      directoryPath: resolveCanonicalSubagentsDir(paths.liveCanonicalUserSkillsDir),
+      format: 'markdown-frontmatter',
+      writable: true,
+      canonical: true,
+    });
+  }
+
+  if (includeSandboxSources) {
+    owners.push({
+      agentId: 'sandbox-agents-subagents',
+      agentLabel: 'Sandbox .agents',
+      scope: 'sandbox',
+      directoryPath: resolveCanonicalSubagentsDir(paths.sandboxCanonicalUserSkillsDir),
+      format: 'markdown-frontmatter',
+      writable: true,
+      canonical: true,
+    });
+  }
+
+  for (const agent of agents) {
+    const format = agent.subagentParserKind ?? 'unknown';
+    if (
+      agent.installState !== 'installed'
+      || agent.subagentsLocation?.state !== 'available'
+      || !agent.subagentsLocation.path
+      || !isSupportedSubagentDirectoryFormat(format)
+    ) {
+      continue;
+    }
+
+    owners.push({
+      agentId: agent.id,
+      agentLabel: agent.label,
+      family: agent.family,
+      scope: agent.scope,
+      directoryPath: agent.subagentsLocation.path,
+      format,
+      writable: agent.writable,
+      canonical: false,
+    });
+  }
+
+  return owners.sort((left, right) =>
+    left.agentLabel.localeCompare(right.agentLabel, undefined, { sensitivity: 'base' }));
+}
+
+function collectSubagentFilePaths(owner: SubagentOwnerRecord): string[] {
+  let entries;
+  try {
+    entries = readdirSync(owner.directoryPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const paths: string[] = [];
+  for (const entry of entries) {
+    const filePath = path.join(owner.directoryPath, entry.name);
+    if (entry.isFile() || entry.isSymbolicLink()) {
+      if (isSupportedSubagentFile(owner, entry.name)) {
+        paths.push(filePath);
+      }
+      continue;
+    }
+
+    if (entry.isDirectory() && owner.family === 'deepagents') {
+      const nestedPath = path.join(filePath, 'AGENTS.md');
+      if (safeFileExists(nestedPath)) {
+        paths.push(nestedPath);
+      }
+    }
+  }
+
+  return paths.sort((left, right) => left.localeCompare(right));
+}
+
+function isSupportedSubagentFile(owner: SubagentOwnerRecord, fileName: string): boolean {
+  switch (owner.format) {
+    case 'codex-toml':
+      return /\.toml$/iu.test(fileName);
+    case 'json':
+      return /\.json$/iu.test(fileName);
+    case 'jsonc':
+      return /\.jsonc?$/iu.test(fileName);
+    case 'toml':
+      return /\.toml$/iu.test(fileName);
+    case 'yaml':
+      return /\.ya?ml$/iu.test(fileName);
+    case 'markdown-frontmatter':
+      return /\.md$/iu.test(fileName);
+    default:
+      return false;
+  }
+}
+
+function buildSubagentLocation(
+  filePath: string,
+  owner: SubagentOwnerRecord,
+  parsed: ParsedSubagentDefinition,
+): SubagentLocationRecord {
+  const stats = lstatSync(filePath);
+  const fileType: SkillLocationType = stats.isSymbolicLink() ? 'symlink' : 'real-file';
+  const resolvedPath = safeRealpathSync(filePath);
+  const modifiedAt = new Date(stats.mtimeMs).toISOString();
+  const definitionComparisonKey = parsed.invalidDetails.length === 0 && fileType === 'real-file'
+    ? stableStringify(normalizeSubagentDefinition(parsed.definition))
+    : undefined;
+  const localExtrasKeys = parsed.invalidDetails.length === 0 && fileType === 'real-file'
+    ? Object.keys(omitSubagentAliasFields(parsed.definition)).sort()
+    : [];
+
+  return {
+    agentId: owner.agentId,
+    agentLabel: owner.agentLabel,
+    scope: owner.scope,
+    path: filePath,
+    directoryPath: owner.directoryPath,
+    fileType,
+    modifiedAt,
+    canonical: owner.canonical,
+    format: owner.format,
+    definitionText: parsed.definitionText,
+    definitionComparisonKey,
+    localExtrasKeys: localExtrasKeys.length > 0 ? localExtrasKeys : undefined,
+    invalidDetails: parsed.invalidDetails.length > 0 ? parsed.invalidDetails : undefined,
+    resolvedPath,
+    symlinkTarget: fileType === 'symlink' ? resolvedPath : undefined,
+    provenance: createSubagentProvenance(filePath, owner, modifiedAt),
+    canonicalRole: owner.canonical ? 'canonical' : 'materialized-copy',
+    mutability: owner.writable ? 'writable' : owner.plugin ? 'read-only-managed' : 'unknown',
+  };
+}
+
+function classifySubagentLocations(
+  name: string,
+  locations: SubagentLocationRecord[],
+  expectedOwners: SubagentOwnerRecord[],
+): SubagentRecord {
+  const sortedLocations = [...locations].sort((left, right) =>
+    left.path.localeCompare(right.path) || left.agentId.localeCompare(right.agentId));
+  const canonicalLocation = sortedLocations.find((location) => location.canonical && location.fileType === 'real-file') ?? null;
+  const validLocations = sortedLocations.filter((location) => (location.invalidDetails?.length ?? 0) === 0);
+  const validComparisonKeys = new Set(validLocations
+    .map((location) => location.definitionComparisonKey)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0));
+  const issueReasons = new Set<SubagentIssueReason>();
+
+  if (sortedLocations.some((location) => (location.invalidDetails?.length ?? 0) > 0)) {
+    issueReasons.add('invalid-definition');
+  }
+
+  if (!canonicalLocation) {
+    issueReasons.add('missing-universal');
+  }
+
+  const expectedLocations = canonicalLocation
+    ? expectedOwners.map((owner) => buildExpectedLocation(owner, name, canonicalLocation))
+    : [];
+  const presentAgentIds = new Set(sortedLocations.map((location) => location.agentId));
+  const missingLocations = expectedLocations.filter((location) =>
+    location.supportStatus !== 'unsupported' && !presentAgentIds.has(location.agentId));
+  if (missingLocations.length > 0) {
+    issueReasons.add('missing-from-agents');
+  }
+
+  if (validComparisonKeys.size > 1) {
+    issueReasons.add('definition-mismatch');
+  }
+
+  if (canonicalLocation) {
+    const canonicalResolvedPath = canonicalLocation.resolvedPath ?? canonicalLocation.path;
+    const sameFormatDuplicates = sortedLocations.filter((location) =>
+      !location.canonical
+      && location.fileType === 'real-file'
+      && location.mutability === 'writable'
+      && location.format === canonicalLocation.format
+      && isMarkdownSubagentSymlinkCompatible(findSubagentOwnerForLocation(location, expectedOwners)?.family)
+      && !hasSubagentLocalExtras(location)
+      && location.definitionComparisonKey === canonicalLocation.definitionComparisonKey);
+    if (sameFormatDuplicates.length > 0) {
+      issueReasons.add('identical-copies');
+    }
+
+    for (const location of sortedLocations) {
+      if (location.canonical || location.fileType !== 'symlink') {
+        continue;
+      }
+      if (!location.resolvedPath) {
+        issueReasons.add('broken-symlink');
+        continue;
+      }
+      if (path.normalize(location.resolvedPath) !== path.normalize(canonicalResolvedPath)) {
+        issueReasons.add('wrong-symlink-target');
+      }
+    }
+  }
+
+  const issueReasonsList = [...issueReasons].sort(compareSubagentIssueReasons);
+  const status = issueReasonsList.length > 0 ? 'needs-attention' : 'healthy';
+
+  return {
+    name,
+    displayName: getSubagentDisplayName(name),
+    description: getSubagentDescription(sortedLocations),
+    status,
+    presentation: status === 'needs-attention' ? 'active' : 'none',
+    locations: sortedLocations,
+    expectedLocations,
+    missingLocations,
+    issueReasons: issueReasonsList,
+    signature: status === 'needs-attention'
+      ? createSubagentSignature(name, sortedLocations, expectedLocations, missingLocations, issueReasonsList)
+      : undefined,
+  };
+}
+
+function buildExpectedLocation(
+  owner: SubagentOwnerRecord,
+  name: string,
+  canonicalLocation: SubagentLocationRecord,
+): SubagentExpectedLocationRecord {
+  const renderable = isRenderableFromCanonical(owner, canonicalLocation);
+  return {
+    agentId: owner.agentId,
+    agentLabel: owner.agentLabel,
+    scope: owner.scope,
+    directoryPath: owner.directoryPath,
+    path: path.join(owner.directoryPath, getSubagentFileNameForOwner(owner, name, canonicalLocation)),
+    format: owner.format,
+    supportStatus: renderable ? 'supported' : 'unsupported',
+    unsupportedReason: renderable ? undefined : 'unsupported-format',
+  };
+}
+
+function isRenderableFromCanonical(owner: SubagentOwnerRecord, canonicalLocation: SubagentLocationRecord): boolean {
+  return isSubagentFormatRenderableFromUniversal(owner.format, canonicalLocation.format);
+}
+
+function findSubagentOwnerForLocation(
+  location: SubagentLocationRecord,
+  owners: SubagentOwnerRecord[],
+): SubagentOwnerRecord | undefined {
+  return owners.find((owner) =>
+    owner.agentId === location.agentId
+    && owner.directoryPath === location.directoryPath);
+}
+
+function getSubagentFileNameForOwner(
+  owner: Pick<SubagentOwnerRecord, 'family' | 'format'>,
+  name: string,
+  canonicalLocation?: Pick<SubagentLocationRecord, 'path'>,
+): string {
+  return getSubagentFileNameForFormat({
+    name,
+    format: owner.format,
+    family: owner.family,
+    canonicalPath: canonicalLocation?.path,
+  });
+}
+
+export function readPortableSubagentDefinitionFromFile({
+  family,
+  filePath,
+  format,
+  fallbackName,
+}: {
+  family?: string;
+  filePath: string;
+  format: AgentSubagentParserKind;
+  fallbackName?: string;
+}): PortableSubagentDefinition {
+  const parsed = readSubagentDefinition(filePath, {
+    agentId: 'portable-reader',
+    agentLabel: 'Portable Reader',
+    family,
+    scope: 'live',
+    directoryPath: path.dirname(filePath),
+    format,
+    writable: false,
+    canonical: false,
+  }, fallbackName);
+  if (parsed.invalidDetails.length > 0) {
+    throw new Error(parsed.invalidDetails.join(' '));
+  }
+
+  return toPortableSubagentDefinition(parsed);
+}
+
+export function renderPortableSubagentDefinition(
+  definition: PortableSubagentDefinition,
+  format: AgentSubagentParserKind,
+  options: { family?: string } = {},
+): string {
+  switch (format) {
+    case 'codex-toml':
+      assertPortableSubagentCanRender(definition, format);
+      return renderTomlFields({
+        name: definition.name,
+        description: definition.description,
+        developer_instructions: definition.prompt,
+        ...definition.extras,
+      });
+    case 'json':
+    case 'jsonc':
+      assertPortableSubagentCanRender(definition, format);
+      return `${JSON.stringify({
+        name: definition.name,
+        description: definition.description,
+        prompt: definition.prompt,
+        ...definition.extras,
+      }, null, 2)}\n`;
+    case 'toml':
+      assertPortableSubagentCanRender(definition, format);
+      return renderTomlFields({
+        agent_type: 'subagent',
+        name: definition.name,
+        description: definition.description,
+        instructions: definition.prompt,
+        ...definition.extras,
+      });
+    case 'markdown-frontmatter':
+      assertPortableSubagentCanRender(definition, format);
+      return renderMarkdownSubagentDefinition(definition, options.family);
+    case 'yaml':
+      assertPortableSubagentCanRender(definition, format);
+      return renderYamlFields({
+        name: definition.name,
+        description: definition.description,
+        prompt: definition.prompt,
+        ...definition.extras,
+      });
+    default:
+      throw new Error(`Subagent resolution is not supported for ${format} definitions.`);
+  }
+}
+
+function readSubagentDefinition(
+  filePath: string,
+  owner: SubagentOwnerRecord,
+  fallbackName = getSubagentNameFromPath(filePath),
+): ParsedSubagentDefinition {
+  let raw = '';
+  const invalidDetails: string[] = [];
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch {
+    if (isBrokenSubagentSymlink(filePath)) {
+      return {
+        name: fallbackName,
+        description: null,
+        invalidDetails: [],
+        definition: { name: fallbackName },
+      };
+    }
+
+    return {
+      name: fallbackName,
+      description: null,
+      invalidDetails: ['Skill Index could not read this subagent file.'],
+      definition: { name: fallbackName },
+    };
+  }
+
+  try {
+    switch (owner.format) {
+      case 'codex-toml':
+        return readCodexTomlSubagent(raw, fallbackName);
+      case 'json':
+      case 'jsonc':
+        return readJsonSubagent(raw, fallbackName, owner.format === 'jsonc');
+      case 'toml':
+        return readGenericTomlSubagent(raw, fallbackName);
+      case 'yaml':
+        return readYamlSubagent(raw, fallbackName);
+      case 'markdown-frontmatter':
+      default:
+        return readMarkdownSubagent(raw, fallbackName, owner.family);
+    }
+  } catch (error) {
+    invalidDetails.push(error instanceof Error ? error.message : 'Skill Index could not parse this subagent file.');
+    return {
+      name: fallbackName,
+      description: null,
+      invalidDetails,
+      definition: { name: fallbackName },
+      definitionText: raw,
+    };
+  }
+}
+
+function readMarkdownSubagent(raw: string, fallbackName: string, family?: string): ParsedSubagentDefinition {
+  const frontMatter = parseFrontMatter(raw);
+  const invalidDetails: string[] = [];
+  if (frontMatter.malformed) {
+    invalidDetails.push('The front matter opens with --- but does not close cleanly.');
+  }
+
+  const fields = frontMatter.fields;
+  const name = getStringField(fields, 'name') ?? getStringField(fields, 'agentType') ?? fallbackName;
+  const description = getStringField(fields, 'description') ?? getStringField(fields, 'whenToUse') ?? null;
+  const prompt = getStringField(fields, 'systemPrompt') ?? frontMatter.body.trim();
+  const requiredFields = getRequiredMarkdownSubagentFields(family);
+
+  for (const field of requiredFields) {
+    if (!hasRequiredMarkdownField(fields, field)) {
+      invalidDetails.push(`Missing required field: ${field}`);
+    }
+  }
+
+  return {
+    name,
+    displayName: name,
+    description,
+    prompt: prompt ?? undefined,
+    invalidDetails,
+    definition: {
+      ...fields,
+      name,
+      description,
+      prompt,
+    },
+    definitionText: raw,
+  };
+}
+
+function readCodexTomlSubagent(raw: string, fallbackName: string): ParsedSubagentDefinition {
+  const values = parseFlatToml(raw);
+  const name = getStringField(values, 'name') ?? fallbackName;
+  const description = getStringField(values, 'description') ?? null;
+  const prompt = getStringField(values, 'developer_instructions');
+  const invalidDetails: string[] = [];
+  for (const field of ['name', 'description', 'developer_instructions']) {
+    if (!getStringField(values, field)) {
+      invalidDetails.push(`Missing required field: ${field}`);
+    }
+  }
+
+  return {
+    name,
+    displayName: name,
+    description,
+    prompt: prompt ?? undefined,
+    invalidDetails,
+    definition: {
+      ...values,
+      name,
+      description,
+      prompt,
+    },
+    definitionText: raw,
+  };
+}
+
+function readGenericTomlSubagent(raw: string, fallbackName: string): ParsedSubagentDefinition {
+  const values = parseFlatToml(raw);
+  const name = getStringField(values, 'name') ?? getStringField(values, 'display_name') ?? fallbackName;
+  const description = getStringField(values, 'description') ?? null;
+  const prompt = getStringField(values, 'instructions') ?? getStringField(values, 'prompt');
+  const invalidDetails: string[] = [];
+  if (getStringField(values, 'agent_type') && getStringField(values, 'agent_type') !== 'subagent') {
+    invalidDetails.push('This agent TOML is not marked as agent_type = "subagent".');
+  }
+  if (!description) {
+    invalidDetails.push('Missing required field: description');
+  }
+  if (!prompt) {
+    invalidDetails.push('Missing required field: instructions');
+  }
+
+  return {
+    name,
+    displayName: getStringField(values, 'display_name') ?? name,
+    description,
+    prompt: prompt ?? undefined,
+    invalidDetails,
+    definition: {
+      ...values,
+      name,
+      description,
+      prompt,
+    },
+    definitionText: raw,
+  };
+}
+
+function readJsonSubagent(raw: string, fallbackName: string, jsonc: boolean): ParsedSubagentDefinition {
+  const parsed = JSON.parse(jsonc ? sanitizeJsonc(raw) : raw) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error('Subagent JSON must be an object.');
+  }
+
+  const name = getStringField(parsed, 'name') ?? fallbackName;
+  const description = getStringField(parsed, 'description') ?? null;
+  const prompt = getStringField(parsed, 'prompt') ?? getStringField(parsed, 'systemPrompt');
+  const invalidDetails: string[] = [];
+  if (!description) {
+    invalidDetails.push('Missing required field: description');
+  }
+  if (!prompt) {
+    invalidDetails.push('Missing required field: prompt');
+  }
+
+  return {
+    name,
+    displayName: name,
+    description,
+    prompt: prompt ?? undefined,
+    invalidDetails,
+    definition: {
+      ...parsed,
+      name,
+      description,
+      prompt,
+    },
+    definitionText: raw,
+  };
+}
+
+function readYamlSubagent(raw: string, fallbackName: string): ParsedSubagentDefinition {
+  const values = parseFlatYaml(raw);
+  const name = getStringField(values, 'name') ?? getStringField(values, 'agentType') ?? fallbackName;
+  const description = getStringField(values, 'description') ?? getStringField(values, 'whenToUse') ?? null;
+  const prompt = getStringField(values, 'prompt')
+    ?? getStringField(values, 'systemPrompt')
+    ?? getStringField(values, 'instructions');
+  const invalidDetails: string[] = [];
+  if (!description) {
+    invalidDetails.push('Missing required field: description');
+  }
+  if (!prompt) {
+    invalidDetails.push('Missing required field: prompt');
+  }
+
+  return {
+    name,
+    displayName: name,
+    description,
+    prompt: prompt ?? undefined,
+    invalidDetails,
+    definition: {
+      ...values,
+      name,
+      description,
+      prompt,
+    },
+    definitionText: raw,
+  };
+}
+
+function parseFrontMatter(raw: string): {
+  body: string;
+  fields: Record<string, unknown>;
+  malformed: boolean;
+} {
+  const normalizedContent = raw.startsWith('\uFEFF') ? raw.slice(1) : raw;
+  const lines = normalizedContent.split(/\r?\n/u);
+  if (lines[0] !== '---') {
+    return { body: normalizedContent, fields: {}, malformed: false };
+  }
+
+  const closingIndex = lines.findIndex((line, index) => index > 0 && (line === '---' || line === '...'));
+  if (closingIndex < 0) {
+    return { body: normalizedContent, fields: {}, malformed: true };
+  }
+
+  const fields: Record<string, unknown> = {};
+  for (const line of lines.slice(1, closingIndex)) {
+    const match = /^([A-Za-z][A-Za-z0-9_.-]*):(?:\s*(.*))?$/u.exec(line);
+    if (!match) {
+      continue;
+    }
+
+    const key = match[1];
+    const rawValue = match[2] ?? '';
+    if (key) {
+      fields[key] = parseYamlScalar(rawValue);
+    }
+  }
+
+  return {
+    body: lines.slice(closingIndex + 1).join('\n'),
+    fields,
+    malformed: false,
+  };
+}
+
+function parseFlatYaml(raw: string): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+  const lines = raw.split(/\r?\n/u);
+  for (let index = 0; index < lines.length; index += 1) {
+    const originalLine = lines[index] ?? '';
+    const line = stripComment(originalLine).trim();
+    if (!line || line === '---' || line === '...') {
+      continue;
+    }
+
+    const match = /^([A-Za-z][A-Za-z0-9_.-]*):(?:\s*(.*))?$/u.exec(line);
+    if (!match) {
+      continue;
+    }
+
+    const key = match[1];
+    if (key) {
+      const rawValue = match[2] ?? '';
+      if (rawValue.trim() === '|' || rawValue.trim() === '>') {
+        const parsed = readYamlBlockScalar(lines, index, rawValue.trim() === '>');
+        values[key] = parsed.value;
+        index = parsed.endIndex;
+        continue;
+      }
+
+      if (rawValue.trim() === '') {
+        const parsed = readYamlIndentedList(lines, index, getLeadingWhitespace(originalLine).length);
+        if (parsed) {
+          values[key] = parsed.value;
+          index = parsed.endIndex;
+          continue;
+        }
+      }
+
+      values[key] = parseYamlScalar(rawValue);
+    }
+  }
+
+  return values;
+}
+
+function readYamlBlockScalar(
+  lines: string[],
+  startIndex: number,
+  fold: boolean,
+): { value: string; endIndex: number } {
+  const chunks: string[] = [];
+  let endIndex = startIndex;
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    if (line.trim().length > 0 && getLeadingWhitespace(line).length === 0) {
+      break;
+    }
+
+    chunks.push(line);
+    endIndex = index;
+  }
+
+  const normalized = trimYamlIndentedBlock(chunks);
+  return {
+    value: fold ? normalized.replace(/\n+/gu, ' ').trim() : normalized,
+    endIndex,
+  };
+}
+
+function readYamlIndentedList(
+  lines: string[],
+  startIndex: number,
+  parentIndent: number,
+): { value: unknown[]; endIndex: number } | null {
+  const values: unknown[] = [];
+  let endIndex = startIndex;
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    if (!line.trim()) {
+      continue;
+    }
+
+    const indent = getLeadingWhitespace(line).length;
+    if (indent <= parentIndent) {
+      break;
+    }
+
+    const item = /^-\s*(.*)$/u.exec(line.trim());
+    if (!item) {
+      break;
+    }
+
+    values.push(parseYamlScalar(item[1] ?? ''));
+    endIndex = index;
+  }
+
+  return values.length > 0 ? { value: values, endIndex } : null;
+}
+
+function trimYamlIndentedBlock(lines: string[]): string {
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0);
+  const indent = nonEmptyLines.reduce(
+    (current, line) => Math.min(current, getLeadingWhitespace(line).length),
+    Number.POSITIVE_INFINITY,
+  );
+  const trimLength = Number.isFinite(indent) ? indent : 0;
+  return lines
+    .map((line) => line.slice(trimLength))
+    .join('\n')
+    .replace(/\n+$/u, '');
+}
+
+function getLeadingWhitespace(line: string): string {
+  return /^\s*/u.exec(line)?.[0] ?? '';
+}
+
+function parseFlatToml(raw: string): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+  const lines = raw.split(/\r?\n/u);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const trimmed = stripComment(line).trim();
+    if (!trimmed || trimmed.startsWith('[')) {
+      continue;
+    }
+
+    const assignment = /^([A-Za-z0-9_-]+)\s*=\s*(.*)$/u.exec(trimmed);
+    if (!assignment) {
+      continue;
+    }
+
+    const key = assignment[1];
+    if (key) {
+      const rawValue = assignment[2] ?? '';
+      if (rawValue.trim().startsWith('"""')) {
+        const parsed = readTomlMultilineString(rawValue, lines, index);
+        values[key] = parsed.value;
+        index = parsed.endIndex;
+        continue;
+      }
+
+      values[key] = parseYamlScalar(rawValue);
+    }
+  }
+
+  return values;
+}
+
+function readTomlMultilineString(
+  openingValue: string,
+  lines: string[],
+  startIndex: number,
+): { value: string; endIndex: number } {
+  const openingIndex = openingValue.indexOf('"""');
+  const firstChunk = openingValue.slice(openingIndex + 3);
+  const sameLineEnd = firstChunk.indexOf('"""');
+  if (sameLineEnd >= 0) {
+    return {
+      value: firstChunk.slice(0, sameLineEnd),
+      endIndex: startIndex,
+    };
+  }
+
+  const chunks = [firstChunk];
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const endIndex = line.indexOf('"""');
+    if (endIndex >= 0) {
+      chunks.push(line.slice(0, endIndex));
+      return {
+        value: trimTomlMultilineString(chunks.join('\n')),
+        endIndex: index,
+      };
+    }
+    chunks.push(line);
+  }
+
+  return {
+    value: trimTomlMultilineString(chunks.join('\n')),
+    endIndex: lines.length - 1,
+  };
+}
+
+function trimTomlMultilineString(value: string): string {
+  return value.replace(/^\n/u, '').replace(/\n$/u, '');
+}
+
+function parseYamlScalar(value: string): unknown {
+  const trimmedValue = value.trim();
+  if (trimmedValue.startsWith('[') && trimmedValue.endsWith(']')) {
+    return trimmedValue.slice(1, -1)
+      .split(',')
+      .map((entry) => parseYamlScalar(entry))
+      .filter((entry) => entry !== '');
+  }
+  if (trimmedValue.startsWith('"') && trimmedValue.endsWith('"')) {
+    try {
+      return JSON.parse(trimmedValue) as unknown;
+    } catch {
+      return trimmedValue.slice(1, -1);
+    }
+  }
+  if (trimmedValue.startsWith("'") && trimmedValue.endsWith("'")) {
+    return trimmedValue.slice(1, -1);
+  }
+  if (trimmedValue === 'true') {
+    return true;
+  }
+  if (trimmedValue === 'false') {
+    return false;
+  }
+  const numberValue = Number(trimmedValue);
+  if (Number.isFinite(numberValue) && trimmedValue !== '') {
+    return numberValue;
+  }
+  return trimmedValue;
+}
+
+function stripComment(line: string): string {
+  let inQuote: '"' | "'" | null = null;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if ((character === '"' || character === "'") && line[index - 1] !== '\\') {
+      inQuote = inQuote === character ? null : inQuote ?? character;
+    }
+    if (character === '#' && !inQuote) {
+      return line.slice(0, index);
+    }
+  }
+  return line;
+}
+
+function normalizeSubagentDefinition(definition: Record<string, unknown>): Record<string, unknown> {
+  const name = getStringField(definition, 'name')
+    ?? getStringField(definition, 'agentType')
+    ?? getStringField(definition, 'display_name')
+    ?? '';
+  const description = getStringField(definition, 'description')
+    ?? getStringField(definition, 'whenToUse')
+    ?? null;
+  const prompt = getStringField(definition, 'prompt')
+    ?? getStringField(definition, 'systemPrompt')
+    ?? getStringField(definition, 'developer_instructions')
+    ?? getStringField(definition, 'instructions')
+    ?? '';
+  return {
+    name,
+    description,
+    prompt,
+  };
+}
+
+function toPortableSubagentDefinition(parsed: ParsedSubagentDefinition): PortableSubagentDefinition {
+  const normalized = normalizeSubagentDefinition(parsed.definition);
+  return {
+    name: getStringField(normalized, 'name') ?? parsed.name,
+    description: getStringField(normalized, 'description') ?? parsed.description ?? null,
+    prompt: getStringField(normalized, 'prompt') ?? parsed.prompt ?? '',
+    extras: omitSubagentAliasFields(parsed.definition),
+  };
+}
+
+function omitSubagentAliasFields(definition: Record<string, unknown>): Record<string, unknown> {
+  const omittedKeys = new Set([
+    'agent_type',
+    'agentType',
+    'description',
+    'developer_instructions',
+    'displayName',
+    'display_name',
+    'instructions',
+    'name',
+    'prompt',
+    'systemPrompt',
+    'whenToUse',
+  ]);
+  return Object.fromEntries(
+    Object.entries(definition)
+      .filter(([key, value]) => !omittedKeys.has(key) && value !== undefined && value !== null),
+  );
+}
+
+function hasSubagentLocalExtras(location: Pick<SubagentLocationRecord, 'localExtrasKeys'>): boolean {
+  return (location.localExtrasKeys?.length ?? 0) > 0;
+}
+
+function assertPortableSubagentCanRender(
+  definition: PortableSubagentDefinition,
+  format: AgentSubagentParserKind,
+): void {
+  if (!definition.name.trim()) {
+    throw new Error('Subagent definitions need a name before Skill Index can write them.');
+  }
+  if (!definition.description?.trim()) {
+    throw new Error('Subagent definitions need a description before Skill Index can write them.');
+  }
+  if (format !== 'markdown-frontmatter' && !definition.prompt.trim()) {
+    throw new Error(`Subagent definitions need prompt text before Skill Index can write ${format} files.`);
+  }
+}
+
+function renderMarkdownSubagentDefinition(
+  definition: PortableSubagentDefinition,
+  family: string | undefined,
+): string {
+  if (family === 'iflow-cli') {
+    if (!definition.prompt.trim()) {
+      throw new Error('iFlow CLI subagent definitions need prompt text before Skill Index can write them.');
+    }
+
+    return `---\n${renderYamlFields({
+      ...definition.extras,
+      agentType: definition.name,
+      whenToUse: definition.description,
+      systemPrompt: definition.prompt,
+    })}---\n`;
+  }
+
+  const fields: Record<string, unknown> = {
+    ...definition.extras,
+    name: definition.name,
+    description: definition.description,
+  };
+  if (family === 'mux') {
+    fields['subagent.runnable'] = true;
+  }
+
+  return `---\n${renderYamlFields(fields)}---\n${definition.prompt.trimEnd()}\n`;
+}
+
+function renderYamlFields(fields: Record<string, unknown>): string {
+  return Object.entries(fields)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${key}: ${renderYamlScalar(value)}`)
+    .join('\n')
+    .concat('\n');
+}
+
+function renderTomlFields(fields: Record<string, unknown>): string {
+  return Object.entries(fields)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${key} = ${renderTomlScalar(value)}`)
+    .join('\n')
+    .concat('\n');
+}
+
+function renderYamlScalar(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(renderYamlScalar).join(', ')}]`;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(String(value));
+}
+
+function renderTomlScalar(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(renderTomlScalar).join(', ')}]`;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(String(value));
+}
+
+function getStringField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function hasRequiredMarkdownField(fields: Record<string, unknown>, field: string): boolean {
+  if (field === 'subagent.runnable') {
+    return fields[field] === true || getStringField(fields, field) === 'true';
+  }
+
+  return Boolean(getStringField(fields, field));
+}
+
+function getSubagentDescription(locations: SubagentLocationRecord[]): string | null {
+  for (const location of [...locations].sort((left, right) => Number(right.canonical) - Number(left.canonical))) {
+    try {
+      const parsed = readSubagentDefinition(location.path, {
+        agentId: location.agentId,
+        agentLabel: location.agentLabel,
+        scope: location.scope,
+        directoryPath: location.directoryPath,
+        format: location.format,
+        writable: location.mutability === 'writable',
+        canonical: location.canonical,
+      });
+      if (parsed.description) {
+        return parsed.description;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function getSubagentDisplayName(name: string): string {
+  return getUnqualifiedSubagentName(name);
+}
+
+function getUnqualifiedSubagentName(name: string): string {
+  const qualifierEnd = name.indexOf(':');
+  return qualifierEnd >= 0 ? name.slice(qualifierEnd + 1) : name;
+}
+
+function getGroupedSubagentName(
+  filePath: string,
+  parsed: ParsedSubagentDefinition,
+  owner: SubagentOwnerRecord,
+  pluginSubagentAliases: Map<string, string>,
+): string {
+  const baseName = isSymlink(filePath) ? getSubagentNameFromPath(filePath) : parsed.name;
+  if (owner.plugin) {
+    return `${owner.plugin.pluginName}:${baseName}`;
+  }
+
+  return pluginSubagentAliases.get(getPluginSubagentAliasKey(owner.scope, filePath, parsed.name)) ?? baseName;
+}
+
+function getSubagentNameFromPath(filePath: string): string {
+  return path.basename(filePath).replace(/(?:\.agent)?\.(?:md|toml|jsonc?|ya?ml)$/iu, '');
+}
+
+function buildPluginSubagentAliases(plugins: PluginRecord[]): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const plugin of plugins) {
+    for (const subagent of plugin.bundledSubagents ?? []) {
+      const scopedName = `${plugin.pluginName}:${subagent.name}`;
+      const fileBaseName = getSanitizedSubagentFileBaseName(scopedName);
+      aliases.set(buildPluginSubagentAliasKey(plugin.scope ?? 'live', fileBaseName, subagent.name), scopedName);
+    }
+  }
+  return aliases;
+}
+
+function getPluginSubagentAliasKey(scope: SkillSourceScope, filePath: string, definitionName: string): string {
+  return buildPluginSubagentAliasKey(scope, getSubagentNameFromPath(filePath), definitionName);
+}
+
+function buildPluginSubagentAliasKey(scope: SkillSourceScope, fileBaseName: string, definitionName: string): string {
+  return `${scope}:${fileBaseName}:${definitionName}`;
+}
+
+function getSanitizedSubagentFileBaseName(name: string): string {
+  return name.replace(/[^A-Za-z0-9._-]+/gu, '-');
+}
+
+function isSymlink(filePath: string): boolean {
+  try {
+    return lstatSync(filePath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function isBrokenSubagentSymlink(filePath: string): boolean {
+  return isSymlink(filePath) && safeRealpathSync(filePath) === undefined;
+}
+
+function createSubagentProvenance(
+  filePath: string,
+  owner: SubagentOwnerRecord,
+  discoveredAt: string,
+): SkillProvenance {
+  if (owner.plugin) {
+    return {
+      kind: 'plugin',
+      plugin: {
+        host: owner.plugin.host,
+        pluginId: owner.plugin.pluginId,
+        version: owner.plugin.version,
+      },
+      sourcePath: filePath,
+      discoveredAt,
+    };
+  }
+
+  return {
+    kind: owner.canonical ? 'universal' : 'agent-local',
+    sourcePath: filePath,
+    discoveredAt,
+  };
+}
+
+function createPluginSubagentOwnerId(plugin: Pick<PluginRecord, 'host' | 'pluginId' | 'version' | 'scope'>): string {
+  const scopePrefix = plugin.scope === 'sandbox' ? 'sandbox:' : '';
+  return `plugin:${scopePrefix}${plugin.host}:${plugin.pluginId}:${plugin.version ?? 'unknown'}:subagents`;
+}
+
+function createSubagentSignature(
+  name: string,
+  locations: SubagentLocationRecord[],
+  expectedLocations: SubagentExpectedLocationRecord[],
+  missingLocations: SubagentExpectedLocationRecord[],
+  issueReasons: SubagentIssueReason[],
+): string {
+  return stableStringify({
+    name,
+    issueReasons,
+    locations: locations.map((location) => ({
+      agentId: location.agentId,
+      path: location.path,
+      resolvedPath: location.resolvedPath,
+      fileType: location.fileType,
+      definitionComparisonKey: location.definitionComparisonKey,
+      invalidDetails: location.invalidDetails,
+    })),
+    expectedLocations: expectedLocations.map((location) => ({
+      agentId: location.agentId,
+      path: location.path,
+      supportStatus: location.supportStatus,
+    })),
+    missingLocations: missingLocations.map((location) => ({
+      agentId: location.agentId,
+      path: location.path,
+    })),
+  });
+}
+
+function compareSubagents(left: SubagentRecord, right: SubagentRecord): number {
+  const presentationRank = getSubagentPresentationRank(left) - getSubagentPresentationRank(right);
+  return presentationRank
+    || right.issueReasons.length - left.issueReasons.length
+    || left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
+}
+
+function getSubagentPresentationRank(subagent: SubagentRecord): number {
+  if (subagent.presentation === 'active') {
+    return 0;
+  }
+  if (subagent.presentation === 'dismissed') {
+    return 1;
+  }
+  return 2;
+}
+
+function compareSubagentIssueReasons(left: SubagentIssueReason, right: SubagentIssueReason): number {
+  return getSubagentIssueRank(left) - getSubagentIssueRank(right);
+}
+
+function getSubagentIssueRank(reason: SubagentIssueReason): number {
+  switch (reason) {
+    case 'definition-mismatch':
+      return 0;
+    case 'wrong-symlink-target':
+      return 1;
+    case 'broken-symlink':
+      return 2;
+    case 'identical-copies':
+      return 3;
+    case 'missing-universal':
+      return 4;
+    case 'missing-from-agents':
+      return 5;
+    case 'invalid-definition':
+      return 6;
+  }
+}
+
+function resolveCanonicalSubagentsDir(canonicalSkillsDir: string): string {
+  return path.join(path.dirname(canonicalSkillsDir), 'agents');
+}
+
+function safeFileExists(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function safeRealpathSync(filePath: string): string | undefined {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -17,6 +17,7 @@ import {
   type SettingsState,
   type SkillInventorySnapshot,
   type SkillIssueReason,
+  type SubagentIssueReason,
 } from '@shared/contracts';
 import { CANONICAL_USER_SKILLS_DISPLAY_PATH } from '@shared/skill-path-policy';
 
@@ -31,30 +32,35 @@ import {
   loadInventorySnapshot,
   waitForStartupObservation,
 } from './app/bootstrap';
-import { getAutoResolvableMcpRequests, getAutoResolvableSkillRequests } from './lib/issue-resolution';
+import { getAutoResolvableMcpRequests, getAutoResolvableSkillRequests, getAutoResolvableSubagentRequests } from './lib/issue-resolution';
 import type { PendingInventoryOperation } from './lib/pending-inventory-operation';
 import { AppSidebar } from './components/AppSidebar';
 import {
   buildMcpInspectorModel,
   buildSkillInspectorModel,
+  buildSubagentInspectorModel,
   type InspectorProvenanceSummaryRow,
 } from './lib/detail-inspector-model';
 import {
   compareAgentsForTable,
   filterMcpRowsByStatus,
+  filterSubagentRowsByStatus,
   filterSkillRowsByStatus,
   formatLastScanLabel,
   type McpStatusFilter,
   type SkillStatusFilter,
+  type SubagentStatusFilter,
 } from './lib/inventory-presentation';
 import {
   filterAgentRows,
   filterMcpRows,
   filterPluginRows,
   filterSkillRows,
+  filterSubagentRows,
   getHomeSummary,
   getMcpTableRows,
   getSkillTableRows,
+  getSubagentTableRows,
   type PrimaryTab,
 } from './inventory-view-model';
 import { AgentsWorkspaceView } from './views/AgentsWorkspaceView';
@@ -65,6 +71,7 @@ import { OnboardingFlow } from './views/OnboardingFlow';
 import { PluginsWorkspaceView } from './views/PluginsWorkspaceView';
 import { SettingsWorkspaceView } from './views/SettingsWorkspaceView';
 import { SkillsWorkspaceView } from './views/SkillsWorkspaceView';
+import { SubagentsWorkspaceView } from './views/SubagentsWorkspaceView';
 
 function getAutoResolvableRequestsForSnapshot(snapshot: SkillInventorySnapshot): ResolveIssueRequest[] {
   const sourceIndex = new Map(snapshot.sources.map((source) => [source.id, source]));
@@ -72,13 +79,14 @@ function getAutoResolvableRequestsForSnapshot(snapshot: SkillInventorySnapshot):
   return [
     ...getAutoResolvableSkillRequests(snapshot, sourceIndex),
     ...getAutoResolvableMcpRequests(snapshot),
+    ...getAutoResolvableSubagentRequests(snapshot),
   ];
 }
 
 function getResolveIssueRequestKey(request: ResolveIssueRequest): string {
   return [
     request.entity,
-    request.skillName ?? request.mcpName,
+    request.skillName ?? request.mcpName ?? request.subagentName,
     request.issue,
     request.selectedVariantPath ?? '',
   ].join(':');
@@ -115,6 +123,7 @@ export default function App() {
   const initialInventorySnapshot = useRef<SkillInventorySnapshot | null>(getInitialInventorySnapshot()).current;
   const skillSearchInputRef = useRef<HTMLInputElement | null>(null);
   const mcpSearchInputRef = useRef<HTMLInputElement | null>(null);
+  const subagentSearchInputRef = useRef<HTMLInputElement | null>(null);
   const agentSearchInputRef = useRef<HTMLInputElement | null>(null);
   const pluginSearchInputRef = useRef<HTMLInputElement | null>(null);
   const auditSearchInputRef = useRef<HTMLInputElement | null>(null);
@@ -124,11 +133,11 @@ export default function App() {
   const [inventorySnapshot, setInventorySnapshot] = useState<SkillInventorySnapshot | null>(initialInventorySnapshot);
   const latestInventorySnapshotRef = useRef<SkillInventorySnapshot | null>(initialInventorySnapshot);
   const mcpConnectivityRunIdRef = useRef(0);
-  const mcpConnectivityErrorMessageRef = useRef<string | null>(null);
   const [inventorySourceMode, setInventorySourceMode] = useState<InventorySourceMode>('live');
   const [activeTab, setActiveTab] = useState<PrimaryTab>('home');
   const [skillSearchQuery, setSkillSearchQuery] = useState('');
   const [mcpSearchQuery, setMcpSearchQuery] = useState('');
+  const [subagentSearchQuery, setSubagentSearchQuery] = useState('');
   const [agentSearchQuery, setAgentSearchQuery] = useState('');
   const [pluginSearchQuery, setPluginSearchQuery] = useState('');
   const [auditSearchQuery, setAuditSearchQuery] = useState('');
@@ -136,8 +145,10 @@ export default function App() {
   const [selectedPluginKey, setSelectedPluginKey] = useState<string | null>(null);
   const [skillStatusFilter, setSkillStatusFilter] = useState<SkillStatusFilter>('all');
   const [mcpStatusFilter, setMcpStatusFilter] = useState<McpStatusFilter>('all');
+  const [subagentStatusFilter, setSubagentStatusFilter] = useState<SubagentStatusFilter>('all');
   const [selectedSkillName, setSelectedSkillName] = useState<string | null>(null);
   const [selectedMcpName, setSelectedMcpName] = useState<string | null>(null);
+  const [selectedSubagentName, setSelectedSubagentName] = useState<string | null>(null);
   const [customScanPathInput, setCustomScanPathInput] = useState('');
   const [preferredCanonicalSourcePathInput, setPreferredCanonicalSourcePathInput] = useState('');
   const [, setSettingsMessage] = useState<string | null>(null);
@@ -167,13 +178,13 @@ export default function App() {
   const [selectedSkillVariantPath, setSelectedSkillVariantPath] = useState<string | null>(null);
   const [selectedMcpProblemKey, setSelectedMcpProblemKey] = useState<McpIssueReason | null>(null);
   const [selectedMcpVariantPath, setSelectedMcpVariantPath] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [selectedSubagentProblemKey, setSelectedSubagentProblemKey] = useState<SubagentIssueReason | null>(null);
+  const [selectedSubagentVariantPath, setSelectedSubagentVariantPath] = useState<string | null>(null);
   const [autoUpdateStatus, setAutoUpdateStatus] = useState<AutoUpdateStatus>({ phase: 'disabled' });
   const [isInstallingUpdate, setIsInstallingUpdate] = useState(false);
   const didRequestUpdateInstallRef = useRef(false);
   const [isPreviewingOnboarding, setIsPreviewingOnboarding] = useState(false);
   const [isCompletingOnboarding, setIsCompletingOnboarding] = useState(false);
-  const [onboardingErrorMessage, setOnboardingErrorMessage] = useState<string | null>(null);
 
   const applyInventorySnapshot = useCallback(
     (nextInventorySnapshot: SkillInventorySnapshot, preferredSkillName?: string | null) => {
@@ -225,6 +236,20 @@ export default function App() {
     });
   }, []);
 
+  const showErrorToast = useCallback((
+    title: string,
+    error: unknown,
+    fallbackMessage = 'Unknown preload error',
+  ): string => {
+    const description = typeof error === 'string'
+      ? error
+      : error instanceof Error
+        ? error.message
+        : fallbackMessage;
+    showAppToast(title, description, null, 'error');
+    return description;
+  }, [showAppToast]);
+
   const showAppToastWithLatestUndo = useCallback(async (
     title: string,
     description: string,
@@ -246,9 +271,6 @@ export default function App() {
     const runId = mcpConnectivityRunIdRef.current + 1;
     mcpConnectivityRunIdRef.current = runId;
     setIsTestingMcpConnectivity(true);
-    setErrorMessage((currentMessage) =>
-      currentMessage === mcpConnectivityErrorMessageRef.current ? null : currentMessage);
-    mcpConnectivityErrorMessageRef.current = null;
 
     void desktopApi.testMcpConnectivity()
       .then((nextInventorySnapshot) => {
@@ -256,17 +278,13 @@ export default function App() {
           return;
         }
         applyInventorySnapshot(nextInventorySnapshot);
-        setErrorMessage((currentMessage) =>
-          currentMessage === mcpConnectivityErrorMessageRef.current ? null : currentMessage);
       })
       .catch((error) => {
         if (runId !== mcpConnectivityRunIdRef.current) {
           return;
         }
 
-        const message = error instanceof Error ? error.message : 'Unknown preload error';
-        mcpConnectivityErrorMessageRef.current = message;
-        setErrorMessage(message);
+        showErrorToast('MCP connectivity failed', error);
       })
       .finally(() => {
         if (runId !== mcpConnectivityRunIdRef.current) {
@@ -274,7 +292,7 @@ export default function App() {
         }
         setIsTestingMcpConnectivity(false);
       });
-  }, [applyInventorySnapshot, desktopApi]);
+  }, [applyInventorySnapshot, desktopApi, showErrorToast]);
 
   const triggerRescan = useCallback(async ({
     pendingOperation = null,
@@ -305,7 +323,6 @@ export default function App() {
         verifyMcpConnectivity === undefined ? undefined : { verifyMcpConnectivity },
       );
       applyInventorySnapshot(nextInventorySnapshot);
-      setErrorMessage(null);
       if (showSuccessToast) {
         showAppToast('Inventory refreshed', 'Manual rescan completed successfully.');
       }
@@ -313,14 +330,14 @@ export default function App() {
       if (showSuccessToast) {
         setAppToast(null);
       }
-      setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+      showErrorToast('Inventory refresh failed', error);
     } finally {
       setIsRescanning(false);
       if (shouldManagePendingOperation) {
         setPendingInventoryOperation(null);
       }
     }
-  }, [applyInventorySnapshot, desktopApi, showAppToast]);
+  }, [applyInventorySnapshot, desktopApi, showAppToast, showErrorToast]);
 
   const triggerManualRescan = useCallback(async () => {
     await triggerRescan({ showSuccessToast: true });
@@ -380,7 +397,7 @@ export default function App() {
           return;
         }
 
-        setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+        showErrorToast('Startup failed', error);
       } finally {
         if (isMounted) {
           setHasLoadedStartupState(true);
@@ -412,7 +429,7 @@ export default function App() {
           return;
         }
 
-        setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+        showErrorToast('Inventory cache failed', error);
       }
 
       try {
@@ -423,13 +440,12 @@ export default function App() {
         }
 
         applyInventorySnapshot(nextInventorySnapshot);
-        setErrorMessage(null);
       } catch (error) {
         if (!isMounted) {
           return;
         }
 
-        setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+        showErrorToast('Inventory load failed', error);
       }
     };
 
@@ -439,17 +455,15 @@ export default function App() {
     return () => {
       isMounted = false;
     };
-  }, [applyInventorySnapshot, desktopApi, devApi]);
+  }, [applyInventorySnapshot, desktopApi, devApi, showErrorToast]);
 
   useEffect(() => {
     return desktopApi.onInventoryUpdated((nextInventorySnapshot) => {
       applyInventorySnapshot(nextInventorySnapshot);
       setIsResolvingIssue(false);
       setIsDismissingDrift(false);
-      setErrorMessage(null);
     });
   }, [applyInventorySnapshot, desktopApi]);
-
   useEffect(() => {
     let isMounted = true;
     void desktopApi.readUpdateStatus()
@@ -514,13 +528,13 @@ export default function App() {
         await showAppToastWithLatestUndo('Settings updated', successMessage);
       } catch (error) {
         setSettingsMessage(null);
-        setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+        showErrorToast('Settings update failed', error);
       } finally {
         setIsUpdatingSettings(false);
         setPendingInventoryOperation(null);
       }
     },
-    [inventorySourceMode, showAppToastWithLatestUndo, startMcpConnectivityTest, triggerRescan],
+    [inventorySourceMode, showAppToastWithLatestUndo, showErrorToast, startMcpConnectivityTest, triggerRescan],
   );
 
   const handleAddCustomScanPath = useCallback(
@@ -628,7 +642,6 @@ export default function App() {
     async (visible: boolean) => {
       setIsUpdatingSettings(true);
       setSettingsMessage(null);
-      setErrorMessage(null);
 
       try {
         const nextSettingsState = await desktopApi.setDevSidebarInventorySourceSwitcherVisible(visible);
@@ -640,17 +653,17 @@ export default function App() {
         await showAppToastWithLatestUndo('Settings updated', successMessage);
       } catch (error) {
         setSettingsMessage(null);
-        setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+        showErrorToast('Settings update failed', error);
       } finally {
         setIsUpdatingSettings(false);
       }
     },
-    [desktopApi, showAppToastWithLatestUndo],
+    [desktopApi, showAppToastWithLatestUndo, showErrorToast],
   );
 
   const handleSeedRepresentativeFixtures = useCallback(async () => {
     if (!devApi) {
-      setErrorMessage('Representative sandbox controls are only available in development.');
+      showErrorToast('Sandbox reset unavailable', 'Representative sandbox controls are only available in development.');
       return;
     }
 
@@ -662,7 +675,6 @@ export default function App() {
       detail: 'Rebuilding fixtures and rescanning the representative sandbox.',
     });
     setSettingsMessage(null);
-    setErrorMessage(null);
 
     try {
       const seededFixtures = await devApi.seedRepresentativeFixtures();
@@ -674,21 +686,19 @@ export default function App() {
       await showAppToastWithLatestUndo('Sandbox reset', 'Representative fixtures were reset.');
     } catch (error) {
       setSettingsMessage(null);
-      setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+      showErrorToast('Sandbox reset failed', error);
     } finally {
       setIsSeedingFixtures(false);
       setPendingInventoryOperation(null);
     }
-  }, [applyInventorySnapshot, desktopApi, devApi, showAppToastWithLatestUndo]);
+  }, [applyInventorySnapshot, desktopApi, devApi, showAppToastWithLatestUndo, showErrorToast]);
 
   const handleAddSkill = useCallback(async (request: AddSkillRequest) => {
     setIsAddingSkill(true);
-    setErrorMessage(null);
 
     try {
       const nextInventorySnapshot = await desktopApi.addSkill(request);
       applyInventorySnapshot(nextInventorySnapshot);
-      setErrorMessage(null);
       await showAppToastWithLatestUndo(
         'Skill added',
         request.sourceType === 'markdown'
@@ -696,32 +706,28 @@ export default function App() {
           : 'The skill install completed.',
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown preload error';
-      setErrorMessage(message);
+      const message = showErrorToast('Skill add failed', error);
       throw error instanceof Error ? error : new Error(message);
     } finally {
       setIsAddingSkill(false);
     }
-  }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo]);
+  }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo, showErrorToast]);
 
   const handleAddMcpServer = useCallback(async (request: AddMcpServerRequest) => {
     setIsAddingMcpServer(true);
-    setErrorMessage(null);
 
     try {
       const nextInventorySnapshot = await desktopApi.addMcpServer(request);
       applyInventorySnapshot(nextInventorySnapshot);
       setSelectedMcpName(request.name.trim());
-      setErrorMessage(null);
       await showAppToastWithLatestUndo('MCP server added', `${request.name.trim()} was added.`);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown preload error';
-      setErrorMessage(message);
+      const message = showErrorToast('MCP server add failed', error);
       throw error instanceof Error ? error : new Error(message);
     } finally {
       setIsAddingMcpServer(false);
     }
-  }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo]);
+  }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo, showErrorToast]);
 
   const sourceIndex = useMemo(
     () => new Map(inventorySnapshot?.sources.map((source) => [source.id, source]) ?? []),
@@ -749,6 +755,14 @@ export default function App() {
   const mcpRows = useMemo(
     () => filterMcpRows(filterMcpRowsByStatus(allMcpRows, mcpStatusFilter), mcpSearchQuery),
     [allMcpRows, mcpSearchQuery, mcpStatusFilter],
+  );
+  const allSubagentRows = useMemo(
+    () => (inventorySnapshot ? getSubagentTableRows(inventorySnapshot) : []),
+    [inventorySnapshot],
+  );
+  const subagentRows = useMemo(
+    () => filterSubagentRows(filterSubagentRowsByStatus(allSubagentRows, subagentStatusFilter), subagentSearchQuery),
+    [allSubagentRows, subagentSearchQuery, subagentStatusFilter],
   );
   const agentRows = useMemo(
     () => filterAgentRows((inventorySnapshot?.agents ?? []).slice().sort(compareAgentsForTable), agentSearchQuery),
@@ -800,6 +814,19 @@ export default function App() {
       : null,
     [agentIndex, selectedMcp, selectedMcpProblemKey, selectedMcpVariantPath],
   );
+  const selectedSubagent = useMemo(
+    () => inventorySnapshot?.subagents?.find((subagent) => subagent.name === selectedSubagentName) ?? null,
+    [inventorySnapshot?.subagents, selectedSubagentName],
+  );
+  const selectedSubagentInspectorModel = useMemo(
+    () => selectedSubagent
+      ? buildSubagentInspectorModel(selectedSubagent, {
+        selectedProblemKey: selectedSubagentProblemKey,
+        selectedVariantPath: selectedSubagentVariantPath,
+      }, agentIndex)
+      : null,
+    [agentIndex, selectedSubagent, selectedSubagentProblemKey, selectedSubagentVariantPath],
+  );
   useEffect(() => {
     setSelectedSkillProblemKey(null);
     setSelectedSkillVariantPath(null);
@@ -809,6 +836,11 @@ export default function App() {
     setSelectedMcpProblemKey(null);
     setSelectedMcpVariantPath(null);
   }, [selectedMcpName]);
+
+  useEffect(() => {
+    setSelectedSubagentProblemKey(null);
+    setSelectedSubagentVariantPath(null);
+  }, [selectedSubagentName]);
 
   useEffect(() => {
     if (!selectionOverrideSkillName) {
@@ -853,48 +885,57 @@ export default function App() {
     }
   }, [activeTab, inventorySnapshot?.mcps, selectedMcpName]);
 
+  useEffect(() => {
+    if (activeTab !== 'subagents' || !selectedSubagentName) {
+      return;
+    }
+
+    const subagentStillExists = inventorySnapshot?.subagents?.some((subagent) => subagent.name === selectedSubagentName) ?? false;
+    if (!subagentStillExists) {
+      setSelectedSubagentName(null);
+    }
+  }, [activeTab, inventorySnapshot?.subagents, selectedSubagentName]);
+
   const handleResolveIssue = useCallback(
     async (request: ResolveIssueRequest) => {
       const skillName = request.entity === 'skill' ? request.skillName : null;
       setIsResolvingIssue(true);
       setPendingDriftTransitionSkillName(skillName);
-      setErrorMessage(null);
 
       try {
         const nextInventorySnapshot = await desktopApi.resolveIssue(request);
         applyInventorySnapshot(nextInventorySnapshot, skillName ?? undefined);
         if (request.entity === 'skill') {
           await showAppToastWithLatestUndo('Skill updated', `${request.skillName} was updated.`);
-        } else {
+        } else if (request.entity === 'mcp') {
           await showAppToastWithLatestUndo('MCP server updated', `${request.mcpName} was updated.`);
+        } else {
+          await showAppToastWithLatestUndo('Subagent updated', `${request.subagentName} was updated.`);
         }
       } catch (error) {
         setPendingDriftTransitionSkillName(null);
-        const message = error instanceof Error ? error.message : 'Unknown preload error';
-        setErrorMessage(message);
-        showAppToast('Resolution failed', message, null, 'error');
+        showErrorToast('Resolution failed', error);
       } finally {
         await waitForResolvePendingPaintWindow();
         setIsResolvingIssue(false);
       }
     },
-    [applyInventorySnapshot, desktopApi, showAppToast, showAppToastWithLatestUndo],
+    [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo, showErrorToast],
   );
 
   const handleCapabilityAction = useCallback(async (request: CapabilityActionRequest) => {
     setIsApplyingCapabilityAction(true);
-    setErrorMessage(null);
 
     try {
       const nextInventorySnapshot = await desktopApi.applyCapabilityAction(request);
       applyInventorySnapshot(nextInventorySnapshot);
       await showAppToastWithLatestUndo('Capability updated', `${request.skillName} metadata was updated.`);
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+      showErrorToast('Capability update failed', error);
     } finally {
       setIsApplyingCapabilityAction(false);
     }
-  }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo]);
+  }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo, showErrorToast]);
 
   const handleDismissDrift = useCallback(
     async (request: DismissDriftRequest) => {
@@ -904,23 +945,26 @@ export default function App() {
       if (skillName) {
         setSelectionOverrideSkillName(skillName);
       }
-      setErrorMessage(null);
 
       try {
-      const nextInventorySnapshot = await desktopApi.dismissDrift(request);
-      applyInventorySnapshot(nextInventorySnapshot, skillName ?? undefined);
-      await showAppToastWithLatestUndo(
-        'Dismissal updated',
-        skillName ? `${skillName} dismissal state changed.` : `${request.mcpName} dismissal state changed.`,
-      );
-    } catch (error) {
-      setPendingDriftTransitionSkillName(null);
-      setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
-    } finally {
-      setIsDismissingDrift(false);
-    }
-  },
-    [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo],
+        const nextInventorySnapshot = await desktopApi.dismissDrift(request);
+        applyInventorySnapshot(nextInventorySnapshot, skillName ?? undefined);
+        await showAppToastWithLatestUndo(
+          'Dismissal updated',
+          skillName
+            ? `${skillName} dismissal state changed.`
+            : 'mcpName' in request
+              ? `${request.mcpName} dismissal state changed.`
+              : `${request.subagentName} dismissal state changed.`,
+        );
+      } catch (error) {
+        setPendingDriftTransitionSkillName(null);
+        showErrorToast('Dismissal failed', error);
+      } finally {
+        setIsDismissingDrift(false);
+      }
+    },
+    [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo, showErrorToast],
   );
 
   const handleAutoResolve = useCallback(async () => {
@@ -936,7 +980,6 @@ export default function App() {
     const plannedRepairCount = remainingRequests.length;
 
     setIsAutoResolving(true);
-    setErrorMessage(null);
 
     try {
       const attemptedRequestKeys = new Set<string>();
@@ -957,13 +1000,11 @@ export default function App() {
         { includeUndo: plannedRepairCount === 1 },
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown preload error';
-      setErrorMessage(message);
-      showAppToast('Repairs failed', message, null, 'error');
+      showErrorToast('Repairs failed', error);
     } finally {
       setIsAutoResolving(false);
     }
-  }, [applyInventorySnapshot, desktopApi, showAppToast, showAppToastWithLatestUndo]);
+  }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo, showErrorToast]);
 
   const resetSkillSelection = useCallback(() => {
     setSelectedSkillName(null);
@@ -978,9 +1019,14 @@ export default function App() {
     setSelectedMcpVariantPath(null);
   }, []);
 
+  const resetSubagentSelection = useCallback(() => {
+    setSelectedSubagentName(null);
+    setSelectedSubagentProblemKey(null);
+    setSelectedSubagentVariantPath(null);
+  }, []);
+
   const handleUndoToastOperation = useCallback(async (operationId: string) => {
     setIsUndoingToastOperation(true);
-    setErrorMessage(null);
 
     try {
       const result = await desktopApi.undoAuditOperation(operationId);
@@ -993,16 +1039,16 @@ export default function App() {
       }
       const operation = result.auditLog.find((candidate) => candidate.id === operationId);
       if (operation?.status === 'undo-blocked' || operation?.status === 'undo-failed' || operation?.undoState === 'blocked') {
-        showAppToast('Undo blocked', 'The last change could not be undone because the current state has changed.');
+        showAppToast('Undo blocked', 'The last change could not be undone because the current state has changed.', null, 'error');
       } else {
         showAppToast('Undo applied', 'The last change was undone.');
       }
     } catch (error) {
-      showAppToast('Undo blocked', error instanceof Error ? error.message : 'The last change could not be undone.');
+      showErrorToast('Undo blocked', error, 'The last change could not be undone.');
     } finally {
       setIsUndoingToastOperation(false);
     }
-  }, [applyInventorySnapshot, desktopApi, showAppToast]);
+  }, [applyInventorySnapshot, desktopApi, showAppToast, showErrorToast]);
 
   const openPluginFromProvenance = useCallback((
     action: NonNullable<InspectorProvenanceSummaryRow['action']>,
@@ -1012,7 +1058,7 @@ export default function App() {
       && candidate.pluginId === action.pluginId
       && (!action.version || candidate.version === action.version));
     if (!plugin) {
-      setErrorMessage(`Could not find plugin ${action.pluginId} in the current inventory.`);
+      showErrorToast('Plugin not found', `Could not find plugin ${action.pluginId} in the current inventory.`);
       return;
     }
 
@@ -1020,8 +1066,9 @@ export default function App() {
     setSelectedPluginKey(getPluginSelectionKey(plugin));
     resetSkillSelection();
     resetMcpSelection();
+    resetSubagentSelection();
     setActiveTab('plugins');
-  }, [inventorySnapshot?.plugins, resetMcpSelection, resetSkillSelection]);
+  }, [inventorySnapshot?.plugins, resetMcpSelection, resetSkillSelection, resetSubagentSelection, showErrorToast]);
 
   const handleInventorySourceModeChange = useCallback(async (nextMode: InventorySourceMode) => {
     if (nextMode === inventorySourceMode) {
@@ -1035,9 +1082,9 @@ export default function App() {
       kind: 'switch-inventory-source',
       detail: `Refreshing inventory before showing ${nextMode === 'live' ? 'live agent locations' : 'sandbox fixtures'}.`,
     });
-    setErrorMessage(null);
     resetSkillSelection();
     resetMcpSelection();
+    resetSubagentSelection();
 
     try {
       await devApi?.setInventoryMode(nextMode);
@@ -1058,19 +1105,20 @@ export default function App() {
         startMcpConnectivityTest();
       }
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'Unknown preload error');
+      showErrorToast('Inventory source switch failed', error);
     } finally {
       setPendingInventoryOperation(null);
     }
-  }, [desktopApi, devApi, inventorySourceMode, resetMcpSelection, resetSkillSelection, startMcpConnectivityTest, triggerRescan]);
+  }, [desktopApi, devApi, inventorySourceMode, resetMcpSelection, resetSkillSelection, resetSubagentSelection, showErrorToast, startMcpConnectivityTest, triggerRescan]);
 
   const navigateToSkills = useCallback(() => {
     resetSkillSelection();
     resetMcpSelection();
+    resetSubagentSelection();
     setSkillSearchQuery('');
     setSkillStatusFilter('active');
     setActiveTab('skills');
-  }, [resetMcpSelection, resetSkillSelection]);
+  }, [resetMcpSelection, resetSkillSelection, resetSubagentSelection]);
 
   const openSkillFromHome = useCallback((skillName: string) => {
     setSkillSearchQuery('');
@@ -1091,18 +1139,29 @@ export default function App() {
     setActiveTab('mcps');
   }, []);
 
+  const openSubagentFromHome = useCallback((subagentName: string) => {
+    setSubagentSearchQuery('');
+    setSubagentStatusFilter('all');
+    setSelectedSubagentProblemKey(null);
+    setSelectedSubagentVariantPath(null);
+    setSelectedSubagentName(subagentName);
+    setActiveTab('subagents');
+  }, []);
+
   const focusActiveSearch = useCallback(() => {
     const activeSearchInput = activeTab === 'skills'
       ? skillSearchInputRef.current
       : activeTab === 'mcps'
         ? mcpSearchInputRef.current
-      : activeTab === 'agents'
-        ? agentSearchInputRef.current
-        : activeTab === 'plugins'
-          ? pluginSearchInputRef.current
-          : activeTab === 'audit'
-            ? auditSearchInputRef.current
-          : null;
+        : activeTab === 'subagents'
+          ? subagentSearchInputRef.current
+          : activeTab === 'agents'
+            ? agentSearchInputRef.current
+            : activeTab === 'plugins'
+              ? pluginSearchInputRef.current
+              : activeTab === 'audit'
+                ? auditSearchInputRef.current
+                : null;
 
     if (!activeSearchInput) {
       return false;
@@ -1118,13 +1177,15 @@ export default function App() {
       ? skillSearchInputRef.current
       : activeTab === 'mcps'
         ? mcpSearchInputRef.current
-      : activeTab === 'agents'
-        ? agentSearchInputRef.current
-        : activeTab === 'plugins'
-          ? pluginSearchInputRef.current
-          : activeTab === 'audit'
-            ? auditSearchInputRef.current
-          : null;
+        : activeTab === 'subagents'
+          ? subagentSearchInputRef.current
+          : activeTab === 'agents'
+            ? agentSearchInputRef.current
+            : activeTab === 'plugins'
+              ? pluginSearchInputRef.current
+              : activeTab === 'audit'
+                ? auditSearchInputRef.current
+                : null;
 
     if (!activeSearchInput || document.activeElement !== activeSearchInput) {
       return false;
@@ -1166,8 +1227,23 @@ export default function App() {
       return true;
     }
 
+    if (activeTab === 'subagents') {
+      const nextSubagentName = getNavigatedInventoryName(
+        subagentRows.map((subagent) => subagent.name),
+        selectedSubagent?.name ?? null,
+        direction,
+        step,
+      );
+      if (!nextSubagentName) {
+        return false;
+      }
+
+      setSelectedSubagentName(nextSubagentName);
+      return true;
+    }
+
     return false;
-  }, [activeTab, mcpRows, selectedMcp?.name, selectedSkill?.name, skillRows]);
+  }, [activeTab, mcpRows, selectedMcp?.name, selectedSkill?.name, selectedSubagent?.name, skillRows, subagentRows]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -1230,6 +1306,14 @@ export default function App() {
         tone: 'attention' as const,
       },
       {
+        tab: 'subagents' as const,
+        label: 'Subagents',
+        icon: 'subagents' as const,
+        badge: inventorySnapshot?.subagentCounts?.attentionSubagents ?? 0,
+        meta: inventorySnapshot?.subagentCounts?.totalSubagents ?? 0,
+        tone: 'attention' as const,
+      },
+      {
         tab: 'plugins' as const,
         label: 'Plugins',
         icon: 'plugins' as const,
@@ -1249,14 +1333,17 @@ export default function App() {
       inventorySnapshot?.mcpCounts?.attentionMcps,
       inventorySnapshot?.mcpCounts?.totalMcps,
       inventorySnapshot?.plugins?.length,
+      inventorySnapshot?.subagentCounts?.attentionSubagents,
+      inventorySnapshot?.subagentCounts?.totalSubagents,
     ],
   );
 
   const handleTabChange = useCallback((nextTab: PrimaryTab) => {
     resetSkillSelection();
     resetMcpSelection();
+    resetSubagentSelection();
     setActiveTab(nextTab);
-  }, [resetMcpSelection, resetSkillSelection]);
+  }, [resetMcpSelection, resetSkillSelection, resetSubagentSelection]);
 
   const handleInstallUpdate = useCallback(async () => {
     if (didRequestUpdateInstallRef.current) {
@@ -1271,9 +1358,9 @@ export default function App() {
     } catch (error) {
       didRequestUpdateInstallRef.current = false;
       setIsInstallingUpdate(false);
-      setErrorMessage(error instanceof Error ? error.message : 'Failed to install update.');
+      showErrorToast('Update install failed', error, 'Failed to install update.');
     }
-  }, [desktopApi]);
+  }, [desktopApi, showErrorToast]);
 
   useEffect(() => {
     if (autoUpdateStatus.phase !== 'ready' || didRequestUpdateInstallRef.current) {
@@ -1293,22 +1380,18 @@ export default function App() {
   }, [autoUpdateStatus.phase]);
 
   const chooseOnboardingPreferredSource = useCallback(async () => {
-    setOnboardingErrorMessage(null);
     try {
       return await desktopApi.chooseDirectory({
         title: 'Choose a preferred skills source',
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to open the folder picker.';
-      setOnboardingErrorMessage(message);
+      showErrorToast('Folder picker failed', error, 'Failed to open the folder picker.');
       return null;
     }
-  }, [desktopApi]);
+  }, [desktopApi, showErrorToast]);
 
   const completeOnboarding = useCallback(async (preferredSourcePath: string | null) => {
     setIsCompletingOnboarding(true);
-    setOnboardingErrorMessage(null);
-    setErrorMessage(null);
 
     try {
       if (shellState?.devTools && devApi) {
@@ -1325,18 +1408,14 @@ export default function App() {
       setSettingsState(nextSettingsState);
       setIsPreviewingOnboarding(false);
       applyInventorySnapshot(nextInventorySnapshot);
-      setErrorMessage(null);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to complete onboarding.';
-      setOnboardingErrorMessage(message);
-      setErrorMessage(message);
+      showErrorToast('Onboarding failed', error, 'Failed to complete onboarding.');
     } finally {
       setIsCompletingOnboarding(false);
     }
-  }, [applyInventorySnapshot, desktopApi, devApi, shellState?.devTools]);
+  }, [applyInventorySnapshot, desktopApi, devApi, shellState?.devTools, showErrorToast]);
 
   const openOnboardingFromDevelopment = useCallback(() => {
-    setOnboardingErrorMessage(null);
     setIsPreviewingOnboarding(true);
   }, []);
 
@@ -1354,7 +1433,6 @@ export default function App() {
       mainContent = (
         <HomeDashboard
           autoResolvableRequests={autoResolvableRequests}
-          errorMessage={errorMessage}
           homeSummary={homeSummary}
           inventorySnapshot={inventorySnapshot}
           isAutoResolving={isAutoResolving}
@@ -1371,7 +1449,6 @@ export default function App() {
       mainContent = (
         <SkillsWorkspaceView
           isAddingSkill={isAddingSkill}
-          errorMessage={errorMessage}
           inventorySnapshot={inventorySnapshot}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
@@ -1405,7 +1482,6 @@ export default function App() {
     case 'mcps':
       mainContent = (
         <McpWorkspaceView
-          errorMessage={errorMessage}
           inventorySnapshot={inventorySnapshot}
           isAddingMcpServer={isAddingMcpServer}
           isDismissingDrift={isDismissingDrift}
@@ -1431,10 +1507,36 @@ export default function App() {
         />
       );
       break;
+    case 'subagents':
+      mainContent = (
+        <SubagentsWorkspaceView
+          inventorySnapshot={inventorySnapshot}
+          isDismissingDrift={isDismissingDrift}
+          isResolvingIssue={isResolvingIssue}
+          isRescanning={isRescanActionBusy}
+          onClearSelection={resetSubagentSelection}
+          onDismissDrift={handleDismissDrift}
+          onResolveIssue={handleResolveIssue}
+          onRescan={triggerManualRescan}
+          onSearchQueryChange={setSubagentSearchQuery}
+          onSelectProblem={setSelectedSubagentProblemKey}
+          onSelectSubagent={setSelectedSubagentName}
+          onSelectVariant={setSelectedSubagentVariantPath}
+          onStatusFilterChange={setSubagentStatusFilter}
+          rows={subagentRows}
+          sandboxRoot={shellState?.devTools?.sandboxRoot ?? null}
+          searchInputRef={subagentSearchInputRef}
+          searchQuery={subagentSearchQuery}
+          selectedSubagent={selectedSubagent}
+          selectedSubagentInspectorModel={selectedSubagentInspectorModel}
+          selectedSubagentProblemKey={selectedSubagentProblemKey}
+          statusFilter={subagentStatusFilter}
+        />
+      );
+      break;
     case 'agents':
       mainContent = (
         <AgentsWorkspaceView
-          errorMessage={errorMessage}
           inventorySnapshot={inventorySnapshot}
           isRescanning={isRescanActionBusy}
           onRescan={triggerManualRescan}
@@ -1448,7 +1550,6 @@ export default function App() {
     case 'plugins':
       mainContent = (
         <PluginsWorkspaceView
-          errorMessage={errorMessage}
           inventorySnapshot={inventorySnapshot}
           isRescanning={isRescanActionBusy}
           onRescan={triggerManualRescan}
@@ -1458,6 +1559,7 @@ export default function App() {
             setSelectedPluginKey(getPluginSelectionKey(plugin));
           }}
           onSelectSkillAsset={openSkillFromHome}
+          onSelectSubagentAsset={openSubagentFromHome}
           onClearSelection={() => {
             setSelectedPluginKey(null);
           }}
@@ -1490,7 +1592,6 @@ export default function App() {
       mainContent = (
         <SettingsWorkspaceView
           customScanPathInput={customScanPathInput}
-          errorMessage={errorMessage}
           handleAddCustomScanPath={handleAddCustomScanPath}
           handleClearPreferredCanonicalSourcePath={handleClearPreferredCanonicalSourcePath}
           inventorySourceMode={inventorySourceMode}
@@ -1519,11 +1620,39 @@ export default function App() {
       break;
   }
 
+  const appToastRegion = appToast ? (
+    <div aria-live="polite" className="app-toast-region" role="status">
+      <section className={`app-toast app-toast--${appToast.tone}`} aria-label={appToast.title}>
+        <div className="app-toast-icon" aria-hidden="true">
+          <span>{appToast.tone === 'error' ? '!' : '✓'}</span>
+        </div>
+        <div className="app-toast-copy">
+          <strong>{appToast.title}</strong>
+          <p>{appToast.description}</p>
+        </div>
+        {appToast.undoOperationId ? (
+          <button
+            className="app-toast-action"
+            disabled={isUndoingToastOperation}
+            type="button"
+            onClick={() => {
+              if (appToast.undoOperationId) {
+                void handleUndoToastOperation(appToast.undoOperationId);
+              }
+            }}
+          >
+            <Undo2 className="app-toast-action-icon" aria-hidden="true" strokeWidth={2} />
+            <span>{isUndoingToastOperation ? 'Undoing...' : 'Undo'}</span>
+          </button>
+        ) : null}
+      </section>
+    </div>
+  ) : null;
+
   if (shouldShowOnboarding) {
     return (
       <>
         <OnboardingFlow
-          errorMessage={onboardingErrorMessage}
           isCompleting={isCompletingOnboarding}
           universalSkillsPath={CANONICAL_USER_SKILLS_DISPLAY_PATH}
           onChoosePreferredSource={chooseOnboardingPreferredSource}
@@ -1534,6 +1663,7 @@ export default function App() {
           isInstallingUpdate={isInstallingUpdate}
           status={autoUpdateStatus}
         />
+        {appToastRegion}
       </>
     );
   }
@@ -1576,34 +1706,7 @@ export default function App() {
         <div className="app-main">{mainContent}</div>
       </div>
 
-      {appToast ? (
-        <div aria-live="polite" className="app-toast-region" role="status">
-          <section className={`app-toast app-toast--${appToast.tone}`} aria-label={appToast.title}>
-            <div className="app-toast-icon" aria-hidden="true">
-              <span>{appToast.tone === 'error' ? '!' : '✓'}</span>
-            </div>
-            <div className="app-toast-copy">
-              <strong>{appToast.title}</strong>
-              <p>{appToast.description}</p>
-            </div>
-            {appToast.undoOperationId ? (
-              <button
-                className="app-toast-action"
-                disabled={isUndoingToastOperation}
-                type="button"
-                onClick={() => {
-                  if (appToast.undoOperationId) {
-                    void handleUndoToastOperation(appToast.undoOperationId);
-                  }
-                }}
-              >
-                <Undo2 className="app-toast-action-icon" aria-hidden="true" strokeWidth={2} />
-                <span>{isUndoingToastOperation ? 'Undoing...' : 'Undo'}</span>
-              </button>
-            ) : null}
-          </section>
-        </div>
-      ) : null}
+      {appToastRegion}
 
       <AutoUpdateDialog
         appName={shellState?.appName ?? APP_NAME}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -400,6 +400,9 @@ export default function App() {
     if (!appToast) {
       return;
     }
+    if (appToast.trace && expandedToastTraceId === appToast.id) {
+      return;
+    }
 
     const timeoutId = window.setTimeout(() => {
       setAppToast((currentToast) => (currentToast?.id === appToast.id ? null : currentToast));
@@ -408,7 +411,7 @@ export default function App() {
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [appToast]);
+  }, [appToast, expandedToastTraceId]);
 
   useEffect(() => {
     if (toastTraceCopyState === 'idle') {
@@ -1535,6 +1538,7 @@ export default function App() {
           onSelectMcp={openMcpFromHome}
           onRescan={triggerManualRescan}
           onSelectSkill={openSkillFromHome}
+          onSelectSubagent={openSubagentFromHome}
         />
       );
       break;

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -216,6 +216,14 @@ describe('App shell inventory views', () => {
     });
   }
 
+  async function openSubagents() {
+    fireEvent.click(within(await getPrimaryNavAsync()).getByRole('button', { name: /^Subagents/i }));
+    await screen.findByRole('heading', { name: /^Subagents$/i, level: 2 });
+    await waitFor(() => {
+      expect(screen.queryByText(/Scanning your subagent inventory/i)).not.toBeInTheDocument();
+    });
+  }
+
   function getMcpTable() {
     return screen.getByRole('region', { name: /^MCP list$/i });
   }
@@ -227,6 +235,15 @@ describe('App shell inventory views', () => {
   function getMcpRow(name: string) {
     const pattern = new RegExp(name, 'i');
     return within(getMcpTable()).getByRole('button', { name: pattern });
+  }
+
+  function getSubagentTable() {
+    return screen.getByRole('region', { name: /^Subagent list$/i });
+  }
+
+  function getSubagentRow(name: string) {
+    const pattern = new RegExp(name, 'i');
+    return within(getSubagentTable()).getByRole('button', { name: pattern });
   }
 
   function getHomeAttentionSection() {
@@ -259,7 +276,7 @@ describe('App shell inventory views', () => {
     return row as HTMLElement;
   }
 
-  it('launches into Home with five primary tabs and keeps Audit Log above Settings', async () => {
+  it('launches into Home with six primary tabs and keeps Audit Log above Settings', async () => {
     readAuditLogMock.mockResolvedValue(createAuditOperations());
     render(<App />);
 
@@ -270,17 +287,19 @@ describe('App shell inventory views', () => {
 
     const installedAgentCount = createInventorySnapshot().agentCounts?.installedAgents ?? 0;
 
-    expect(within(primaryNav).getAllByRole('button')).toHaveLength(5);
+    expect(within(primaryNav).getAllByRole('button')).toHaveLength(6);
     expect(within(primaryNav).getAllByRole('button').map((button) => button.textContent?.replace(/\s+/g, ''))).toEqual([
       'Home',
       'Skills38',
       'MCPs16',
+      'Subagents0',
       'Plugins0',
       `Agents${installedAgentCount}`,
     ]);
     expect(within(primaryNav).getByRole('button', { name: /^Home$/i })).toHaveTextContent(/^Home$/);
     expect(within(primaryNav).getByRole('button', { name: /^Skills/i })).toHaveTextContent(/^Skills38$/);
     expect(within(primaryNav).getByRole('button', { name: /^MCPs/i })).toHaveTextContent(/^MCPs16$/);
+    expect(within(primaryNav).getByRole('button', { name: /^Subagents/i })).toHaveTextContent(/^Subagents0$/);
     expect(within(primaryNav).getByRole('button', { name: /^Agents/i })).toHaveTextContent(
       new RegExp(`^Agents${installedAgentCount}$`),
     );
@@ -1434,6 +1453,30 @@ describe('App shell inventory views', () => {
     await waitFor(() => {
       expect(dismissDriftMock).toHaveBeenCalledWith({ mcpName: 'broken-mcp' });
     });
+  });
+
+  it('shows subagent dismissal failures as toasts instead of inline banners', async () => {
+    const snapshot = structuredClone(representativeInventorySnapshot);
+    readCachedInventoryMock.mockResolvedValue(snapshot);
+    scanInventoryMock.mockResolvedValue(snapshot);
+    dismissDriftMock.mockRejectedValueOnce(new Error('Subagent dismissal is not supported yet.'));
+
+    render(<App />);
+    await openSubagents();
+
+    fireEvent.click(getSubagentRow('reviewer'));
+    expect(await screen.findByRole('heading', { name: 'reviewer', level: 3 })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Dismiss issues with this subagent$/i }));
+
+    await waitFor(() => {
+      expect(dismissDriftMock).toHaveBeenCalledWith({ subagentName: 'reviewer' });
+    });
+
+    const toast = await screen.findByRole('status');
+    expect(toast).toHaveTextContent('Dismissal failed');
+    expect(toast).toHaveTextContent('Subagent dismissal is not supported yet.');
+    expect(document.querySelector('.inline-error-banner')).toBeNull();
   });
 
   it('starts with a selected source for diverged canonicalization and lets you switch it on the skill detail page', async () => {
@@ -3358,6 +3401,19 @@ function createMcpOnlyAutoResolvableInventorySnapshot(): SkillInventorySnapshot 
     identicalDriftSkills: 0,
     divergedDriftSkills: 0,
     dismissedDriftSkills: 0,
+  };
+  snapshot.subagents = (snapshot.subagents ?? []).map((subagent) => ({
+    ...subagent,
+    status: 'healthy',
+    presentation: 'none',
+    issueReasons: [],
+    missingLocations: [],
+  }));
+  snapshot.subagentCounts = {
+    totalSubagents: snapshot.subagents.length,
+    attentionSubagents: 0,
+    healthySubagents: snapshot.subagents.length,
+    dismissedAttentionSubagents: 0,
   };
   delete snapshot.homeSummary;
   snapshot.homeSummary = getHomeSummary(snapshot);

--- a/src/renderer/src/app/browser-preview-adapter.ts
+++ b/src/renderer/src/app/browser-preview-adapter.ts
@@ -10,6 +10,7 @@ import {
   type SkillInventorySnapshot,
   type SkillIndexDesktopApi,
   type SkillIndexDevApi,
+  type SubagentPresentation,
 } from '@shared/contracts';
 
 import { representativeInventorySnapshot, representativeSeededFixtures } from '../representative-preview-data';
@@ -236,7 +237,7 @@ function toggleBrowserPreviewDismissal(snapshot: SkillInventorySnapshot, request
       }
       : skill);
     nextSnapshot.counts = recomputeSkillCounts(nextSnapshot);
-  } else {
+  } else if ('mcpName' in request) {
     nextSnapshot.mcps = (nextSnapshot.mcps ?? []).map((mcp) => mcp.name === request.mcpName
       ? {
         ...mcp,
@@ -244,6 +245,14 @@ function toggleBrowserPreviewDismissal(snapshot: SkillInventorySnapshot, request
       }
       : mcp);
     nextSnapshot.mcpCounts = recomputeMcpCounts(nextSnapshot);
+  } else {
+    nextSnapshot.subagents = (nextSnapshot.subagents ?? []).map((subagent) => subagent.name === request.subagentName
+      ? {
+        ...subagent,
+        presentation: toggleSubagentPresentation(subagent.presentation),
+      }
+      : subagent);
+    nextSnapshot.subagentCounts = recomputeSubagentCounts(nextSnapshot);
   }
 
   nextSnapshot.homeSummary = {
@@ -271,6 +280,10 @@ function toggleMcpPresentation(presentation: McpPresentation): McpPresentation {
   return presentation === 'dismissed' ? 'active' : 'dismissed';
 }
 
+function toggleSubagentPresentation(presentation: SubagentPresentation): SubagentPresentation {
+  return presentation === 'dismissed' ? 'active' : 'dismissed';
+}
+
 function recomputeSkillCounts(snapshot: SkillInventorySnapshot): SkillInventorySnapshot['counts'] {
   return {
     totalSkills: snapshot.skills.length,
@@ -291,5 +304,15 @@ function recomputeMcpCounts(snapshot: SkillInventorySnapshot): NonNullable<Skill
     attentionMcps: mcps.filter((mcp) => mcp.status === 'needs-attention' && mcp.presentation === 'active').length,
     healthyMcps: mcps.filter((mcp) => mcp.status === 'healthy').length,
     dismissedAttentionMcps: mcps.filter((mcp) => mcp.status === 'needs-attention' && mcp.presentation === 'dismissed').length,
+  };
+}
+
+function recomputeSubagentCounts(snapshot: SkillInventorySnapshot): NonNullable<SkillInventorySnapshot['subagentCounts']> {
+  const subagents = snapshot.subagents ?? [];
+  return {
+    totalSubagents: subagents.length,
+    attentionSubagents: subagents.filter((subagent) => subagent.status === 'needs-attention' && subagent.presentation === 'active').length,
+    healthySubagents: subagents.filter((subagent) => subagent.status === 'healthy').length,
+    dismissedAttentionSubagents: subagents.filter((subagent) => subagent.status === 'needs-attention' && subagent.presentation === 'dismissed').length,
   };
 }

--- a/src/renderer/src/components/AppSidebar.tsx
+++ b/src/renderer/src/components/AppSidebar.tsx
@@ -9,7 +9,7 @@ import { NavIcon, type NavIconName } from './NavIcon';
 
 export interface AppNavItem {
   badge?: number;
-  icon: Extract<NavIconName, 'home' | 'skills' | 'mcps' | 'agents' | 'plugins'>;
+  icon: Extract<NavIconName, 'home' | 'skills' | 'mcps' | 'subagents' | 'agents' | 'plugins'>;
   label: string;
   meta?: number;
   tab: Exclude<PrimaryTab, 'audit' | 'settings'>;

--- a/src/renderer/src/components/DetailInspectorPanel.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.tsx
@@ -11,7 +11,7 @@ import type {
   InspectorVariantModel,
 } from '../lib/detail-inspector-model';
 import { formatDiffLine, formatInspectorDisplayPath, truncateMiddle } from '../lib/inventory-presentation';
-import { PLUGIN_MCP_TOOLTIP, PLUGIN_SKILL_TOOLTIP, PluginTooltipIndicator } from './ui';
+import { PLUGIN_MCP_TOOLTIP, PLUGIN_SKILL_TOOLTIP, PLUGIN_SUBAGENT_TOOLTIP, PluginTooltipIndicator } from './ui';
 
 export interface DetailInspectorFooterAction {
   detail?: string;
@@ -27,7 +27,6 @@ export function DetailInspectorPanel({
   ariaLabel = 'Detail inspector',
   closeLabel = 'Close',
   entityKind = 'skill',
-  errorMessage = null,
   footerActions,
   model,
   onClose,
@@ -41,8 +40,7 @@ export function DetailInspectorPanel({
 }: {
   ariaLabel?: string;
   closeLabel?: string;
-  entityKind?: 'skill' | 'mcp';
-  errorMessage?: string | null;
+  entityKind?: 'skill' | 'mcp' | 'subagent';
   footerActions?: DetailInspectorFooterAction[];
   model: InspectorModel;
   onClose: () => void;
@@ -87,7 +85,7 @@ export function DetailInspectorPanel({
     ? getDiffStats(activeProblem.diffLines)
     : null;
   const showVariantPreviewHeader = activeProblem.kind === 'variant-resolution'
-    ? !(activeProblem.key === 'missing-canonical' && !activeProblem.baselineVariant)
+    ? !((activeProblem.key === 'missing-canonical' || activeProblem.key === 'missing-universal') && !activeProblem.baselineVariant)
     : false;
   const shouldRenderPlainPath = (problemKey: InspectorModel['problems'][number]['key']) =>
     problemKey === 'missing-symlinks' || problemKey === 'broken-symlink';
@@ -104,7 +102,11 @@ export function DetailInspectorPanel({
     `detail-inspector-panel--${entityKind}`,
     paneClassName,
   ].filter(Boolean).join(' ');
-  const pluginTooltip = entityKind === 'mcp' ? PLUGIN_MCP_TOOLTIP : PLUGIN_SKILL_TOOLTIP;
+  const pluginTooltip = entityKind === 'mcp'
+    ? PLUGIN_MCP_TOOLTIP
+    : entityKind === 'subagent'
+      ? PLUGIN_SUBAGENT_TOOLTIP
+      : PLUGIN_SKILL_TOOLTIP;
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -166,8 +168,6 @@ export function DetailInspectorPanel({
           <span className="detail-inspector-panel__updated-copy">{model.header.updatedLabel}</span>
         </div>
       </section>
-
-      {errorMessage ? <p className="inline-error-banner">{errorMessage}</p> : null}
 
       {model.provenanceSummary.length > 0 ? (
         <section className="detail-inspector-panel__provenance-block" aria-label={`${ariaLabel} provenance`}>
@@ -266,7 +266,7 @@ export function DetailInspectorPanel({
                           aria-pressed={isSelected}
                           className={[
                             'detail-inspector-panel__variant-card',
-                            entityKind === 'skill' ? 'detail-inspector-panel__variant-card--skill' : 'detail-inspector-panel__variant-card--mcp',
+                            entityKind === 'mcp' ? 'detail-inspector-panel__variant-card--mcp' : 'detail-inspector-panel__variant-card--skill',
                             isSelected ? 'detail-inspector-panel__variant-card--selected' : '',
                             isCanonicalComparison ? 'detail-inspector-panel__variant-card--canonical-compare' : '',
                             isCanonical && !isCanonicalComparison && !isSelected ? 'detail-inspector-panel__variant-card--canonical' : '',
@@ -657,7 +657,7 @@ function InspectorVariantPicker({
   selectedPath,
   variants,
 }: {
-  entityKind: 'skill' | 'mcp';
+  entityKind: 'skill' | 'mcp' | 'subagent';
   formatPath: (value: string, maxLength: number) => string;
   listTitle: string;
   onVariantSelect?: (path: string) => void;
@@ -682,7 +682,7 @@ function InspectorVariantPicker({
               aria-pressed={isSelected}
               className={[
                 'detail-inspector-panel__variant-card',
-                entityKind === 'skill' ? 'detail-inspector-panel__variant-card--skill' : 'detail-inspector-panel__variant-card--mcp',
+                entityKind === 'mcp' ? 'detail-inspector-panel__variant-card--mcp' : 'detail-inspector-panel__variant-card--skill',
                 isSelected ? 'detail-inspector-panel__variant-card--selected' : '',
                 isBaseline && !isSelected ? 'detail-inspector-panel__variant-card--canonical' : '',
               ].filter(Boolean).join(' ')}

--- a/src/renderer/src/components/NavIcon.tsx
+++ b/src/renderer/src/components/NavIcon.tsx
@@ -1,6 +1,6 @@
-import { Bot, House, PackageCheck, RefreshCw, ScrollText, Server, Settings, Star } from 'lucide-react';
+import { Bot, BrainCircuit, House, PackageCheck, RefreshCw, ScrollText, Server, Settings, Star } from 'lucide-react';
 
-export type NavIconName = 'home' | 'skills' | 'mcps' | 'agents' | 'plugins' | 'audit' | 'settings' | 'rescan';
+export type NavIconName = 'home' | 'skills' | 'mcps' | 'subagents' | 'agents' | 'plugins' | 'audit' | 'settings' | 'rescan';
 
 export function NavIcon({ icon }: { icon: NavIconName }) {
   switch (icon) {
@@ -10,6 +10,8 @@ export function NavIcon({ icon }: { icon: NavIconName }) {
       return <Star strokeWidth={1.8} />;
     case 'mcps':
       return <Server strokeWidth={1.8} />;
+    case 'subagents':
+      return <BrainCircuit strokeWidth={1.8} />;
     case 'agents':
       return <Bot strokeWidth={1.8} />;
     case 'plugins':

--- a/src/renderer/src/components/ui.tsx
+++ b/src/renderer/src/components/ui.tsx
@@ -16,6 +16,7 @@ import { NavIcon, type NavIconName } from './NavIcon';
 
 export const PLUGIN_SKILL_TOOLTIP = 'This skill was installed via one or more plugins';
 export const PLUGIN_MCP_TOOLTIP = PLUGIN_SKILL_TOOLTIP;
+export const PLUGIN_SUBAGENT_TOOLTIP = 'This subagent was installed via one or more plugins';
 
 const PLUGIN_TOOLTIP_MARGIN = 12;
 const PLUGIN_TOOLTIP_FALLBACK_WIDTH = 360;
@@ -455,6 +456,8 @@ export function AgentStatusRow({
   const isAccountManagedSkills = agent.skillsLocation.reason === 'account-managed';
   const mcpConfigPath = getAgentConfigDisplayPath(agent);
   const mcpConfigTitle = getAgentConfigTitle(agent);
+  const subagentsPath = getAgentSubagentsDisplayPath(agent);
+  const subagentsTitle = getAgentSubagentsTitle(agent);
 
   return (
     <div className="agent-status-row">
@@ -474,6 +477,9 @@ export function AgentStatusRow({
       </div>
       <div className="agent-location-column">
         <code className="agent-location-path" title={mcpConfigTitle}>{mcpConfigPath}</code>
+      </div>
+      <div className="agent-location-column">
+        <code className="agent-location-path" title={subagentsTitle}>{subagentsPath}</code>
       </div>
     </div>
   );
@@ -579,6 +585,30 @@ function getAgentConfigTitle(agent: AgentRecord): string {
   return agent.mcpConfigLocation.path
     ?? agent.configLocation?.path
     ?? getAgentConfigDisplayPath(agent);
+}
+
+function getAgentSubagentsDisplayPath(agent: AgentRecord): string {
+  if (agent.subagentsLocation?.displayPath) {
+    return agent.subagentsLocation.displayPath;
+  }
+
+  if (agent.subagentsLocation?.path) {
+    return agent.subagentsLocation.path;
+  }
+
+  if (agent.subagentsLocation?.reason === 'account-managed') {
+    return 'Cloud account managed';
+  }
+
+  return '-';
+}
+
+function getAgentSubagentsTitle(agent: AgentRecord): string {
+  if (agent.subagentsLocation?.reason === 'account-managed') {
+    return "Subagents are managed through this agent's cloud account; Skill Index cannot scan or install local subagent files for it.";
+  }
+
+  return agent.subagentsLocation?.path ?? getAgentSubagentsDisplayPath(agent);
 }
 
 export function SettingsCard({

--- a/src/renderer/src/inventory-view-model.ts
+++ b/src/renderer/src/inventory-view-model.ts
@@ -6,9 +6,10 @@ import type {
   SkillInventorySnapshot,
   SkillRecord,
   SkillScanSource,
+  SubagentRecord,
 } from '@shared/contracts';
 
-export type PrimaryTab = 'home' | 'skills' | 'mcps' | 'agents' | 'plugins' | 'audit' | 'settings';
+export type PrimaryTab = 'home' | 'skills' | 'mcps' | 'subagents' | 'agents' | 'plugins' | 'audit' | 'settings';
 
 export interface InventorySection<T> {
   title: string;
@@ -66,6 +67,10 @@ export function getMcpTableRows(snapshot: SkillInventorySnapshot): McpRecord[] {
   return [...(snapshot.mcps ?? [])].sort(compareMcpTableRows);
 }
 
+export function getSubagentTableRows(snapshot: SkillInventorySnapshot): SubagentRecord[] {
+  return [...(snapshot.subagents ?? [])].sort(compareSubagentTableRows);
+}
+
 export function getMcpSections(snapshot: SkillInventorySnapshot): InventorySection<McpRecord>[] {
   const mcps = snapshot.mcps ?? [];
   const attentionRows = mcps
@@ -101,6 +106,46 @@ export function getMcpSections(snapshot: SkillInventorySnapshot): InventorySecti
     tone: 'healthy',
     rows: healthyRows,
     emptyMessage: 'MCP servers with matching setup show up here.',
+  });
+
+  return sections;
+}
+
+export function getSubagentSections(snapshot: SkillInventorySnapshot): InventorySection<SubagentRecord>[] {
+  const subagents = snapshot.subagents ?? [];
+  const attentionRows = subagents
+    .filter((subagent) => subagent.status === 'needs-attention' && subagent.presentation === 'active')
+    .sort(compareIssueDenseSubagentRows);
+  const mutedRows = subagents
+    .filter((subagent) => subagent.status === 'needs-attention' && subagent.presentation === 'dismissed')
+    .sort(compareIssueDenseSubagentRows);
+  const healthyRows = subagents
+    .filter((subagent) => subagent.status === 'healthy')
+    .sort(compareAlphabeticallyByName);
+
+  const sections: InventorySection<SubagentRecord>[] = [
+    {
+      title: 'Needs attention',
+      tone: 'attention',
+      rows: attentionRows,
+      emptyMessage: 'No subagent setup issues need attention right now.',
+    },
+  ];
+
+  if (mutedRows.length > 0) {
+    sections.push({
+      title: 'Dismissed issues',
+      tone: 'muted',
+      rows: mutedRows,
+      emptyMessage: 'Hidden subagent issues stay here so you can review them later.',
+    });
+  }
+
+  sections.push({
+    title: 'Healthy',
+    tone: 'healthy',
+    rows: healthyRows,
+    emptyMessage: 'Subagents with matching setup show up here.',
   });
 
   return sections;
@@ -171,6 +216,22 @@ export function filterMcpRows(rows: McpRecord[], query: string): McpRecord[] {
   return rows.filter((row) => matchesSearchFields(normalizedQuery, [getMcpDisplayName(row), row.name]));
 }
 
+export function filterSubagentRows(rows: SubagentRecord[], query: string): SubagentRecord[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+
+  if (!normalizedQuery) {
+    return rows;
+  }
+
+  return rows.filter((row) => matchesSearchFields(normalizedQuery, [
+    getSubagentDisplayName(row),
+    row.name,
+    row.description,
+    ...row.locations.map((location) => location.agentLabel),
+    ...row.locations.map((location) => location.path),
+  ]));
+}
+
 export function filterAgentRows(rows: AgentRecord[], query: string): AgentRecord[] {
   const normalizedQuery = query.trim().toLocaleLowerCase();
 
@@ -189,6 +250,8 @@ export function filterAgentRows(rows: AgentRecord[], query: string): AgentRecord
       row.skillsLocation.displayPath,
       row.mcpConfigLocation.path,
       row.mcpConfigLocation.displayPath,
+      row.subagentsLocation?.path,
+      row.subagentsLocation?.displayPath,
       row.configLocation?.path,
       row.configLocation?.displayPath,
       row.executableLocation?.path,
@@ -215,6 +278,7 @@ export function filterPluginRows(rows: PluginRecord[], query: string): PluginRec
     row.source?.repository,
     ...row.bundledSkills.map((skill) => skill.name),
     ...row.bundledMcps.map((mcp) => mcp.name),
+    ...(row.bundledSubagents ?? []).map((subagent) => subagent.name),
   ]));
 }
 
@@ -341,6 +405,23 @@ function compareMcpTableRows(left: McpRecord, right: McpRecord): number {
   return compareAlphabeticallyByMcpName(left, right);
 }
 
+function compareSubagentTableRows(left: SubagentRecord, right: SubagentRecord): number {
+  const presentationRank = getSubagentTablePresentationRank(left) - getSubagentTablePresentationRank(right);
+  if (presentationRank !== 0) {
+    return presentationRank;
+  }
+
+  if (left.presentation === 'active' && right.presentation === 'active') {
+    return compareIssueDenseSubagentRows(left, right);
+  }
+
+  if (left.presentation === 'dismissed' && right.presentation === 'dismissed') {
+    return compareIssueDenseSubagentRows(left, right);
+  }
+
+  return compareAlphabeticallyBySubagentName(left, right);
+}
+
 function compareIssueDenseMcpRows(left: McpRecord, right: McpRecord): number {
   const issueCountDifference = getMcpIssueCount(right) - getMcpIssueCount(left);
   if (issueCountDifference !== 0) {
@@ -348,6 +429,20 @@ function compareIssueDenseMcpRows(left: McpRecord, right: McpRecord): number {
   }
 
   return compareAlphabeticallyByMcpName(left, right);
+}
+
+function compareIssueDenseSubagentRows(left: SubagentRecord, right: SubagentRecord): number {
+  const issueCountDifference = right.issueReasons.length - left.issueReasons.length;
+  if (issueCountDifference !== 0) {
+    return issueCountDifference;
+  }
+
+  return compareAlphabeticallyBySubagentName(left, right);
+}
+
+function compareAlphabeticallyBySubagentName(left: SubagentRecord, right: SubagentRecord): number {
+  return getSubagentDisplayName(left).localeCompare(getSubagentDisplayName(right), undefined, { sensitivity: 'base' })
+    || left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
 }
 
 function getSkillTablePresentationRank(skill: SkillRecord): number {
@@ -370,6 +465,26 @@ function getMcpTablePresentationRank(mcp: McpRecord): number {
     case 'none':
       return 2;
   }
+}
+
+function getSubagentTablePresentationRank(subagent: SubagentRecord): number {
+  switch (subagent.presentation) {
+    case 'active':
+      return 0;
+    case 'dismissed':
+      return 1;
+    case 'none':
+      return 2;
+  }
+}
+
+export function getSubagentDisplayName(subagent: Pick<SubagentRecord, 'name' | 'displayName'>): string {
+  return subagent.displayName?.trim() || stripPluginQualifier(subagent.name);
+}
+
+function stripPluginQualifier(value: string): string {
+  const qualifierEnd = value.indexOf(':');
+  return qualifierEnd > 0 ? value.slice(qualifierEnd + 1) : value;
 }
 
 function getStableRank(skill: SkillRecord): number {

--- a/src/renderer/src/lib/detail-inspector-model.ts
+++ b/src/renderer/src/lib/detail-inspector-model.ts
@@ -3712,7 +3712,9 @@ function hasPluginMcpLocation(mcp: McpRecord): boolean {
 }
 
 function hasPluginSubagentLocation(subagent: SubagentRecord): boolean {
-  return subagent.locations.some((location) => location.provenance?.kind === 'plugin');
+  return subagent.locations.some((location) =>
+    location.agentId.startsWith('plugin:')
+    || location.provenance?.kind === 'plugin');
 }
 
 function compareSkillLocationForProvenance(left: SkillLocationRecord, right: SkillLocationRecord): number {

--- a/src/renderer/src/lib/detail-inspector-model.ts
+++ b/src/renderer/src/lib/detail-inspector-model.ts
@@ -21,6 +21,9 @@ import type {
   SkillRecord,
   SkillScanSource,
   SkillUniversalAlternate,
+  SubagentIssueReason,
+  SubagentLocationRecord,
+  SubagentRecord,
 } from '@shared/contracts';
 import { buildTextDiffLines } from '@shared/text-diff';
 import { isMcpDefinitionObject, normalizeMcpDefinitionForComparison } from '@shared/mcp-definition';
@@ -32,12 +35,13 @@ import {
   formatMcpIssueReason,
   formatMcpSupportingCopy,
   formatSkillIssueReason,
+  formatSubagentIssueReason,
   getDisplaySkillIssueReasons,
   getSkillRowDescription,
 } from './inventory-presentation';
-import { getMcpDisplayName, getSkillDisplayName } from '../inventory-view-model';
+import { getMcpDisplayName, getSkillDisplayName, getSubagentDisplayName } from '../inventory-view-model';
 
-type InspectorProblemKey = SkillIssueReason | McpIssueReason;
+type InspectorProblemKey = SkillIssueReason | McpIssueReason | SubagentIssueReason;
 type InspectorSectionTitle = 'Variant resolution' | 'Structural repair';
 
 export const DETAIL_DIFF_TITLE = 'Diff: Selected Version vs Universal';
@@ -46,6 +50,13 @@ const SKILL_ACTION_LABELS = {
   useAsUniversal: 'Use as Universal',
   convertCopiesToSymlinks: 'Convert Copies to Symlinks',
   createMissingSymlinks: 'Create Missing Symlinks',
+  repairSymlinks: 'Repair Symlinks',
+} as const;
+const SUBAGENT_ACTION_LABELS = {
+  addToUniversal: 'Add to Universal',
+  addToAgents: 'Add to Agents',
+  applySelectedDefinition: 'Apply Selected Definition',
+  convertCopiesToSymlinks: 'Convert Copies to Symlinks',
   repairSymlinks: 'Repair Symlinks',
 } as const;
 
@@ -259,6 +270,13 @@ interface McpVariantGroup {
   representative: McpLocationRecord;
 }
 
+interface SubagentVariantGroup {
+  id: string;
+  definitionText?: string;
+  locations: SubagentLocationRecord[];
+  representative: SubagentLocationRecord;
+}
+
 type InternalSkillDiffFileRecord = SkillDiffFileRecord & {
   __displayKind?: InspectorChangedFileModel['displayKind'];
 };
@@ -341,6 +359,50 @@ export function buildMcpInspectorModel(
       label: formatMcpIssueReason(key),
       detail: getMcpProblemDetail(mcp, key, agentIndex),
       summary: getMcpProblemSummary(mcp, key),
+      isActive: key === activeProblem.key,
+    })),
+    problemSections: buildProblemSections(problemKeys),
+    activeProblem,
+    selectedVariantPath,
+    provenanceRows,
+    provenanceSummary,
+  };
+}
+
+export function buildSubagentInspectorModel(
+  subagent: SubagentRecord,
+  selection: {
+    selectedProblemKey?: SubagentIssueReason | null;
+    selectedVariantPath?: string | null;
+  } = {},
+  agentIndex: Map<string, AgentRecord> = new Map(),
+): InspectorModel {
+  const problemKeys: SubagentIssueReason[] = subagent.issueReasons.length > 0 ? subagent.issueReasons : [];
+  const activeProblem = problemKeys.length > 0
+    ? buildSubagentProblemModel(subagent, selectProblemKey(problemKeys, selection.selectedProblemKey), selection.selectedVariantPath, agentIndex)
+    : buildHealthySubagentProblem(subagent);
+  const selectedVariantPath = getPreferredSelectedVariantPath(selection.selectedVariantPath, activeProblem);
+  const referencePath = getActiveProblemBaselineVariantPath(activeProblem) ?? getCanonicalSubagentPath(subagent);
+  const provenanceRows = buildSubagentProvenanceRows(subagent, selectedVariantPath, referencePath, agentIndex);
+  const provenanceSummary = buildSubagentProvenanceSummary(subagent, selectedVariantPath, referencePath);
+  const definition = buildSubagentDefinitionModel(subagent, selectedVariantPath);
+
+  return {
+    header: {
+      title: getSubagentDisplayName(subagent),
+      description: subagent.description ?? null,
+      updatedLabel: `Updated ${formatCompactDate(subagent.locations[0]?.modifiedAt)}`,
+      metadata: buildMcpMetadataRows(provenanceRows, referencePath, subagent.locations.length),
+      isLocked: hasPluginSubagentLocation(subagent),
+    },
+    definition,
+    locations: buildSubagentLocationSections(subagent, agentIndex),
+    problemCountLabel: formatProblemCount(problemKeys.length),
+    problems: problemKeys.map((key) => ({
+      key,
+      label: formatSubagentIssueReason(key),
+      detail: getSubagentProblemDetail(subagent, key, agentIndex),
+      summary: getSubagentProblemSummary(subagent, key),
       isActive: key === activeProblem.key,
     })),
     problemSections: buildProblemSections(problemKeys),
@@ -714,6 +776,132 @@ function buildMcpProblemModel(
   }
 }
 
+function buildSubagentProblemModel(
+  subagent: SubagentRecord,
+  problemKey: SubagentIssueReason,
+  selectedVariantPath: string | null | undefined,
+  agentIndex: Map<string, AgentRecord>,
+): InspectorActiveProblemModel {
+  switch (problemKey) {
+    case 'missing-universal':
+    case 'definition-mismatch':
+      return buildSubagentVariantProblem(subagent, problemKey, selectedVariantPath, agentIndex);
+    case 'missing-from-agents':
+      return {
+        kind: 'structural-repair',
+        key: problemKey,
+        title: formatSubagentIssueReason(problemKey),
+        listTitle: 'Missing Agent Definitions',
+        items: (subagent.missingLocations ?? []).map((location) => ({
+          id: `${location.agentId}:${location.path ?? location.directoryPath ?? 'missing'}`,
+          label: formatSubagentAgentLabel(location.agentId, agentIndex, location.agentLabel, location.path ?? location.directoryPath),
+          path: location.path ?? location.directoryPath ?? 'Missing subagent path',
+          pathExists: location.path ? undefined : false,
+        })),
+        healthySummary: null,
+        primaryActionLabel: SUBAGENT_ACTION_LABELS.addToAgents,
+      };
+    case 'identical-copies':
+      return {
+        kind: 'structural-repair',
+        key: problemKey,
+        title: formatSubagentIssueReason(problemKey),
+        listTitle: 'Matching Copies',
+        items: subagent.locations
+          .filter((location) => location.fileType === 'real-file' && !location.canonical)
+          .sort(compareSubagentLocationsForDisplay)
+          .map((location) => ({
+            id: location.path,
+            label: formatSubagentAgentLabel(location.agentId, agentIndex, location.agentLabel, location.path),
+            path: location.path,
+          })),
+        healthySummary: null,
+        primaryActionLabel: SUBAGENT_ACTION_LABELS.convertCopiesToSymlinks,
+      };
+    case 'invalid-definition':
+      return {
+        kind: 'structural-repair',
+        key: problemKey,
+        title: formatSubagentIssueReason(problemKey),
+        listTitle: 'Definition Issues',
+        items: subagent.locations.flatMap((location) =>
+          (location.invalidDetails ?? []).map((detail, index) => ({
+            id: `${location.path}:${index}`,
+            label: detail,
+            path: location.path,
+            detail: formatSubagentAgentLabel(location.agentId, agentIndex, location.agentLabel, location.path),
+            snippet: getMcpDefinitionIssueSnippet(location.definitionText),
+          }))),
+        healthySummary: null,
+        primaryActionLabel: null,
+      };
+    case 'broken-symlink':
+    case 'wrong-symlink-target':
+      return buildSubagentSymlinkRepairProblem(subagent, problemKey, agentIndex);
+  }
+}
+
+function buildSubagentVariantProblem(
+  subagent: SubagentRecord,
+  problemKey: 'missing-universal' | 'definition-mismatch',
+  selectedVariantPath: string | null | undefined,
+  agentIndex: Map<string, AgentRecord>,
+): VariantResolutionProblemModel {
+  const groupedVariants = groupSubagentVariants(subagent.locations);
+  const baselineVariant = getSubagentBaselineVariant(groupedVariants, getCanonicalSubagentPath(subagent));
+  const orderedVariants = orderSubagentVariantsForInspector(groupedVariants, baselineVariant);
+  const selectedVariant = selectSubagentVariant(orderedVariants, selectedVariantPath, baselineVariant);
+  const selectedModel = selectedVariant ? mapSubagentVariant(selectedVariant, baselineVariant, selectedVariant, agentIndex) : null;
+  const baselineModel = baselineVariant ? mapSubagentVariant(baselineVariant, baselineVariant, selectedVariant, agentIndex) : null;
+  const diffLines = selectedVariant
+    ? baselineVariant
+      ? buildTextDiffLines(selectedVariant.definitionText, baselineVariant.definitionText)
+      : buildTextPreviewLines(selectedVariant.definitionText)
+    : [];
+
+  return {
+    kind: 'variant-resolution',
+    key: problemKey,
+    title: formatSubagentIssueReason(problemKey),
+    listTitle: 'Detected Definitions',
+    variants: orderedVariants.map((variant) => mapSubagentVariant(variant, baselineVariant, selectedVariant, agentIndex)),
+    changedFiles: [],
+    selectedVariant: selectedModel,
+    baselineVariant: baselineModel,
+    diffTitle: baselineVariant ? 'Diff: Selected Definition vs Universal' : 'Selected Definition Preview',
+    diffLines,
+    diffPath: selectedVariant?.representative.path ?? null,
+    primaryActionLabel: problemKey === 'missing-universal'
+      ? SUBAGENT_ACTION_LABELS.addToUniversal
+      : SUBAGENT_ACTION_LABELS.applySelectedDefinition,
+  };
+}
+
+function buildSubagentSymlinkRepairProblem(
+  subagent: SubagentRecord,
+  problemKey: 'broken-symlink' | 'wrong-symlink-target',
+  agentIndex: Map<string, AgentRecord>,
+): StructuralRepairProblemModel {
+  const affectedLocations = getAffectedSubagentSymlinkRepairLocations(subagent, problemKey);
+
+  return {
+    kind: 'structural-repair',
+    key: problemKey,
+    title: formatSubagentIssueReason(problemKey),
+    listTitle: formatSubagentIssueReason(problemKey),
+    items: affectedLocations.map((location) => ({
+      id: location.path,
+      label: formatSubagentAgentLabel(location.agentId, agentIndex, location.agentLabel, location.path),
+      path: location.path,
+      detail: problemKey === 'wrong-symlink-target'
+        ? getWrongSubagentSymlinkTargetPath(location)
+        : undefined,
+    })),
+    healthySummary: null,
+    primaryActionLabel: SUBAGENT_ACTION_LABELS.repairSymlinks,
+  };
+}
+
 function buildHealthySkillProblem(skill: SkillRecord): StructuralRepairProblemModel {
   return {
     kind: 'structural-repair',
@@ -739,6 +927,25 @@ function buildHealthyMcpProblem(): StructuralRepairProblemModel {
     listTitle: 'Locations',
     items: [],
     healthySummary: 'Defined in every agent the exact same way.',
+    primaryActionLabel: null,
+  };
+}
+
+function buildHealthySubagentProblem(subagent: SubagentRecord): StructuralRepairProblemModel {
+  return {
+    kind: 'structural-repair',
+    key: 'missing-from-agents',
+    title: 'Healthy',
+    listTitle: 'Locations',
+    items: subagent.locations.map((location) => ({
+      id: location.path,
+      label: location.canonical
+        ? 'Universal'
+        : location.agentLabel,
+      path: location.path,
+      detail: location.fileType === 'symlink' ? 'Symlink' : formatAgeLabel(location.modifiedAt),
+    })),
+    healthySummary: 'Defined in Universal and every supported agent location.',
     primaryActionLabel: null,
   };
 }
@@ -780,6 +987,25 @@ function buildMcpDefinitionModel(
     selectedVariantPath: selectedVariant?.representative.configPath ?? null,
     files: buildMcpDefinitionFiles(mcp, selectedVariant),
     emptySummary: 'No readable definition was found for this MCP.',
+  };
+}
+
+function buildSubagentDefinitionModel(
+  subagent: SubagentRecord,
+  selectedVariantPath: string | null,
+): InspectorDefinitionModel {
+  const groupedVariants = groupSubagentVariants(subagent.locations);
+  const baselineVariant = getSubagentBaselineVariant(groupedVariants, getCanonicalSubagentPath(subagent));
+  const orderedVariants = orderSubagentVariantsForInspector(groupedVariants, baselineVariant);
+  const selectedVariant = selectSubagentVariant(orderedVariants, selectedVariantPath, baselineVariant);
+
+  return {
+    listTitle: 'Detected Definitions',
+    variants: orderedVariants.map((variant) => mapSubagentVariant(variant, baselineVariant, selectedVariant, new Map())),
+    selectedVariant: selectedVariant ? mapSubagentVariant(selectedVariant, baselineVariant, selectedVariant, new Map()) : null,
+    selectedVariantPath: selectedVariant?.representative.path ?? null,
+    files: buildSubagentDefinitionFiles(selectedVariant),
+    emptySummary: 'No readable definition was found for this subagent.',
   };
 }
 
@@ -868,6 +1094,26 @@ function buildMcpDefinitionFiles(
         openPath: null,
         kind: 'text',
         text,
+      }]
+    : [];
+}
+
+function buildSubagentDefinitionFiles(
+  selectedVariant: SubagentVariantGroup | null,
+): InspectorDefinitionFileModel[] {
+  if (!selectedVariant) {
+    return [];
+  }
+
+  const location = selectedVariant.representative;
+  const definitionText = normalizeDefinitionText(location.definitionText);
+
+  return definitionText
+    ? [{
+        relativePath: getPathBasename(location.path),
+        absolutePath: location.path,
+        kind: 'text',
+        text: definitionText,
       }]
     : [];
 }
@@ -988,6 +1234,73 @@ function getMcpProblemDetail(mcp: McpRecord, key: McpIssueReason, agentIndex: Ma
   }
 }
 
+function getSubagentProblemSummary(subagent: SubagentRecord, key: SubagentIssueReason): string {
+  switch (key) {
+    case 'missing-universal':
+      return '1 issue';
+    case 'missing-from-agents': {
+      const count = subagent.missingLocations?.length ?? 0;
+      return `${count} agent${count === 1 ? '' : 's'}`;
+    }
+    case 'definition-mismatch': {
+      const count = groupSubagentVariants(subagent.locations).length;
+      return `${count} definition${count === 1 ? '' : 's'}`;
+    }
+    case 'identical-copies': {
+      const count = subagent.locations.filter((location) => location.fileType === 'real-file' && !location.canonical).length;
+      return `${count} cop${count === 1 ? 'y' : 'ies'}`;
+    }
+    case 'invalid-definition': {
+      const count = subagent.locations.reduce((total, location) => total + (location.invalidDetails?.length ?? 0), 0);
+      return `${count} issue${count === 1 ? '' : 's'}`;
+    }
+    case 'broken-symlink':
+    case 'wrong-symlink-target': {
+      const count = getAffectedSubagentSymlinkRepairLocations(subagent, key).length;
+      return `${count} issue${count === 1 ? '' : 's'}`;
+    }
+  }
+}
+
+function getSubagentProblemDetail(
+  subagent: SubagentRecord,
+  key: SubagentIssueReason,
+  agentIndex: Map<string, AgentRecord>,
+): string {
+  switch (key) {
+    case 'missing-universal':
+      return 'Choose the definition to add to Universal';
+    case 'missing-from-agents': {
+      const count = subagent.missingLocations?.length ?? 0;
+      return `${count} agent${count === 1 ? '' : 's'} need this subagent`;
+    }
+    case 'definition-mismatch':
+      return summarizeSubagentDefinitionMismatch(subagent, agentIndex);
+    case 'identical-copies':
+      return 'Convert matching Markdown copies to symlinks';
+    case 'invalid-definition':
+      return 'One or more detected definitions are invalid';
+    case 'broken-symlink':
+      return 'One or more symlinks need repair';
+    case 'wrong-symlink-target':
+      return 'One or more symlinks point somewhere other than Universal';
+  }
+}
+
+function summarizeSubagentDefinitionMismatch(subagent: SubagentRecord, agentIndex: Map<string, AgentRecord>): string {
+  const labels = subagent.locations.map((location) =>
+    formatSubagentAgentLabel(location.agentId, agentIndex, location.agentLabel, location.path));
+  if (labels.length === 0) {
+    return 'Detected definitions differ across agents';
+  }
+
+  const compactLabels = labels.length > 3
+    ? [...labels.slice(0, 3), `${labels.length - 3} more`]
+    : labels;
+
+  return `Definitions differ across ${compactLabels.join(', ')}`;
+}
+
 function summarizeDefinitionMismatch(mcp: McpRecord, agentIndex: Map<string, AgentRecord>): string {
   const labels = mcp.locations.map((location) =>
     formatMcpAgentLabel(location.agentId, agentIndex, location.agentLabel, location.configPath));
@@ -1070,6 +1383,20 @@ function formatMcpAgentLabel(
 ): string {
   const agent = agentIndex.get(agentId);
   if (configPath && isAgentsPath(configPath)) {
+    return 'Universal';
+  }
+
+  return agent?.label ?? stripScopePrefix(fallbackLabel);
+}
+
+function formatSubagentAgentLabel(
+  agentId: string,
+  agentIndex: Map<string, AgentRecord>,
+  fallbackLabel: string,
+  path?: string,
+): string {
+  const agent = agentIndex.get(agentId);
+  if (path && isAgentsPath(path)) {
     return 'Universal';
   }
 
@@ -1662,6 +1989,218 @@ function getMcpLocationIssueState(
   return { tone: 'healthy' };
 }
 
+function buildSubagentLocationSections(
+  subagent: SubagentRecord,
+  agentIndex: Map<string, AgentRecord>,
+): InspectorLocationSectionModel[] {
+  const universalRows = getSubagentUniversalDirectoryRows(subagent);
+  const pluginRows = subagent.locations
+    .filter((location) => location.provenance?.kind === 'plugin')
+    .map((location) => mapSubagentLocationRow(subagent, location, stripScopePrefix(location.agentLabel)));
+  const installedRows = getSubagentAgentEntries(subagent, agentIndex)
+    .filter((entry) => !entry.path || !isAgentsPath(entry.path))
+    .filter((entry) => entry.location?.provenance?.kind !== 'plugin')
+    .map((entry) => {
+      const issue = getSubagentLocationIssueState(subagent, entry);
+      return {
+        id: `${entry.agentId}:${entry.path ?? 'missing'}`,
+        label: entry.label,
+        path: entry.location?.path ?? entry.path ?? null,
+        pathText: entry.location?.path ?? entry.path ?? 'Not configured',
+        statusLabel: issue.statusLabel,
+        tone: issue.tone,
+      };
+    })
+    .sort(compareInspectorLocationRowsByLabel);
+
+  return [
+    {
+      id: 'universal',
+      title: 'Universal Directory',
+      rows: universalRows,
+    },
+    {
+      id: 'plugin-paths',
+      title: 'Plugin Paths',
+      rows: pluginRows,
+    },
+    {
+      id: 'installed-paths',
+      title: 'Installed Paths',
+      rows: installedRows,
+    },
+  ].filter((section) => section.rows.length > 0 || section.id === 'universal');
+}
+
+function getSubagentUniversalDirectoryRows(subagent: SubagentRecord): InspectorLocationRow[] {
+  const universalLocations = subagent.locations.filter((location) => location.canonical || isAgentsPath(location.path));
+  if (universalLocations.length > 0) {
+    return universalLocations.map((location) =>
+      mapSubagentLocationRow(subagent, location, universalLocations.length > 1 ? 'Universal' : null));
+  }
+
+  const expectedUniversal = [...(subagent.expectedLocations ?? []), ...(subagent.missingLocations ?? [])]
+    .find((location) => location.path && isAgentsPath(location.path));
+
+  return [{
+    id: expectedUniversal?.path ?? 'missing-universal-subagent',
+    label: null,
+    path: expectedUniversal?.path ?? null,
+    pathText: expectedUniversal?.path ?? 'Not found',
+    statusLabel: 'Missing Universal',
+    tone: 'muted',
+  }];
+}
+
+function mapSubagentLocationRow(
+  subagent: SubagentRecord,
+  location: SubagentLocationRecord,
+  label: string | null,
+): InspectorLocationRow {
+  const issue = getSubagentLocationIssueState(subagent, {
+    agentId: location.agentId,
+    label: location.canonical ? 'Universal' : location.agentLabel,
+    path: location.path,
+    location,
+  });
+
+  return {
+    id: location.path,
+    label,
+    path: location.path,
+    pathText: location.path,
+    statusLabel: issue.statusLabel,
+    tone: issue.tone,
+  };
+}
+
+function getSubagentAgentEntries(
+  subagent: SubagentRecord,
+  agentIndex: Map<string, AgentRecord>,
+): Array<{
+  agentId: string;
+  label: string;
+  path?: string;
+  supportStatus?: 'supported' | 'unsupported';
+  unsupportedReason?: 'not-documented' | 'unsupported-format' | 'account-managed';
+  location: SubagentLocationRecord | null;
+}> {
+  const locationsByAgent = new Map(subagent.locations.map((location) => [location.agentId, location]));
+  const entries = new Map<string, {
+    agentId: string;
+    label: string;
+    path?: string;
+    supportStatus?: 'supported' | 'unsupported';
+    unsupportedReason?: 'not-documented' | 'unsupported-format' | 'account-managed';
+    location: SubagentLocationRecord | null;
+  }>();
+
+  for (const expected of subagent.expectedLocations ?? []) {
+    entries.set(expected.agentId, {
+      agentId: expected.agentId,
+      label: expected.agentLabel,
+      path: expected.path ?? expected.directoryPath,
+      supportStatus: expected.supportStatus,
+      unsupportedReason: expected.unsupportedReason,
+      location: locationsByAgent.get(expected.agentId) ?? null,
+    });
+  }
+
+  for (const location of subagent.locations) {
+    if (!entries.has(location.agentId)) {
+      entries.set(location.agentId, {
+        agentId: location.agentId,
+        label: location.agentLabel,
+        path: location.path,
+        location,
+      });
+    }
+  }
+
+  for (const missing of subagent.missingLocations ?? []) {
+    if (!entries.has(missing.agentId)) {
+      entries.set(missing.agentId, {
+        agentId: missing.agentId,
+        label: missing.agentLabel,
+        path: missing.path ?? missing.directoryPath,
+        supportStatus: missing.supportStatus,
+        unsupportedReason: missing.unsupportedReason,
+        location: null,
+      });
+    }
+  }
+
+  return [...entries.values()].map((entry) => ({
+    ...entry,
+    label: formatSubagentAgentLabel(entry.agentId, agentIndex, entry.label, entry.path),
+  }));
+}
+
+function getSubagentLocationIssueState(
+  subagent: SubagentRecord,
+  entry: {
+    agentId?: string;
+    label?: string;
+    path?: string;
+    supportStatus?: 'supported' | 'unsupported';
+    unsupportedReason?: 'not-documented' | 'unsupported-format' | 'account-managed';
+    location: SubagentLocationRecord | null;
+  },
+): { statusLabel?: string; tone: InspectorLocationTone } {
+  if (entry.supportStatus === 'unsupported') {
+    return {
+      statusLabel: formatSubagentUnsupportedLocationStatus(entry.unsupportedReason),
+      tone: 'muted',
+    };
+  }
+
+  const location = entry.location;
+  if (!location) {
+    return { statusLabel: 'Missing From Agent', tone: 'muted' };
+  }
+
+  if ((location.invalidDetails?.length ?? 0) > 0) {
+    return { statusLabel: 'Invalid Definition', tone: 'danger' };
+  }
+
+  if (location.fileType === 'symlink') {
+    if (subagent.issueReasons.includes('broken-symlink') && !location.resolvedPath) {
+      return { statusLabel: 'Broken Symlink', tone: 'danger' };
+    }
+
+    if (subagent.issueReasons.includes('wrong-symlink-target') && isWrongSubagentSymlinkTarget(subagent, location)) {
+      return { statusLabel: 'Wrong Target', tone: 'warning' };
+    }
+
+    return { statusLabel: 'symlink', tone: 'healthy' };
+  }
+
+  if (!location.canonical && subagent.issueReasons.includes('definition-mismatch') && isSubagentDefinitionMismatch(subagent, location)) {
+    return { statusLabel: 'Definition Mismatch', tone: 'warning' };
+  }
+
+  if (!location.canonical && subagent.issueReasons.includes('identical-copies')) {
+    return { statusLabel: 'Identical Copy', tone: 'warning' };
+  }
+
+  return { tone: 'healthy' };
+}
+
+function formatSubagentUnsupportedLocationStatus(
+  reason?: 'not-documented' | 'unsupported-format' | 'account-managed',
+): string {
+  switch (reason) {
+    case 'account-managed':
+      return 'Account managed';
+    case 'not-documented':
+      return 'Not documented';
+    case 'unsupported-format':
+      return 'Unsupported format';
+    case undefined:
+      return 'Unsupported';
+  }
+}
+
 function formatMcpUnsupportedLocationStatus(entry: {
   unsupportedReason?: 'remote-mcp-not-supported' | 'transport-not-supported';
   unsupportedTransport?: McpTransportKind;
@@ -1748,6 +2287,35 @@ function mapMcpVariant(
       path: location.configPath,
     })),
     updatedLabel: summarizeMcpCommand(representative),
+    definitionText: variant.definitionText,
+  };
+}
+
+function mapSubagentVariant(
+  variant: SubagentVariantGroup,
+  baselineVariant: SubagentVariantGroup | null,
+  selectedVariant: SubagentVariantGroup | null,
+  agentIndex: Map<string, AgentRecord>,
+): InspectorVariantModel {
+  const representative = variant.representative;
+  const badge = representative.path === baselineVariant?.representative.path
+    ? 'Universal'
+    : representative.path === selectedVariant?.representative.path
+      ? 'Selected Version'
+      : undefined;
+
+  return {
+    id: variant.id,
+    path: representative.path,
+    label: formatSubagentAgentLabel(representative.agentId, agentIndex, representative.agentLabel, representative.path),
+    secondaryLabel: representative.path,
+    badge,
+    isBaseline: representative.path === baselineVariant?.representative.path,
+    locations: variant.locations.map((location) => ({
+      label: formatSubagentAgentLabel(location.agentId, agentIndex, location.agentLabel, location.path),
+      path: location.path,
+    })),
+    updatedLabel: formatAgeLabel(representative.modifiedAt),
     definitionText: variant.definitionText,
   };
 }
@@ -2222,6 +2790,38 @@ function groupMcpVariants(locations: McpLocationRecord[]): McpVariantGroup[] {
   });
 }
 
+function groupSubagentVariants(locations: SubagentLocationRecord[]): SubagentVariantGroup[] {
+  const groups = new Map<string, SubagentLocationRecord[]>();
+
+  for (const location of locations.filter(isReadableSubagentVariantLocation)) {
+    const definitionText = normalizeDefinitionText(location.definitionText);
+    const key = location.definitionComparisonKey ?? (definitionText ? `text:${hashStableString(definitionText)}` : `path:${location.path}`);
+    const existing = groups.get(key) ?? [];
+    existing.push(location);
+    groups.set(key, existing);
+  }
+
+  return [...groups.entries()].map(([id, groupedLocations]) => {
+    const sortedLocations = groupedLocations.slice().sort(compareSubagentLocationsForDisplay);
+    const representative = sortedLocations[0];
+    if (!representative) {
+      throw new Error(`Expected a representative location for subagent variant group ${id}.`);
+    }
+
+    return {
+      id,
+      definitionText: normalizeDefinitionText(representative.definitionText),
+      locations: sortedLocations,
+      representative,
+    };
+  });
+}
+
+function isReadableSubagentVariantLocation(location: SubagentLocationRecord): boolean {
+  return (location.invalidDetails?.length ?? 0) === 0
+    && (location.fileType === 'real-file' || Boolean(normalizeDefinitionText(location.definitionText)));
+}
+
 const MCP_BREAKDOWN_FIELD_ORDER = [
   'transport',
   'command',
@@ -2532,6 +3132,22 @@ function selectMcpVariant(
   return agentsVariant ?? baselineVariant ?? variants[0] ?? null;
 }
 
+function selectSubagentVariant(
+  variants: SubagentVariantGroup[],
+  selectedVariantPath: string | null | undefined,
+  baselineVariant: SubagentVariantGroup | null,
+): SubagentVariantGroup | null {
+  if (selectedVariantPath) {
+    const selectedVariant = variants.find((variant) => variant.locations.some((location) => location.path === selectedVariantPath));
+    if (selectedVariant) {
+      return withSubagentRepresentativeOverride(selectedVariant, selectedVariantPath);
+    }
+  }
+
+  const agentsVariant = variants.find((variant) => isAgentsPath(variant.representative.path));
+  return agentsVariant ?? baselineVariant ?? variants[0] ?? null;
+}
+
 function withSkillRepresentativeOverride(variant: SkillVariantGroup, selectedPath: string): SkillVariantGroup {
   const representative = variant.locations.find((location) => location.path === selectedPath) ?? variant.representative;
   return {
@@ -2542,6 +3158,14 @@ function withSkillRepresentativeOverride(variant: SkillVariantGroup, selectedPat
 
 function withMcpRepresentativeOverride(variant: McpVariantGroup, selectedPath: string): McpVariantGroup {
   const representative = variant.locations.find((location) => location.configPath === selectedPath) ?? variant.representative;
+  return {
+    ...variant,
+    representative,
+  };
+}
+
+function withSubagentRepresentativeOverride(variant: SubagentVariantGroup, selectedPath: string): SubagentVariantGroup {
+  const representative = variant.locations.find((location) => location.path === selectedPath) ?? variant.representative;
   return {
     ...variant,
     representative,
@@ -2562,6 +3186,23 @@ function getMcpBaselineVariant(
   }
 
   return variants[0] ?? null;
+}
+
+function getSubagentBaselineVariant(
+  variants: SubagentVariantGroup[],
+  canonicalPath: string | null,
+): SubagentVariantGroup | null {
+  if (canonicalPath) {
+    const canonicalVariant = variants.find((variant) =>
+      variant.locations.some((location) => location.path === canonicalPath),
+    );
+    if (canonicalVariant) {
+      return withSubagentRepresentativeOverride(canonicalVariant, canonicalPath);
+    }
+  }
+
+  const agentsVariant = variants.find((variant) => isAgentsPath(variant.representative.path));
+  return agentsVariant ?? variants[0] ?? null;
 }
 
 function getSkillBaselineVariant(
@@ -2612,6 +3253,16 @@ function orderMcpVariantsForInspector(
   );
 }
 
+function orderSubagentVariantsForInspector(
+  variants: SubagentVariantGroup[],
+  baselineVariant: SubagentVariantGroup | null,
+): SubagentVariantGroup[] {
+  return orderVariantsForInspector(
+    variants,
+    baselineVariant?.id ?? null,
+  );
+}
+
 function orderVariantsForInspector<T extends { id: string }>(
   variants: T[],
   baselineId: string | null,
@@ -2653,7 +3304,10 @@ function buildProblemSections(problemKeys: InspectorProblemKey[]): InspectorProb
 }
 
 function isVariantResolutionProblemKey(problemKey: InspectorProblemKey): boolean {
-  return problemKey === 'diverged-copies' || problemKey === 'missing-canonical' || problemKey === 'definition-mismatch';
+  return problemKey === 'diverged-copies'
+    || problemKey === 'missing-canonical'
+    || problemKey === 'missing-universal'
+    || problemKey === 'definition-mismatch';
 }
 
 function getActiveProblemSelectedVariantPath(problem: InspectorActiveProblemModel): string | null {
@@ -2818,6 +3472,93 @@ function buildMcpProvenanceSummary(
   return buildSourceSummaryRows(location?.provenance);
 }
 
+function buildSubagentProvenanceRows(
+  subagent: SubagentRecord,
+  selectedVariantPath: string | null,
+  referencePath: string | null,
+  agentIndex: Map<string, AgentRecord>,
+): InspectorProvenanceRow[] {
+  return subagent.locations
+    .slice()
+    .sort(compareSubagentLocationsForDisplay)
+    .map((location) => ({
+      id: `${location.agentId}:${location.path}`,
+      label: location.path === selectedVariantPath
+        ? 'Selected definition'
+        : location.path === referencePath
+          ? 'Reference definition'
+          : 'Definition',
+      sourceLabel: formatSubagentAgentLabel(location.agentId, agentIndex, location.agentLabel, location.path),
+      path: location.path,
+      detail: location.fileType === 'symlink'
+        ? location.symlinkTarget ?? location.resolvedPath ?? 'Linked copy'
+        : formatAgeLabel(location.modifiedAt),
+      isSelected: location.path === selectedVariantPath,
+      isCanonical: location.path === referencePath,
+    }));
+}
+
+function buildSubagentProvenanceSummary(
+  subagent: SubagentRecord,
+  selectedVariantPath: string | null,
+  referencePath: string | null,
+): InspectorProvenanceSummaryRow[] {
+  const pluginLocations = subagent.locations.filter((entry) =>
+    entry.provenance?.kind === 'plugin' && entry.provenance.plugin);
+  const hasManualLocations = subagent.locations.some((entry) => entry.provenance?.kind !== 'plugin');
+  if (pluginLocations.length > 0 && hasManualLocations) {
+    return buildMixedSubagentSourceSummaryRows(pluginLocations);
+  }
+
+  let location: SubagentLocationRecord | null = null;
+  if (selectedVariantPath) {
+    location = subagent.locations.find((entry) => entry.path === selectedVariantPath) ?? null;
+  }
+  if (!location && referencePath) {
+    location = subagent.locations.find((entry) => entry.path === referencePath) ?? null;
+  }
+  location ??= subagent.locations[0] ?? null;
+
+  return buildSourceSummaryRows(location?.provenance);
+}
+
+function buildMixedSubagentSourceSummaryRows(pluginLocations: SubagentLocationRecord[]): InspectorProvenanceSummaryRow[] {
+  const uniquePlugins = new Map<string, NonNullable<SkillProvenance['plugin']>>();
+  for (const location of pluginLocations) {
+    const plugin = location.provenance?.plugin;
+    if (!plugin) {
+      continue;
+    }
+    uniquePlugins.set(`${plugin.host}:${plugin.pluginId}:${plugin.version ?? ''}`, plugin);
+  }
+
+  const [plugin] = uniquePlugins.values();
+  return [
+    {
+      id: 'source-type',
+      label: 'Source Type',
+      value: 'Plugin + Manual',
+    },
+    ...(plugin
+      ? [{
+          id: 'source',
+          label: 'Source' as const,
+          value: uniquePlugins.size === 1 ? plugin.pluginId : `${uniquePlugins.size} plugin sources`,
+          ...(uniquePlugins.size === 1
+            ? {
+                action: {
+                  kind: 'plugin' as const,
+                  host: plugin.host,
+                  pluginId: plugin.pluginId,
+                  version: plugin.version,
+                },
+              }
+            : {}),
+        }]
+      : []),
+  ];
+}
+
 function buildMixedMcpSourceSummaryRows(pluginLocations: McpLocationRecord[]): InspectorProvenanceSummaryRow[] {
   const uniquePlugins = new Map<string, NonNullable<SkillProvenance['plugin']>>();
   for (const location of pluginLocations) {
@@ -2970,6 +3711,10 @@ function hasPluginMcpLocation(mcp: McpRecord): boolean {
   return mcp.locations.some((location) => location.provenance?.kind === 'plugin');
 }
 
+function hasPluginSubagentLocation(subagent: SubagentRecord): boolean {
+  return subagent.locations.some((location) => location.provenance?.kind === 'plugin');
+}
+
 function compareSkillLocationForProvenance(left: SkillLocationRecord, right: SkillLocationRecord): number {
   if (left.canonical !== right.canonical) {
     return left.canonical ? -1 : 1;
@@ -2981,6 +3726,10 @@ function compareSkillLocationForProvenance(left: SkillLocationRecord, right: Ski
 
 function getCanonicalSkillPath(skill: SkillRecord): string | null {
   return skill.locations.find((location) => location.canonical)?.path ?? null;
+}
+
+function getCanonicalSubagentPath(subagent: SubagentRecord): string | null {
+  return subagent.locations.find((location) => location.canonical)?.path ?? null;
 }
 
 function getMcpReferencePath(mcp: McpRecord): string | null {
@@ -3080,6 +3829,59 @@ function resolveSkillInstallAgent(
   }
 
   return null;
+}
+
+function compareSubagentLocationsForDisplay(left: SubagentLocationRecord, right: SubagentLocationRecord): number {
+  if (left.canonical !== right.canonical) {
+    return left.canonical ? -1 : 1;
+  }
+
+  const modifiedDifference = new Date(right.modifiedAt).getTime() - new Date(left.modifiedAt).getTime();
+  return modifiedDifference || left.path.localeCompare(right.path);
+}
+
+function getAffectedSubagentSymlinkRepairLocations(
+  subagent: SubagentRecord,
+  problemKey: 'broken-symlink' | 'wrong-symlink-target',
+): SubagentLocationRecord[] {
+  return subagent.locations.filter((location) => {
+    if (location.canonical || location.fileType !== 'symlink') {
+      return false;
+    }
+
+    if (problemKey === 'broken-symlink') {
+      return !location.resolvedPath;
+    }
+
+    return isWrongSubagentSymlinkTarget(subagent, location);
+  });
+}
+
+function getWrongSubagentSymlinkTargetPath(location: SubagentLocationRecord): string {
+  return location.symlinkTarget ?? location.resolvedPath ?? 'Missing target';
+}
+
+function isWrongSubagentSymlinkTarget(subagent: SubagentRecord, location: SubagentLocationRecord): boolean {
+  const canonicalPath = getCanonicalSubagentPath(subagent);
+  if (!canonicalPath) {
+    return Boolean(location.symlinkTarget || location.resolvedPath);
+  }
+
+  return location.resolvedPath !== canonicalPath && location.symlinkTarget !== canonicalPath;
+}
+
+function isSubagentDefinitionMismatch(subagent: SubagentRecord, location: SubagentLocationRecord): boolean {
+  const canonicalLocation = subagent.locations.find((candidate) => candidate.canonical) ?? subagent.locations[0] ?? null;
+  if (!canonicalLocation || canonicalLocation.path === location.path) {
+    return false;
+  }
+
+  return getSubagentLocationComparisonKey(canonicalLocation) !== getSubagentLocationComparisonKey(location);
+}
+
+function getSubagentLocationComparisonKey(location: Pick<SubagentLocationRecord, 'definitionComparisonKey' | 'definitionText' | 'path'>): string {
+  const definitionText = normalizeDefinitionText(location.definitionText);
+  return location.definitionComparisonKey ?? (definitionText ? `text:${hashStableString(definitionText)}` : `path:${location.path}`);
 }
 
 function stripScopePrefix(label: string): string {

--- a/src/renderer/src/lib/inventory-presentation.ts
+++ b/src/renderer/src/lib/inventory-presentation.ts
@@ -7,11 +7,15 @@ import type {
   SkillInventorySnapshot,
   SkillIssueReason,
   SkillRecord,
+  SubagentIssueReason,
+  SubagentPresentation,
+  SubagentRecord,
 } from '@shared/contracts';
 
 type InventoryStatusFilter = 'all';
 export type SkillStatusFilter = InventoryStatusFilter | SkillDriftPresentation;
 export type McpStatusFilter = InventoryStatusFilter | McpPresentation;
+export type SubagentStatusFilter = InventoryStatusFilter | SubagentPresentation;
 
 export function compareNewestCandidate(
   left: SkillRecord['detailDiagnostics']['duplicateCandidates'][number],
@@ -51,6 +55,18 @@ export function getPillToneForMcp(mcp: McpRecord): 'attention' | 'healthy' | 'mu
   }
 
   if (mcp.status === 'healthy') {
+    return 'healthy';
+  }
+
+  return 'attention';
+}
+
+export function getPillToneForSubagent(subagent: SubagentRecord): 'attention' | 'healthy' | 'muted' {
+  if (subagent.presentation === 'dismissed') {
+    return 'muted';
+  }
+
+  if (subagent.status === 'healthy') {
     return 'healthy';
   }
 
@@ -276,6 +292,33 @@ export function getMcpStatusLabels(mcp: McpRecord): string[] {
   return ['Healthy'];
 }
 
+export function getSubagentStatusLabels(subagent: SubagentRecord): string[] {
+  if (subagent.issueReasons.length > 0) {
+    return subagent.issueReasons.map(formatSubagentIssueReason);
+  }
+
+  return ['Healthy'];
+}
+
+export function formatSubagentIssueReason(reason: SubagentIssueReason): string {
+  switch (reason) {
+    case 'missing-universal':
+      return 'Missing Universal';
+    case 'missing-from-agents':
+      return 'Missing From Agents';
+    case 'definition-mismatch':
+      return 'Definition Mismatch';
+    case 'identical-copies':
+      return 'Identical Copies';
+    case 'broken-symlink':
+      return 'Broken Symlink';
+    case 'wrong-symlink-target':
+      return 'Wrong Symlink Target';
+    case 'invalid-definition':
+      return 'Invalid Definition';
+  }
+}
+
 function compareSkillIssueReasons(left: SkillIssueReason, right: SkillIssueReason): number {
   return getSkillIssueRank(left) - getSkillIssueRank(right);
 }
@@ -316,6 +359,14 @@ export function getSkillRowDescription(skill: SkillRecord): string {
 }
 
 export function filterMcpRowsByStatus(rows: McpRecord[], filter: McpStatusFilter): McpRecord[] {
+  if (filter === 'all') {
+    return rows;
+  }
+
+  return rows.filter((row) => row.presentation === filter);
+}
+
+export function filterSubagentRowsByStatus(rows: SubagentRecord[], filter: SubagentStatusFilter): SubagentRecord[] {
   if (filter === 'all') {
     return rows;
   }

--- a/src/renderer/src/lib/issue-resolution.test.ts
+++ b/src/renderer/src/lib/issue-resolution.test.ts
@@ -1,13 +1,15 @@
-import type { AgentMcpParserKind, McpRecord, SkillInventorySnapshot, SkillRecord } from '@shared/contracts';
+import type { AgentMcpParserKind, McpRecord, SkillInventorySnapshot, SkillRecord, SubagentRecord } from '@shared/contracts';
 import { describe, expect, it } from 'vitest';
 
 import { representativeInventorySnapshot } from '../representative-preview-data';
-import { buildMcpInspectorModel, buildSkillInspectorModel } from './detail-inspector-model';
+import { buildMcpInspectorModel, buildSkillInspectorModel, buildSubagentInspectorModel } from './detail-inspector-model';
 import {
   getAutoResolvableMcpRequests,
   getAutoResolvableSkillRequests,
+  getAutoResolvableSubagentRequests,
   getMcpResolveActionState,
   getSkillResolveActionState,
+  getSubagentResolveActionState,
 } from './issue-resolution';
 
 const sourceIndex = new Map(representativeInventorySnapshot.sources.map((source) => [source.id, source]));
@@ -19,6 +21,14 @@ function findRepresentativeMcp(name: string): McpRecord {
     throw new Error(`Missing representative MCP fixture: ${name}`);
   }
   return mcp;
+}
+
+function findRepresentativeSubagent(name: string): SubagentRecord {
+  const subagent = representativeInventorySnapshot.subagents?.find((entry) => entry.name === name);
+  if (!subagent) {
+    throw new Error(`Missing representative subagent fixture: ${name}`);
+  }
+  return subagent;
 }
 
 describe('issue resolution request builder', () => {
@@ -153,6 +163,27 @@ describe('issue resolution request builder', () => {
         selectedVariantPath: '~/.skillindex/sandbox/.agents/mcp.json',
       },
     ]);
+  });
+
+  it('includes supported missing-from-agents subagent repairs in Home auto-resolve batches', () => {
+    expect(getAutoResolvableSubagentRequests(representativeInventorySnapshot)).toEqual([
+      {
+        entity: 'subagent',
+        issue: 'missing-from-agents',
+        subagentName: 'reviewer',
+        selectedVariantPath: '~/.skillindex/sandbox/.agents/agents/reviewer.md',
+      },
+    ]);
+  });
+
+  it('keeps plugin-owned subagent repairs out of Home auto-resolve batches', () => {
+    const pluginSubagent = findRepresentativeSubagent('sandbox-plugin-pack:deployment-expert');
+    const snapshot: SkillInventorySnapshot = {
+      ...representativeInventorySnapshot,
+      subagents: [pluginSubagent],
+    };
+
+    expect(getAutoResolvableSubagentRequests(snapshot)).toEqual([]);
   });
 
   it('keeps plugin-owned missing-from-agents MCP repairs out of Home auto-resolve batches', () => {
@@ -931,6 +962,129 @@ describe('issue resolution request builder', () => {
         mcpName: 'missing-from-agents-mcp',
         selectedVariantPath: '/Users/tester/.claude.json',
       },
+    });
+  });
+
+  it('auto-selects the canonical subagent definition for missing-from-agents', () => {
+    const subagent = findRepresentativeSubagent('reviewer');
+    const model = buildSubagentInspectorModel(subagent, {
+      selectedProblemKey: 'missing-from-agents',
+      selectedVariantPath: null,
+    }, agentIndex);
+
+    expect(getSubagentResolveActionState(subagent, model, representativeInventorySnapshot)).toEqual({
+      disabledReason: null,
+      request: {
+        entity: 'subagent',
+        issue: 'missing-from-agents',
+        subagentName: 'reviewer',
+        selectedVariantPath: '~/.skillindex/sandbox/.agents/agents/reviewer.md',
+      },
+    });
+  });
+
+  it('allows subagent repairs for YAML targets', () => {
+    const baseSubagent = findRepresentativeSubagent('reviewer');
+    const targetAgentId = 'target-yaml-subagent';
+    const subagent: SubagentRecord = {
+      ...baseSubagent,
+      missingLocations: [{
+        agentId: targetAgentId,
+        agentLabel: 'YAML Agent',
+        scope: 'live',
+        directoryPath: '/Users/tester/yaml/agents',
+        path: '/Users/tester/yaml/agents/reviewer.yaml',
+        format: 'yaml',
+        supportStatus: 'supported',
+      }],
+    };
+    const baseAgent = representativeInventorySnapshot.agents!.find((agent) => agent.id === 'sandbox-codex')!;
+    const snapshot: SkillInventorySnapshot = {
+      ...representativeInventorySnapshot,
+      subagents: [subagent],
+      agents: [
+        ...(representativeInventorySnapshot.agents ?? []),
+        {
+          ...baseAgent,
+          id: targetAgentId,
+          label: 'YAML Agent',
+          scope: 'live',
+          writable: true,
+          installState: 'installed',
+          subagentParserKind: 'yaml',
+          subagentsLocation: {
+            state: 'available',
+            path: '/Users/tester/yaml/agents',
+            displayPath: '/Users/tester/yaml/agents',
+            exists: true,
+          },
+        },
+      ],
+    };
+    const localAgentIndex = new Map((snapshot.agents ?? []).map((agent) => [agent.id, agent]));
+    const model = buildSubagentInspectorModel(subagent, {
+      selectedProblemKey: 'missing-from-agents',
+      selectedVariantPath: null,
+    }, localAgentIndex);
+
+    expect(getSubagentResolveActionState(subagent, model, snapshot)).toEqual({
+      disabledReason: null,
+      request: {
+        entity: 'subagent',
+        issue: 'missing-from-agents',
+        subagentName: 'reviewer',
+        selectedVariantPath: '~/.skillindex/sandbox/.agents/agents/reviewer.md',
+      },
+    });
+  });
+
+  it('keeps subagent repairs disabled for installed agents with unsupported parser kinds', () => {
+    const baseSubagent = findRepresentativeSubagent('reviewer');
+    const targetAgentId = 'target-unknown-subagent';
+    const subagent: SubagentRecord = {
+      ...baseSubagent,
+      missingLocations: [{
+        agentId: targetAgentId,
+        agentLabel: 'Unknown Agent',
+        scope: 'live',
+        directoryPath: '/Users/tester/unknown/agents',
+        path: '/Users/tester/unknown/agents/reviewer.agent',
+        format: 'unknown',
+        supportStatus: 'supported',
+      }],
+    };
+    const baseAgent = representativeInventorySnapshot.agents!.find((agent) => agent.id === 'sandbox-codex')!;
+    const snapshot: SkillInventorySnapshot = {
+      ...representativeInventorySnapshot,
+      subagents: [subagent],
+      agents: [
+        ...(representativeInventorySnapshot.agents ?? []),
+        {
+          ...baseAgent,
+          id: targetAgentId,
+          label: 'Unknown Agent',
+          scope: 'live',
+          writable: true,
+          installState: 'installed',
+          subagentParserKind: 'unknown',
+          subagentsLocation: {
+            state: 'available',
+            path: '/Users/tester/unknown/agents',
+            displayPath: '/Users/tester/unknown/agents',
+            exists: true,
+          },
+        },
+      ],
+    };
+    const localAgentIndex = new Map((snapshot.agents ?? []).map((agent) => [agent.id, agent]));
+    const model = buildSubagentInspectorModel(subagent, {
+      selectedProblemKey: 'missing-from-agents',
+      selectedVariantPath: null,
+    }, localAgentIndex);
+
+    expect(getSubagentResolveActionState(subagent, model, snapshot)).toEqual({
+      disabledReason: 'This subagent can only be resolved when every target location is writable and uses a supported format.',
+      request: null,
     });
   });
 

--- a/src/renderer/src/lib/issue-resolution.ts
+++ b/src/renderer/src/lib/issue-resolution.ts
@@ -8,7 +8,13 @@ import type {
   SkillRecord,
   SkillResolvableIssue,
   SkillScanSource,
+  SubagentRecord,
+  SubagentResolvableIssue,
 } from '@shared/contracts';
+import {
+  isMarkdownSubagentSymlinkCompatible,
+  isSupportedSubagentDirectoryFormat,
+} from '@shared/subagent-format-policy';
 
 import type { InspectorModel } from './detail-inspector-model';
 import { getDisplaySkillIssueReasons } from './inventory-presentation';
@@ -31,6 +37,15 @@ const SKILL_RESOLVABLE_ISSUES = new Set([
 const MCP_RESOLVABLE_ISSUES = new Set([
   'definition-mismatch',
   'missing-from-agents',
+] as const);
+
+const SUBAGENT_RESOLVABLE_ISSUES = new Set([
+  'missing-universal',
+  'missing-from-agents',
+  'definition-mismatch',
+  'identical-copies',
+  'broken-symlink',
+  'wrong-symlink-target',
 ] as const);
 
 export function getSkillResolveActionState(
@@ -138,6 +153,56 @@ export function getMcpResolveActionState(
   };
 }
 
+export function getSubagentResolveActionState(
+  subagent: SubagentRecord,
+  inspectorModel: InspectorModel | null,
+  snapshot: SkillInventorySnapshot | null,
+): ResolveActionState {
+  const activeProblem = inspectorModel?.activeProblem ?? null;
+  if (!activeProblem || !activeProblem.primaryActionLabel || !isSubagentResolvableIssue(activeProblem.key)) {
+    return {
+      disabledReason: null,
+      request: null,
+    };
+  }
+
+  if (!snapshot) {
+    return {
+      disabledReason: 'Subagent inventory is still loading.',
+      request: null,
+    };
+  }
+
+  const selectedVariantPath = getSubagentSelectedVariantPath(
+    subagent,
+    inspectorModel?.selectedVariantPath ?? null,
+  );
+  if (!selectedVariantPath) {
+    return {
+      disabledReason: 'Choose a subagent definition before resolving this issue.',
+      request: null,
+    };
+  }
+
+  const targetabilityBlocker = getSubagentTargetabilityBlocker(subagent, activeProblem.key, selectedVariantPath, snapshot);
+  if (targetabilityBlocker) {
+    return {
+      disabledReason: targetabilityBlocker,
+      request: null,
+    };
+  }
+
+  return {
+    disabledReason: null,
+    request: {
+      entity: 'subagent',
+      issue: activeProblem.key,
+      subagentName: subagent.name,
+      selectedVariantPath,
+    },
+  };
+}
+
 function isWritableSupportedMcpTarget(
   location: McpRecord['locations'][number] | NonNullable<McpRecord['missingLocations']>[number],
   snapshot: SkillInventorySnapshot,
@@ -158,6 +223,111 @@ function isWritableSupportedMcpTarget(
     && agent.mcpConfigLocation.state === 'available'
     && SUPPORTED_MCP_PARSER_KINDS.has((agent.mcpParserKind ?? 'json-servers') as never),
   );
+}
+
+type SubagentResolutionTarget =
+  | SubagentRecord['locations'][number]
+  | NonNullable<SubagentRecord['missingLocations']>[number];
+
+function getSubagentTargetabilityBlocker(
+  subagent: SubagentRecord,
+  issue: SubagentResolvableIssue,
+  selectedVariantPath: string,
+  snapshot: SkillInventorySnapshot,
+): string | null {
+  const targetLocations = getSubagentResolutionTargets(subagent, issue, selectedVariantPath, snapshot);
+  if (targetLocations.length === 0) {
+    return null;
+  }
+
+  const allTargetsWritable = targetLocations.every((location) =>
+    isWritableSupportedSubagentTarget(location, snapshot));
+  return allTargetsWritable
+    ? null
+    : 'This subagent can only be resolved when every target location is writable and uses a supported format.';
+}
+
+function getSubagentResolutionTargets(
+  subagent: SubagentRecord,
+  issue: SubagentResolvableIssue,
+  selectedVariantPath: string,
+  snapshot: SkillInventorySnapshot,
+): SubagentResolutionTarget[] {
+  const canonicalLocation = subagent.locations.find((location) =>
+    location.canonical
+    && location.fileType === 'real-file'
+    && (location.invalidDetails?.length ?? 0) === 0);
+  const selectedLocation = subagent.locations.find((location) => location.path === selectedVariantPath);
+
+  switch (issue) {
+    case 'missing-universal':
+      return [];
+    case 'missing-from-agents':
+      return subagent.missingLocations ?? [];
+    case 'identical-copies':
+      return subagent.locations.filter((location) =>
+        location.fileType === 'real-file'
+        && !location.canonical
+        && location.format === 'markdown-frontmatter'
+        && isMarkdownSubagentSymlinkCompatible(findSubagentAgent(snapshot, location.agentId)?.family)
+        && !hasSubagentLocalExtras(location)
+        && location.definitionComparisonKey === canonicalLocation?.definitionComparisonKey);
+    case 'broken-symlink':
+      return subagent.locations.filter((location) =>
+        location.fileType === 'symlink'
+        && !location.canonical
+        && location.resolvedPath === undefined);
+    case 'wrong-symlink-target':
+      return subagent.locations.filter((location) =>
+        location.fileType === 'symlink'
+        && !location.canonical
+        && location.resolvedPath !== undefined
+        && canonicalLocation
+        && location.resolvedPath !== canonicalLocation.path);
+    case 'definition-mismatch':
+      return subagent.locations.filter((location) =>
+        location.fileType === 'real-file'
+        && !location.canonical
+        && location.path !== selectedVariantPath
+        && location.definitionComparisonKey !== selectedLocation?.definitionComparisonKey);
+  }
+}
+
+function isWritableSupportedSubagentTarget(
+  location: SubagentResolutionTarget,
+  snapshot: SkillInventorySnapshot,
+): boolean {
+  if (!location.path) {
+    return false;
+  }
+
+  const format = location.format ?? findSubagentAgent(snapshot, location.agentId)?.subagentParserKind ?? 'unknown';
+  if (!isSupportedSubagentDirectoryFormat(format)) {
+    return false;
+  }
+
+  if ('fileType' in location) {
+    if (location.canonical) {
+      return true;
+    }
+    return location.mutability === 'writable' && !location.agentId.startsWith('plugin:');
+  }
+
+  const agent = findSubagentAgent(snapshot, location.agentId);
+  return Boolean(
+    agent
+    && agent.writable
+    && agent.subagentsLocation?.state === 'available'
+    && agent.subagentsLocation.path,
+  );
+}
+
+function findSubagentAgent(snapshot: SkillInventorySnapshot, agentId: string) {
+  return (snapshot.agents ?? []).find((entry) => entry.id === agentId);
+}
+
+function hasSubagentLocalExtras(location: { localExtrasKeys?: string[] }): boolean {
+  return (location.localExtrasKeys?.length ?? 0) > 0;
 }
 
 function hasCanonicalRealFile(skill: SkillRecord): boolean {
@@ -234,6 +404,33 @@ function getMcpSelectedVariantPath(mcp: McpRecord, selectedVariantPath: string |
   return getDistinctMcpVariantCount(mcp) === 1 ? mcp.locations[0]?.configPath ?? null : null;
 }
 
+function getSubagentSelectedVariantPath(subagent: SubagentRecord, selectedVariantPath: string | null): string | null {
+  if (selectedVariantPath && subagent.locations.some((location) =>
+    location.path === selectedVariantPath
+    && location.fileType === 'real-file'
+    && (location.invalidDetails?.length ?? 0) === 0)) {
+    return selectedVariantPath;
+  }
+
+  const selectableLocations = subagent.locations.filter((location) =>
+    location.fileType === 'real-file'
+    && (location.invalidDetails?.length ?? 0) === 0);
+  const canonicalLocation = selectableLocations.find((location) => location.canonical && location.fileType === 'real-file');
+  if (canonicalLocation) {
+    return canonicalLocation.path;
+  }
+
+  const groups = new Map<string, string[]>();
+  for (const location of selectableLocations) {
+    const key = location.definitionComparisonKey ?? location.definitionText ?? `path:${location.path}`;
+    const existing = groups.get(key) ?? [];
+    existing.push(location.path);
+    groups.set(key, existing);
+  }
+
+  return groups.size === 1 ? selectableLocations[0]?.path ?? null : null;
+}
+
 function getDistinctMcpVariantCount(mcp: McpRecord): number {
   return new Set(mcp.locations.map((location) =>
     location.definitionComparisonKey ?? location.definitionText ?? `path:${location.configPath}`)).size;
@@ -259,6 +456,10 @@ function isSkillResolvableIssue(value: string): value is SkillResolvableIssue {
 
 function isMcpResolvableIssue(value: string): value is McpResolvableIssue {
   return MCP_RESOLVABLE_ISSUES.has(value as McpResolvableIssue);
+}
+
+function isSubagentResolvableIssue(value: string): value is SubagentResolvableIssue {
+  return SUBAGENT_RESOLVABLE_ISSUES.has(value as SubagentResolvableIssue);
 }
 
 const AUTO_RESOLVABLE_ISSUES: Set<SkillIssueReason> = new Set([
@@ -353,6 +554,49 @@ export function getAutoResolvableMcpRequests(
   return requests;
 }
 
+const AUTO_RESOLVABLE_SUBAGENT_ISSUES: Set<SubagentResolvableIssue> = new Set([
+  'missing-universal',
+  'missing-from-agents',
+  'identical-copies',
+  'broken-symlink',
+]);
+
+export function getAutoResolvableSubagentRequests(
+  snapshot: SkillInventorySnapshot,
+): ResolveIssueRequest[] {
+  const requests: ResolveIssueRequest[] = [];
+
+  for (const subagent of snapshot.subagents ?? []) {
+    if (subagent.presentation !== 'active' || hasPluginSubagentLocation(subagent)) {
+      continue;
+    }
+
+    for (const reason of subagent.issueReasons) {
+      if (!AUTO_RESOLVABLE_SUBAGENT_ISSUES.has(reason as SubagentResolvableIssue)) {
+        continue;
+      }
+
+      const selectedVariantPath = getSubagentSelectedVariantPath(subagent, null);
+      if (!selectedVariantPath) {
+        continue;
+      }
+
+      if (getSubagentTargetabilityBlocker(subagent, reason as SubagentResolvableIssue, selectedVariantPath, snapshot)) {
+        continue;
+      }
+
+      requests.push({
+        entity: 'subagent',
+        issue: reason as SubagentResolvableIssue,
+        subagentName: subagent.name,
+        selectedVariantPath,
+      });
+    }
+  }
+
+  return requests;
+}
+
 function hasPluginMcpLocation(
   mcp: McpRecord,
   sourceIndex: Map<string, SkillScanSource>,
@@ -360,4 +604,10 @@ function hasPluginMcpLocation(
   return mcp.locations.some((location) =>
     location.provenance?.kind === 'plugin'
     || sourceIndex.get(location.agentId)?.kind === 'plugin');
+}
+
+function hasPluginSubagentLocation(subagent: SubagentRecord): boolean {
+  return subagent.locations.some((location) =>
+    location.agentId.startsWith('plugin:')
+    || location.provenance?.kind === 'plugin');
 }

--- a/src/renderer/src/representative-preview-data.ts
+++ b/src/renderer/src/representative-preview-data.ts
@@ -108,6 +108,13 @@ export const representativeInventorySnapshot: SkillInventorySnapshot = normalize
         },
       ],
       bundledMcps: [],
+      bundledSubagents: [
+        {
+          name: 'deployment-expert',
+          path: '~/.skillindex/sandbox/plugins/agents/deployment-expert.md',
+          sourceId: 'sandbox-plugin-pack',
+        },
+      ],
       unsupportedAssets: [
         {
           kind: 'hook',
@@ -1010,6 +1017,116 @@ export const representativeInventorySnapshot: SkillInventorySnapshot = normalize
     healthyMcps: 5,
     dismissedAttentionMcps: 1,
   },
+  subagents: [
+    {
+      name: 'reviewer',
+      displayName: 'reviewer',
+      description: 'Reviews code changes before handoff.',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['missing-from-agents'],
+      locations: [
+        {
+          agentId: 'sandbox-agents-subagents',
+          agentLabel: 'Sandbox .agents',
+          scope: 'sandbox',
+          path: '~/.skillindex/sandbox/.agents/agents/reviewer.md',
+          directoryPath: '~/.skillindex/sandbox/.agents/agents',
+          fileType: 'real-file',
+          modifiedAt: '2026-01-09T00:00:00.000Z',
+          canonical: true,
+          format: 'markdown-frontmatter',
+          definitionComparisonKey: 'reviewer-v1',
+          canonicalRole: 'canonical',
+          mutability: 'writable',
+        },
+      ],
+      expectedLocations: [
+        {
+          agentId: 'sandbox-codex',
+          agentLabel: 'Codex',
+          scope: 'sandbox',
+          directoryPath: '~/.skillindex/sandbox/.codex/agents',
+          path: '~/.skillindex/sandbox/.codex/agents/reviewer.toml',
+          format: 'codex-toml',
+          supportStatus: 'supported',
+        },
+        {
+          agentId: 'sandbox-claude',
+          agentLabel: 'Claude Code',
+          scope: 'sandbox',
+          directoryPath: '~/.skillindex/sandbox/.claude/agents',
+          path: '~/.skillindex/sandbox/.claude/agents/reviewer.md',
+          format: 'markdown-frontmatter',
+          supportStatus: 'supported',
+        },
+      ],
+      missingLocations: [
+        {
+          agentId: 'sandbox-codex',
+          agentLabel: 'Codex',
+          scope: 'sandbox',
+          directoryPath: '~/.skillindex/sandbox/.codex/agents',
+          path: '~/.skillindex/sandbox/.codex/agents/reviewer.toml',
+          format: 'codex-toml',
+          supportStatus: 'supported',
+        },
+        {
+          agentId: 'sandbox-claude',
+          agentLabel: 'Claude Code',
+          scope: 'sandbox',
+          directoryPath: '~/.skillindex/sandbox/.claude/agents',
+          path: '~/.skillindex/sandbox/.claude/agents/reviewer.md',
+          format: 'markdown-frontmatter',
+          supportStatus: 'supported',
+        },
+      ],
+      signature: 'reviewer-missing-from-agents',
+    },
+    {
+      name: 'sandbox-plugin-pack:deployment-expert',
+      displayName: 'deployment-expert',
+      description: 'Specializes in deployment strategies and production rollouts.',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['missing-universal'],
+      locations: [
+        {
+          agentId: 'plugin:sandbox:claude:sandbox-plugin-pack:0.1.0:subagents',
+          agentLabel: 'Claude Plugin sandbox-plugin-pack',
+          scope: 'sandbox',
+          path: '~/.skillindex/sandbox/plugins/agents/deployment-expert.md',
+          directoryPath: '~/.skillindex/sandbox/plugins',
+          fileType: 'real-file',
+          modifiedAt: '2026-01-09T00:15:00.000Z',
+          canonical: false,
+          format: 'markdown-frontmatter',
+          definitionComparisonKey: 'deployment-expert-v1',
+          provenance: {
+            kind: 'plugin',
+            plugin: {
+              host: 'claude',
+              pluginId: 'sandbox-plugin-pack',
+              version: '0.1.0',
+            },
+            sourcePath: '~/.skillindex/sandbox/plugins/agents/deployment-expert.md',
+            discoveredAt: '2026-01-09T00:15:00.000Z',
+          },
+          canonicalRole: 'materialized-copy',
+          mutability: 'read-only-managed',
+        },
+      ],
+      expectedLocations: [],
+      missingLocations: [],
+      signature: 'sandbox-plugin-pack-deployment-expert-missing-universal',
+    },
+  ],
+  subagentCounts: {
+    totalSubagents: 2,
+    attentionSubagents: 2,
+    healthySubagents: 0,
+    dismissedAttentionSubagents: 0,
+  },
   agents: buildRepresentativeAgents('~/.skillindex/sandbox', { cursorInstalled: true, windsurfInstalled: true }),
   agentCounts: buildAgentCounts(buildRepresentativeAgents('~/.skillindex/sandbox', { cursorInstalled: true, windsurfInstalled: true })),
   homeSummary: {
@@ -1438,6 +1555,9 @@ function buildRepresentativeAgents(
       mcpConfigKind: family.mcpConfigKind,
       mcpParserKind: family.mcpParserKind,
       mcpSupportedTransports: family.mcpSupportedTransports,
+      subagentConfigKind: family.subagentConfigKind,
+      subagentParserKind: family.subagentParserKind,
+      subagentWriteDialect: family.subagentWriteDialect,
       metadataSources: family.metadataSources,
       icon: family.icon,
       skillsLocation: family.skillStorageKind === 'local-directory'
@@ -1461,6 +1581,17 @@ function buildRepresentativeAgents(
             state: 'unavailable',
             exists: false,
             reason: 'not-supported',
+          },
+      subagentsLocation: family.subagentGlobalDirRelativeParts
+        ? {
+            state: 'available',
+            path: joinPreviewPath(rootDir, ...family.subagentGlobalDirRelativeParts),
+            exists: installState === 'installed',
+          }
+        : {
+            state: 'unavailable',
+            exists: false,
+            reason: family.subagentConfigKind === 'account-managed' ? 'account-managed' : 'not-supported',
           },
       configLocation: family.agentConfigRelativeParts
         ? {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1153,23 +1153,6 @@ body {
   height: 12px;
 }
 
-.repair-error {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 18px;
-  border-top: 1px solid var(--border-soft);
-  background: var(--attention-soft);
-  font-size: var(--text-caption);
-  color: var(--attention);
-}
-
-.repair-error svg {
-  width: 13px;
-  height: 13px;
-  flex-shrink: 0;
-}
-
 .review-panel {
   border-top: 1px solid var(--border-soft);
   background: var(--bg-panel-muted);
@@ -1908,14 +1891,6 @@ body {
   font-size: 0.8125rem;
 }
 
-.inline-error-banner {
-  margin: 0;
-  padding: 12px 14px;
-  border-radius: 12px;
-  background: rgba(255, 237, 234, 0.9);
-  color: var(--pill-attention-text);
-}
-
 .callout-card {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -2102,7 +2077,15 @@ body {
   gap: 16px;
 }
 
-.agent-status-row,
+.agent-status-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) repeat(3, minmax(0, 1fr));
+  align-items: start;
+  gap: 16px;
+  padding: 16px 22px;
+  border-top: 1px solid var(--border-color);
+}
+
 .settings-row {
   display: grid;
   grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr) minmax(0, 1fr);
@@ -5094,17 +5077,6 @@ body {
 .onboarding-note strong {
   color: #3a3a37;
   font-weight: 600;
-}
-
-.onboarding-error {
-  margin: 12px 0 0;
-  padding: 10px 12px;
-  border: 1px solid #f3d4cf;
-  border-radius: 7px;
-  background: #fbecea;
-  color: #ba1a1a;
-  font-size: 12.5px;
-  line-height: 17px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -9183,7 +9155,7 @@ body {
 }
 
 .agent-status-row {
-  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1.1fr) repeat(3, minmax(0, 1fr));
   gap: 14px;
   padding: 11px 16px;
 }
@@ -9216,7 +9188,7 @@ body {
 
 .inventory-section-block--agents > .inventory-section-header {
   display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1.1fr) repeat(3, minmax(0, 1fr));
   align-items: center;
 }
 

--- a/src/renderer/src/views/AgentsWorkspaceView.test.tsx
+++ b/src/renderer/src/views/AgentsWorkspaceView.test.tsx
@@ -37,7 +37,6 @@ function createAgent(overrides: Partial<AgentRecord> = {}): AgentRecord {
 function renderAgentsView(rows: AgentRecord[], options: { isRescanning?: boolean } = {}) {
   return render(
     <AgentsWorkspaceView
-      errorMessage={null}
       inventorySnapshot={{} as SkillInventorySnapshot}
       isRescanning={options.isRescanning ?? false}
       onRescan={vi.fn(() => Promise.resolve())}
@@ -75,7 +74,6 @@ describe('AgentsWorkspaceView', () => {
 
     const { container } = render(
       <AgentsWorkspaceView
-        errorMessage={null}
         inventorySnapshot={{} as SkillInventorySnapshot}
         isRescanning={false}
         onRescan={vi.fn(() => Promise.resolve())}
@@ -200,7 +198,6 @@ describe('AgentsWorkspaceView', () => {
 
     rerender(
       <AgentsWorkspaceView
-        errorMessage={null}
         inventorySnapshot={{} as SkillInventorySnapshot}
         isRescanning={false}
         onRescan={vi.fn(() => Promise.resolve())}

--- a/src/renderer/src/views/AgentsWorkspaceView.tsx
+++ b/src/renderer/src/views/AgentsWorkspaceView.tsx
@@ -8,7 +8,6 @@ import { AgentStatusRow, EmptyStatePanel, HeaderSearch, InventorySectionBlock, P
 type AgentStatusFilter = 'all' | AgentInstallState;
 
 export function AgentsWorkspaceView({
-  errorMessage,
   inventorySnapshot,
   isRescanning,
   onRescan,
@@ -17,7 +16,6 @@ export function AgentsWorkspaceView({
   searchInputRef,
   searchQuery,
 }: {
-  errorMessage: string | null;
   inventorySnapshot: SkillInventorySnapshot | null;
   isRescanning: boolean;
   onRescan: () => Promise<void>;
@@ -37,6 +35,7 @@ export function AgentsWorkspaceView({
         <div className="agent-section-columns" aria-hidden="true">
           <span className="agent-section-column-label">Skills source</span>
           <span className="agent-section-column-label">MCP / config</span>
+          <span className="agent-section-column-label">Subagents</span>
         </div>
       ),
       rows: installedAgents,
@@ -49,6 +48,7 @@ export function AgentsWorkspaceView({
         <div className="agent-section-columns" aria-hidden="true">
           <span className="agent-section-column-label">Skills source</span>
           <span className="agent-section-column-label">MCP / config</span>
+          <span className="agent-section-column-label">Subagents</span>
         </div>
       ),
       rows: missingAgents,
@@ -88,7 +88,6 @@ export function AgentsWorkspaceView({
           onFilterChange={setStatusFilter}
         />
         <section aria-label="Agents list" className="master-list-panel agent-group-stack--scroll">
-          {errorMessage ? <p className="inline-error-banner">{errorMessage}</p> : null}
           {inventorySnapshot ? (
             visibleSections.length > 0 ? (
               visibleSections.map((section) => (

--- a/src/renderer/src/views/HomeDashboard.test.tsx
+++ b/src/renderer/src/views/HomeDashboard.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { McpRecord, ResolveIssueRequest, SkillInventorySnapshot } from '@shared/contracts';
+import type { McpRecord, ResolveIssueRequest, SkillInventorySnapshot, SubagentRecord } from '@shared/contracts';
 
 import { getHomeSummary } from '../inventory-view-model';
 import { representativeInventorySnapshot } from '../representative-preview-data';
@@ -87,6 +87,68 @@ describe('HomeDashboard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /^Skills tab$/i }));
     expect(onNavigateToSkills).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not treat subagent-only manual attention as healthy', () => {
+    const inventorySnapshot = createNoAttentionSnapshot();
+    const onSelectSubagent = vi.fn();
+    const subagent: SubagentRecord = {
+      name: 'manual-subagent',
+      displayName: 'manual-subagent',
+      description: 'Requires a manual definition choice.',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['definition-mismatch'],
+      locations: [
+        {
+          agentId: 'sandbox-agents-subagents',
+          agentLabel: 'Sandbox .agents',
+          scope: 'sandbox',
+          path: '/tmp/.agents/agents/manual-subagent.md',
+          directoryPath: '/tmp/.agents/agents',
+          fileType: 'real-file',
+          modifiedAt: '2026-05-29T00:00:00.000Z',
+          canonical: true,
+          format: 'markdown-frontmatter',
+          definitionComparisonKey: 'canonical',
+          definitionText: '---\nname: manual-subagent\n---\nCanonical prompt.',
+        },
+        {
+          agentId: 'sandbox-claude',
+          agentLabel: 'Claude Code',
+          scope: 'sandbox',
+          path: '/tmp/.claude/agents/manual-subagent.md',
+          directoryPath: '/tmp/.claude/agents',
+          fileType: 'real-file',
+          modifiedAt: '2026-05-29T00:00:00.000Z',
+          canonical: false,
+          format: 'markdown-frontmatter',
+          definitionComparisonKey: 'claude',
+          definitionText: '---\nname: manual-subagent\n---\nClaude prompt.',
+        },
+      ],
+    };
+    inventorySnapshot.subagents = [subagent];
+    inventorySnapshot.subagentCounts = {
+      totalSubagents: 1,
+      healthySubagents: 0,
+      attentionSubagents: 1,
+      dismissedAttentionSubagents: 0,
+    };
+    inventorySnapshot.homeSummary = getHomeSummary(inventorySnapshot);
+
+    renderDashboard({
+      autoResolvableRequests: [],
+      homeSummary: getHomeSummary(inventorySnapshot),
+      inventorySnapshot,
+      onSelectSubagent,
+    });
+
+    expect(screen.getByText(/No safe auto-fixes available/i)).toBeInTheDocument();
+    expect(screen.queryByText('Everything looks good')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Subagents tab$/i }));
+    expect(onSelectSubagent).toHaveBeenCalledWith('manual-subagent');
   });
 
   it('expands, collapses, and applies safe repair requests accessibly', () => {
@@ -326,6 +388,7 @@ function renderDashboard(overrides: Partial<ComponentProps<typeof HomeDashboard>
     onRescan: vi.fn(() => Promise.resolve()),
     onSelectMcp: vi.fn(),
     onSelectSkill: vi.fn(),
+    onSelectSubagent: vi.fn(),
     ...overrides,
   };
 
@@ -347,6 +410,7 @@ function rerenderDashboard(
     onRescan: vi.fn(() => Promise.resolve()),
     onSelectMcp: vi.fn(),
     onSelectSkill: vi.fn(),
+    onSelectSubagent: vi.fn(),
     ...overrides,
   };
 

--- a/src/renderer/src/views/HomeDashboard.test.tsx
+++ b/src/renderer/src/views/HomeDashboard.test.tsx
@@ -38,14 +38,13 @@ describe('HomeDashboard', () => {
     expect(brokenMcpRow).toHaveTextContent('Invalid Definition');
   });
 
-  it('renders the healthy repair state and keeps errors visible', () => {
+  it('renders the healthy repair state without inline error banners', () => {
     renderDashboard({
-      errorMessage: 'Rescan failed',
       inventorySnapshot: createNoAttentionSnapshot(),
     });
 
     expect(screen.getByText('Everything looks good')).toBeInTheDocument();
-    expect(screen.getByText('Rescan failed')).toBeInTheDocument();
+    expect(screen.queryByText('Rescan failed')).not.toBeInTheDocument();
   });
 
   it('renders clean attention table states when skills and MCPs are healthy', () => {
@@ -80,12 +79,11 @@ describe('HomeDashboard', () => {
     const onNavigateToSkills = vi.fn();
     renderDashboard({
       autoResolvableRequests: [],
-      errorMessage: 'Repair failed',
       onNavigateToSkills,
     });
 
     expect(screen.getByText(/No safe auto-fixes available/i)).toBeInTheDocument();
-    expect(screen.getByText('Repair failed')).toBeInTheDocument();
+    expect(screen.queryByText('Repair failed')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /^Skills tab$/i }));
     expect(onNavigateToSkills).toHaveBeenCalledTimes(1);
@@ -116,7 +114,7 @@ describe('HomeDashboard', () => {
     expect(screen.queryByText('Review planned fixes')).not.toBeInTheDocument();
   });
 
-  it('describes mixed skill and MCP safe repairs as items', () => {
+  it('describes mixed skill, MCP, and subagent safe repairs by entity and issue', () => {
     renderDashboard({
       autoResolvableRequests: [
         safeRepairRequest,
@@ -125,15 +123,23 @@ describe('HomeDashboard', () => {
           issue: 'missing-from-agents',
           mcpName: 'missing-from-agents-mcp',
         },
+        {
+          entity: 'subagent',
+          issue: 'broken-symlink',
+          subagentName: 'broken-symlink-subagent',
+        },
       ],
     });
 
-    const toggle = screen.getByRole('button', { name: /Review 2 safe repairs for 2 items/i });
+    const toggle = screen.getByRole('button', { name: /Review 3 safe repairs for 3 items/i });
     fireEvent.click(toggle);
 
-    expect(screen.getAllByText('Missing From Agents').length).toBeGreaterThan(0);
+    expect(screen.getByText('Skills • Identical Copies')).toBeInTheDocument();
+    expect(screen.getByText('MCPs • Missing From Agents')).toBeInTheDocument();
+    expect(screen.getByText('Subagents • Broken Symlink')).toBeInTheDocument();
     expect(screen.getByText('Add to missing agents')).toBeInTheDocument();
-    expect(screen.getByText(/2 repairs · 2 items affected/i)).toBeInTheDocument();
+    expect(screen.getByText('Relink to canonical')).toBeInTheDocument();
+    expect(screen.getByText(/3 repairs · 3 items affected/i)).toBeInTheDocument();
   });
 
   it('shows how many active issues will still need manual review', () => {
@@ -311,7 +317,6 @@ describe('HomeDashboard', () => {
 function renderDashboard(overrides: Partial<ComponentProps<typeof HomeDashboard>> = {}) {
   const props: ComponentProps<typeof HomeDashboard> = {
     autoResolvableRequests: [],
-    errorMessage: null,
     homeSummary: getHomeSummary(overrides.inventorySnapshot ?? representativeInventorySnapshot),
     inventorySnapshot: representativeInventorySnapshot,
     isAutoResolving: false,
@@ -333,7 +338,6 @@ function rerenderDashboard(
 ) {
   const props: ComponentProps<typeof HomeDashboard> = {
     autoResolvableRequests: [],
-    errorMessage: null,
     homeSummary: getHomeSummary(overrides.inventorySnapshot ?? representativeInventorySnapshot),
     inventorySnapshot: representativeInventorySnapshot,
     isAutoResolving: false,
@@ -357,6 +361,7 @@ function createNoAttentionSnapshot(): SkillInventorySnapshot {
     isDrifted: false,
   }));
   snapshot.mcps = [];
+  snapshot.subagents = [];
   snapshot.counts = {
     ...snapshot.counts,
     driftedSkills: 0,
@@ -368,6 +373,12 @@ function createNoAttentionSnapshot(): SkillInventorySnapshot {
     healthyMcps: 0,
     attentionMcps: 0,
     dismissedAttentionMcps: 0,
+  };
+  snapshot.subagentCounts = {
+    totalSubagents: 0,
+    healthySubagents: 0,
+    attentionSubagents: 0,
+    dismissedAttentionSubagents: 0,
   };
   delete snapshot.homeSummary;
   snapshot.homeSummary = getHomeSummary(snapshot);

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, ArrowRight, Check, ChevronUp, Wrench } from 'lucide-react';
+import { ArrowRight, Check, ChevronUp, Wrench } from 'lucide-react';
 import { useState } from 'react';
 
 import type { McpRecord, ResolveIssueRequest, SkillInventorySnapshot, SkillRecord, SkillScanSource } from '@shared/contracts';
@@ -26,7 +26,9 @@ const FIX_ACTION_LABELS: Record<string, string> = {
   'missing-symlinks': 'Create missing symlinks',
   'identical-copies': 'Convert copies to symlinks',
   'missing-canonical': 'Promote to universal',
+  'missing-universal': 'Promote to universal',
   'broken-symlink': 'Relink to canonical',
+  'wrong-symlink-target': 'Relink to canonical',
   'missing-from-agents': 'Add to missing agents',
 };
 
@@ -34,13 +36,27 @@ const FIX_TYPE_LABELS: Record<string, string> = {
   'missing-symlinks': 'Missing Symlinks',
   'identical-copies': 'Identical Copies',
   'missing-canonical': 'Missing Universal',
+  'missing-universal': 'Missing Universal',
   'broken-symlink': 'Broken Symlink',
+  'wrong-symlink-target': 'Wrong Symlink Target',
   'missing-from-agents': 'Missing From Agents',
+};
+
+const FIX_ENTITY_LABELS: Record<ResolveIssueRequest['entity'], string> = {
+  skill: 'Skills',
+  mcp: 'MCPs',
+  subagent: 'Subagents',
 };
 
 interface PlannedFixRow {
   key: string;
   name: string;
+}
+
+interface PlannedFixGroup {
+  entity: ResolveIssueRequest['entity'];
+  issue: ResolveIssueRequest['issue'];
+  rows: PlannedFixRow[];
 }
 
 function getResolveRequestDisplayName(
@@ -52,6 +68,10 @@ function getResolveRequestDisplayName(
     return skill ? getSkillDisplayName(skill) : request.skillName;
   }
 
+  if (request.entity === 'subagent') {
+    return request.subagentName;
+  }
+
   const mcp = inventorySnapshot?.mcps?.find((entry) => entry.name === request.mcpName);
   return mcp ? getMcpDisplayName(mcp) : request.mcpName;
 }
@@ -59,7 +79,7 @@ function getResolveRequestDisplayName(
 function getResolveRequestKey(request: ResolveIssueRequest): string {
   return [
     request.entity,
-    request.skillName ?? request.mcpName,
+    request.skillName ?? request.mcpName ?? request.subagentName,
     request.issue,
     request.selectedVariantPath ?? '',
   ].join(':');
@@ -76,26 +96,22 @@ function getActiveIssueCount(inventorySnapshot: SkillInventorySnapshot | null): 
   const mcpIssueCount = (inventorySnapshot.mcps ?? [])
     .filter((mcp) => mcp.presentation === 'active' && mcp.status === 'needs-attention')
     .reduce((count, mcp) => count + mcp.issueReasons.length, 0);
-
-  return skillIssueCount + mcpIssueCount;
+  const subagentIssueCount = (inventorySnapshot.subagents ?? [])
+    .filter((subagent) => subagent.presentation === 'active' && subagent.status === 'needs-attention')
+    .reduce((count, subagent) => count + subagent.issueReasons.length, 0);
+  return skillIssueCount + mcpIssueCount + subagentIssueCount;
 }
 
-function RepairError({ errorMessage }: { errorMessage: string | null }) {
-  if (!errorMessage) {
-    return null;
-  }
+function getFixGroupKey(request: ResolveIssueRequest): string {
+  return `${request.entity}:${request.issue}`;
+}
 
-  return (
-    <div className="repair-error">
-      <AlertCircle />
-      {errorMessage}
-    </div>
-  );
+function formatFixGroupLabel(group: Pick<PlannedFixGroup, 'entity' | 'issue'>): string {
+  return `${FIX_ENTITY_LABELS[group.entity]} • ${FIX_TYPE_LABELS[group.issue] ?? group.issue}`;
 }
 
 function RepairSurface({
   autoResolvableRequests,
-  errorMessage,
   hasAttentionIssues,
   inventorySnapshot,
   isAutoResolving,
@@ -103,7 +119,6 @@ function RepairSurface({
   onViewSkills,
 }: {
   autoResolvableRequests: ResolveIssueRequest[];
-  errorMessage: string | null;
   hasAttentionIssues: boolean;
   inventorySnapshot: SkillInventorySnapshot | null;
   isAutoResolving: boolean;
@@ -113,18 +128,23 @@ function RepairSurface({
   const [reviewOpen, setReviewOpen] = useState(false);
   const reviewPanelId = 'home-auto-repair-review-panel';
 
-  const fixesByType = autoResolvableRequests.reduce<Map<string, PlannedFixRow[]>>((acc, req) => {
-    const names = acc.get(req.issue) ?? [];
-    names.push({
+  const fixesByType = autoResolvableRequests.reduce<Map<string, PlannedFixGroup>>((acc, req) => {
+    const groupKey = getFixGroupKey(req);
+    const group = acc.get(groupKey) ?? {
+      entity: req.entity,
+      issue: req.issue,
+      rows: [],
+    };
+    group.rows.push({
       key: getResolveRequestKey(req),
       name: getResolveRequestDisplayName(req, inventorySnapshot),
     });
-    acc.set(req.issue, names);
+    acc.set(groupKey, group);
     return acc;
   }, new Map());
 
   const totalIssues = autoResolvableRequests.length;
-  const totalItems = new Set(autoResolvableRequests.map((r) => r.skillName ?? r.mcpName)).size;
+  const totalItems = new Set(autoResolvableRequests.map((r) => r.skillName ?? r.mcpName ?? r.subagentName)).size;
   const manualIssueCount = Math.max(0, getActiveIssueCount(inventorySnapshot) - totalIssues);
 
   if (autoResolvableRequests.length === 0 && !hasAttentionIssues) {
@@ -139,7 +159,6 @@ function RepairSurface({
             <p>All skills and MCPs are healthy — nothing needs attention right now.</p>
           </div>
         </div>
-        <RepairError errorMessage={errorMessage} />
       </div>
     );
   }
@@ -160,7 +179,6 @@ function RepairSurface({
             .
           </div>
         </div>
-        <RepairError errorMessage={errorMessage} />
       </div>
     );
   }
@@ -196,25 +214,23 @@ function RepairSurface({
         </button>
       </div>
 
-      <RepairError errorMessage={errorMessage} />
-
       {reviewOpen ? (
         <div className="review-panel review-panel--open" id={reviewPanelId}>
           <div className="review-header">
             <span className="review-header-title">Review planned fixes</span>
           </div>
           <div className="review-body">
-            {[...fixesByType.entries()].map(([issueType, fixRows]) => (
-              <div className="issue-bucket" key={issueType}>
+            {[...fixesByType.values()].map((fixGroup) => (
+              <div className="issue-bucket" key={`${fixGroup.entity}:${fixGroup.issue}`}>
                 <div className="issue-bucket-header">
-                  <span className="issue-bucket-label">{FIX_TYPE_LABELS[issueType] ?? issueType}</span>
-                  <span className="issue-bucket-count">{fixRows.length} {fixRows.length === 1 ? 'item' : 'items'}</span>
+                  <span className="issue-bucket-label">{formatFixGroupLabel(fixGroup)}</span>
+                  <span className="issue-bucket-count">{fixGroup.rows.length} {fixGroup.rows.length === 1 ? 'item' : 'items'}</span>
                 </div>
                 <div className="issue-bucket-rows">
-                  {fixRows.map((row) => (
+                  {fixGroup.rows.map((row) => (
                     <div className="skill-fix-row" key={row.key}>
                       <span className="skill-fix-name">{row.name}</span>
-                      <span className="skill-fix-action">{FIX_ACTION_LABELS[issueType] ?? issueType}</span>
+                      <span className="skill-fix-action">{FIX_ACTION_LABELS[fixGroup.issue] ?? fixGroup.issue}</span>
                     </div>
                   ))}
                 </div>
@@ -250,7 +266,6 @@ function RepairSurface({
 
 export function HomeDashboard({
   autoResolvableRequests,
-  errorMessage,
   homeSummary,
   inventorySnapshot,
   isAutoResolving,
@@ -262,7 +277,6 @@ export function HomeDashboard({
   onSelectSkill,
 }: {
   autoResolvableRequests: ResolveIssueRequest[];
-  errorMessage: string | null;
   homeSummary: ReturnType<typeof getHomeSummary>;
   inventorySnapshot: SkillInventorySnapshot | null;
   isAutoResolving: boolean;
@@ -333,7 +347,6 @@ export function HomeDashboard({
 
             <RepairSurface
               autoResolvableRequests={autoResolvableRequests}
-              errorMessage={errorMessage}
               hasAttentionIssues={skillAttentionRows.length > 0 || mcpAttentionRows.length > 0}
               inventorySnapshot={inventorySnapshot}
               isAutoResolving={isAutoResolving}

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -3,7 +3,14 @@ import { useState } from 'react';
 
 import type { McpRecord, ResolveIssueRequest, SkillInventorySnapshot, SkillRecord, SkillScanSource } from '@shared/contracts';
 
-import { getHomeSummary, getMcpDisplayName, getMcpSections, getSkillDisplayName, getSkillSections } from '../inventory-view-model';
+import {
+  getHomeSummary,
+  getMcpDisplayName,
+  getMcpSections,
+  getSkillDisplayName,
+  getSkillSections,
+  getSubagentSections,
+} from '../inventory-view-model';
 import {
   getPillToneForMcp,
   getPillToneForSkill,
@@ -116,14 +123,16 @@ function RepairSurface({
   inventorySnapshot,
   isAutoResolving,
   onAutoResolve,
-  onViewSkills,
+  onViewManualIssues,
+  manualReviewTargetLabel,
 }: {
   autoResolvableRequests: ResolveIssueRequest[];
   hasAttentionIssues: boolean;
   inventorySnapshot: SkillInventorySnapshot | null;
   isAutoResolving: boolean;
+  manualReviewTargetLabel: string;
   onAutoResolve: () => void;
-  onViewSkills: () => void;
+  onViewManualIssues: () => void;
 }) {
   const [reviewOpen, setReviewOpen] = useState(false);
   const reviewPanelId = 'home-auto-repair-review-panel';
@@ -156,7 +165,7 @@ function RepairSurface({
           </div>
           <div className="repair-surface-copy">
             <strong>Everything looks good</strong>
-            <p>All skills and MCPs are healthy — nothing needs attention right now.</p>
+            <p>All skills, MCPs, and subagents are healthy — nothing needs attention right now.</p>
           </div>
         </div>
       </div>
@@ -173,8 +182,8 @@ function RepairSurface({
           <div className="repair-surface-copy">
             <strong>No safe auto-fixes available.</strong>{' '}
             Remaining issues require a manual choice — review them in the{' '}
-            <button className="repair-surface-link" type="button" onClick={onViewSkills}>
-              Skills tab
+            <button className="repair-surface-link" type="button" onClick={onViewManualIssues}>
+              {manualReviewTargetLabel}
             </button>
             .
           </div>
@@ -276,6 +285,7 @@ export function HomeDashboard({
   onRescan,
   onSelectMcp,
   onSelectSkill,
+  onSelectSubagent,
 }: {
   autoResolvableRequests: ResolveIssueRequest[];
   homeSummary: ReturnType<typeof getHomeSummary>;
@@ -288,16 +298,32 @@ export function HomeDashboard({
   onRescan: () => Promise<void>;
   onSelectMcp: (mcpName: string) => void;
   onSelectSkill: (skillName: string) => void;
+  onSelectSubagent: (subagentName: string) => void;
 }) {
   const skillSections = inventorySnapshot ? getSkillSections(inventorySnapshot) : [];
   const mcpSections = inventorySnapshot ? getMcpSections(inventorySnapshot) : [];
+  const subagentSections = inventorySnapshot ? getSubagentSections(inventorySnapshot) : [];
   const skillAttentionRows = skillSections.find((section) => section.tone === 'attention')?.rows ?? [];
   const mcpAttentionRows = mcpSections.find((section) => section.tone === 'attention')?.rows ?? [];
+  const subagentAttentionRows = subagentSections.find((section) => section.tone === 'attention')?.rows ?? [];
   const lastCheckedLabel = formatLastScanLabel(inventorySnapshot?.scannedAt);
   const sourceIndex = inventorySnapshot
     ? new Map(inventorySnapshot.sources.map((source) => [source.id, source]))
     : new Map<string, SkillScanSource>();
-
+  const manualReviewTarget = skillAttentionRows.length > 0
+    ? {
+        label: 'Skills tab',
+        onClick: onNavigateToSkills,
+      }
+    : mcpAttentionRows.length > 0
+      ? {
+          label: 'MCPs tab',
+          onClick: () => onSelectMcp(mcpAttentionRows[0]?.name ?? ''),
+        }
+      : {
+          label: 'Subagents tab',
+          onClick: () => onSelectSubagent(subagentAttentionRows[0]?.name ?? ''),
+        };
 
   return (
     <main className="workspace-view">
@@ -349,11 +375,16 @@ export function HomeDashboard({
 
             <RepairSurface
               autoResolvableRequests={autoResolvableRequests}
-              hasAttentionIssues={skillAttentionRows.length > 0 || mcpAttentionRows.length > 0}
+              hasAttentionIssues={
+                skillAttentionRows.length > 0
+                || mcpAttentionRows.length > 0
+                || subagentAttentionRows.length > 0
+              }
               inventorySnapshot={inventorySnapshot}
               isAutoResolving={isAutoResolving}
+              manualReviewTargetLabel={manualReviewTarget.label}
               onAutoResolve={onAutoResolve}
-              onViewSkills={onNavigateToSkills}
+              onViewManualIssues={manualReviewTarget.onClick}
             />
 
             <AttentionGroupCard

--- a/src/renderer/src/views/InventoryViewChrome.test.tsx
+++ b/src/renderer/src/views/InventoryViewChrome.test.tsx
@@ -6,10 +6,11 @@ import { describe, expect, it, vi } from 'vitest';
 import type { McpRecord } from '@shared/contracts';
 
 import { representativeInventorySnapshot } from '../representative-preview-data';
-import { buildMcpInspectorModel, buildSkillInspectorModel } from '../lib/detail-inspector-model';
+import { buildMcpInspectorModel, buildSkillInspectorModel, buildSubagentInspectorModel } from '../lib/detail-inspector-model';
 import { McpWorkspaceView } from './McpWorkspaceView';
 import { PluginsWorkspaceView } from './PluginsWorkspaceView';
 import { SkillsWorkspaceView } from './SkillsWorkspaceView';
+import { SubagentsWorkspaceView } from './SubagentsWorkspaceView';
 
 function renderSkillsWorkspaceView({
   inventorySnapshot = representativeInventorySnapshot,
@@ -27,7 +28,6 @@ function renderSkillsWorkspaceView({
   return render(
     <SkillsWorkspaceView
       isAddingSkill={false}
-      errorMessage={null}
       inventorySnapshot={inventorySnapshot}
       isDismissingDrift={false}
       isApplyingCapabilityAction={false}
@@ -72,11 +72,10 @@ function renderMcpWorkspaceView({
   onSelectMcp?: (name: string | null) => void;
   rows?: NonNullable<typeof representativeInventorySnapshot.mcps>;
   searchQuery?: string;
-  statusFilter?: 'all' | 'active' | 'none';
+  statusFilter?: 'all' | 'active' | 'dismissed' | 'none';
 } = {}) {
   render(
     <McpWorkspaceView
-      errorMessage={null}
       inventorySnapshot={inventorySnapshot}
       isAddingMcpServer={false}
       isDismissingDrift={false}
@@ -103,20 +102,67 @@ function renderMcpWorkspaceView({
   );
 }
 
+function renderSubagentsWorkspaceView({
+  inventorySnapshot = representativeInventorySnapshot,
+  isRescanning = false,
+  rows = representativeInventorySnapshot.subagents ?? [],
+  searchQuery = '',
+  selectedSubagent = null,
+  selectedSubagentInspectorModel = null,
+  selectedSubagentProblemKey = null,
+  statusFilter = 'all',
+}: {
+  inventorySnapshot?: typeof representativeInventorySnapshot;
+  isRescanning?: boolean;
+  rows?: NonNullable<typeof representativeInventorySnapshot.subagents>;
+  searchQuery?: string;
+  selectedSubagent?: NonNullable<typeof representativeInventorySnapshot.subagents>[number] | null;
+  selectedSubagentInspectorModel?: ReturnType<typeof buildSubagentInspectorModel> | null;
+  selectedSubagentProblemKey?: NonNullable<typeof representativeInventorySnapshot.subagents>[number]['issueReasons'][number] | null;
+  statusFilter?: 'all' | 'active' | 'dismissed' | 'none';
+} = {}) {
+  render(
+    <SubagentsWorkspaceView
+      inventorySnapshot={inventorySnapshot}
+      isDismissingDrift={false}
+      isResolvingIssue={false}
+      isRescanning={isRescanning}
+      onClearSelection={vi.fn()}
+      onDismissDrift={vi.fn(() => Promise.resolve())}
+      onResolveIssue={vi.fn(() => Promise.resolve())}
+      onRescan={vi.fn(() => Promise.resolve())}
+      onSearchQueryChange={vi.fn()}
+      onSelectProblem={vi.fn()}
+      onSelectSubagent={vi.fn()}
+      onSelectVariant={vi.fn()}
+      onStatusFilterChange={vi.fn()}
+      rows={rows}
+      sandboxRoot={null}
+      searchInputRef={createRef<HTMLInputElement>()}
+      searchQuery={searchQuery}
+      selectedSubagent={selectedSubagent}
+      selectedSubagentInspectorModel={selectedSubagentInspectorModel}
+      selectedSubagentProblemKey={selectedSubagentProblemKey}
+      statusFilter={statusFilter}
+    />,
+  );
+}
+
 function renderPluginsWorkspaceView({
   onSelectMcpAsset = vi.fn(),
   onSelectSkillAsset = vi.fn(),
+  onSelectSubagentAsset = vi.fn(),
   sandboxRoot = null,
 }: {
   onSelectMcpAsset?: (mcpName: string) => void;
   onSelectSkillAsset?: (skillName: string) => void;
+  onSelectSubagentAsset?: (subagentName: string) => void;
   sandboxRoot?: string | null;
 } = {}) {
   const selectedPlugin = representativeInventorySnapshot.plugins?.[0] ?? null;
 
   return render(
     <PluginsWorkspaceView
-      errorMessage={null}
       inventorySnapshot={representativeInventorySnapshot}
       isRescanning={false}
       onClearSelection={vi.fn()}
@@ -125,6 +171,7 @@ function renderPluginsWorkspaceView({
       onSelectMcpAsset={onSelectMcpAsset}
       onSelectPlugin={vi.fn()}
       onSelectSkillAsset={onSelectSkillAsset}
+      onSelectSubagentAsset={onSelectSubagentAsset}
       rows={representativeInventorySnapshot.plugins ?? []}
       sandboxRoot={sandboxRoot}
       searchInputRef={createRef<HTMLInputElement>()}
@@ -165,6 +212,31 @@ describe('inventory view chrome', () => {
     expect(screen.queryByRole('button', { name: 'Filter' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /broken-mcp/i }).querySelector('p')).toBeNull();
     expect(screen.getByRole('button', { name: /healthy-mcp/i }).querySelector('p')).toBeNull();
+  });
+
+  it('renders Subagent details with the shared inspector chrome used by Skills', () => {
+    const selectedSubagent = representativeInventorySnapshot.subagents?.find((subagent) => subagent.name === 'reviewer');
+    expect(selectedSubagent).toBeDefined();
+    const agentIndex = new Map((representativeInventorySnapshot.agents ?? []).map((agent) => [agent.id, agent]));
+
+    renderSubagentsWorkspaceView({
+      selectedSubagent: selectedSubagent ?? null,
+      selectedSubagentInspectorModel: selectedSubagent
+        ? buildSubagentInspectorModel(selectedSubagent, {
+          selectedProblemKey: 'missing-from-agents',
+          selectedVariantPath: null,
+        }, agentIndex)
+        : null,
+      selectedSubagentProblemKey: 'missing-from-agents',
+    });
+
+    const detail = screen.getByRole('complementary', { name: 'Subagent detail' });
+    expect(detail).toHaveClass('detail-inspector-panel', 'detail-inspector-panel--subagent');
+    expect(detail).not.toHaveClass('plugin-detail-panel');
+    expect(within(detail).getByRole('tab', { name: /Problems/i })).toBeInTheDocument();
+    expect(within(detail).getByRole('tab', { name: /Locations/i })).toBeInTheDocument();
+    expect(within(detail).getByRole('tab', { name: /Definition/i })).toBeInTheDocument();
+    expect(within(detail).getByRole('button', { name: /Add to Agents/i })).toBeInTheDocument();
   });
 
   it('uses MCP-specific rescan loading copy while connectivity checks run', () => {
@@ -285,10 +357,11 @@ describe('inventory view chrome', () => {
       throw new Error('Expected representative plugin fixture to include a plugin.');
     }
     const onSelectSkillAsset = vi.fn();
-    renderPluginsWorkspaceView({ onSelectSkillAsset });
+    const onSelectSubagentAsset = vi.fn();
+    renderPluginsWorkspaceView({ onSelectSkillAsset, onSelectSubagentAsset });
 
     const tabs = within(screen.getByRole('tablist', { name: /sandbox-plugin-pack detail sections/i })).getAllByRole('tab');
-    expect(tabs.map((tab) => tab.textContent)).toEqual(['Bundled Assets2', 'Metadata']);
+    expect(tabs.map((tab) => tab.textContent)).toEqual(['Bundled Assets3', 'Metadata']);
     expect(screen.getByRole('tab', { name: /Bundled Assets/i })).toHaveAttribute('aria-selected', 'true');
     expect(screen.queryByRole('tab', { name: /Overview/i })).not.toBeInTheDocument();
     expect(screen.queryByText(selectedPlugin.bundledSkills[0].path)).not.toBeInTheDocument();
@@ -299,8 +372,10 @@ describe('inventory view chrome', () => {
     expect(screen.queryByText(unsupportedHookPath)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /^mixed-plugin-skill$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^deployment-expert$/i }));
 
     expect(onSelectSkillAsset).toHaveBeenCalledWith('mixed-plugin-skill');
+    expect(onSelectSubagentAsset).toHaveBeenCalledWith('sandbox-plugin-pack:deployment-expert');
     const unsupportedSection = screen.getByText('Unsupported assets').closest('.plugin-detail-panel__asset-section');
     expect(unsupportedSection).not.toBeNull();
     expect(within(unsupportedSection as HTMLElement).getByText('session-start')).toBeInTheDocument();
@@ -353,7 +428,6 @@ describe('inventory view chrome', () => {
   it('renders one status pill per issue and orders active rows by issue count', () => {
     render(
       <McpWorkspaceView
-        errorMessage={null}
         inventorySnapshot={representativeInventorySnapshot}
         isAddingMcpServer={false}
         isDismissingDrift={false}
@@ -471,18 +545,32 @@ describe('inventory view chrome', () => {
     expect(screen.queryByText('No MCPs were found in the agent configs Skill Index scanned.')).not.toBeInTheDocument();
   });
 
-  it('shows undismiss actions in dismissed detail panes for skills and MCPs', () => {
+  it('shows filter-specific empty states for subagents when a non-empty inventory has no matches for the active filter', () => {
+    renderSubagentsWorkspaceView({ rows: [], statusFilter: 'dismissed' });
+
+    expect(screen.getByText('No dismissed subagents found.')).toBeInTheDocument();
+    expect(screen.queryByText('No subagents were found in the agent folders Skill Index scanned.')).not.toBeInTheDocument();
+  });
+
+  it('shows undismiss actions in dismissed detail panes for skills, MCPs, and subagents', () => {
     const sourceIndex = new Map(representativeInventorySnapshot.sources.map((source) => [source.id, source]));
     const agentIndex = new Map((representativeInventorySnapshot.agents ?? []).map((agent) => [agent.id, agent]));
     const dismissedSkill = representativeInventorySnapshot.skills.find((skill) => skill.name === 'dismissed-drift-skill');
     const dismissedMcp = representativeInventorySnapshot.mcps?.find((mcp) => mcp.name === 'muted-mcp');
+    const activeSubagent = representativeInventorySnapshot.subagents?.find((subagent) => subagent.name === 'reviewer');
+    const dismissedSubagent = activeSubagent
+      ? {
+        ...activeSubagent,
+        presentation: 'dismissed' as const,
+      }
+      : null;
     expect(dismissedSkill).toBeDefined();
     expect(dismissedMcp).toBeDefined();
+    expect(dismissedSubagent).toBeDefined();
 
     const { rerender } = render(
       <SkillsWorkspaceView
         isAddingSkill={false}
-        errorMessage={null}
         inventorySnapshot={representativeInventorySnapshot}
         isDismissingDrift={false}
         isApplyingCapabilityAction={false}
@@ -520,7 +608,6 @@ describe('inventory view chrome', () => {
 
     rerender(
       <McpWorkspaceView
-        errorMessage={null}
         inventorySnapshot={representativeInventorySnapshot}
         isAddingMcpServer={false}
         isDismissingDrift={false}
@@ -550,5 +637,36 @@ describe('inventory view chrome', () => {
     );
 
     expect(screen.getAllByRole('button', { name: 'Undismiss issues with this MCP' }).length).toBeGreaterThan(0);
+
+    rerender(
+      <SubagentsWorkspaceView
+        inventorySnapshot={representativeInventorySnapshot}
+        isDismissingDrift={false}
+        isResolvingIssue={false}
+        isRescanning={false}
+        selectedSubagent={dismissedSubagent}
+        selectedSubagentInspectorModel={dismissedSubagent ? buildSubagentInspectorModel(dismissedSubagent, {
+          selectedProblemKey: 'missing-from-agents',
+          selectedVariantPath: null,
+        }, agentIndex) : null}
+        selectedSubagentProblemKey="missing-from-agents"
+        sandboxRoot={null}
+        onClearSelection={vi.fn()}
+        onDismissDrift={vi.fn(() => Promise.resolve())}
+        onResolveIssue={vi.fn(() => Promise.resolve())}
+        onRescan={vi.fn(() => Promise.resolve())}
+        onSearchQueryChange={vi.fn()}
+        onSelectProblem={vi.fn()}
+        onSelectSubagent={vi.fn()}
+        onSelectVariant={vi.fn()}
+        onStatusFilterChange={vi.fn()}
+        rows={representativeInventorySnapshot.subagents ?? []}
+        searchInputRef={createRef<HTMLInputElement>()}
+        searchQuery=""
+        statusFilter="all"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Undismiss issues with this subagent' })).toBeInTheDocument();
   });
 });

--- a/src/renderer/src/views/McpWorkspaceView.tsx
+++ b/src/renderer/src/views/McpWorkspaceView.tsx
@@ -33,7 +33,6 @@ import {
 } from '../components/ui';
 
 export function McpWorkspaceView({
-  errorMessage,
   inventorySnapshot,
   isAddingMcpServer,
   isDismissingDrift,
@@ -57,7 +56,6 @@ export function McpWorkspaceView({
   searchQuery,
   statusFilter,
 }: {
-  errorMessage: string | null;
   inventorySnapshot: SkillInventorySnapshot | null;
   isAddingMcpServer: boolean;
   isDismissingDrift: boolean;
@@ -145,7 +143,6 @@ export function McpWorkspaceView({
 
           <div className={`split-workspace split-workspace--detail${mcp ? '' : ' split-workspace--detail-collapsed'}`}>
             <section className="master-list-panel" aria-label="MCP list">
-              {errorMessage ? <p className="inline-error-banner">{errorMessage}</p> : null}
               {inventorySnapshot ? (
                 sections.length > 0 ? (
                   sections.map((section) => (
@@ -180,7 +177,6 @@ export function McpWorkspaceView({
 
             {mcp ? (
               <McpDetailPanel
-                errorMessage={errorMessage}
                 isDismissingDrift={isDismissingDrift}
                 isResolvingIssue={isResolvingIssue}
                 inventorySnapshot={inventorySnapshot}
@@ -511,7 +507,6 @@ function parseKeyValueLines(raw: string): Record<string, string> | undefined {
 }
 
 function McpDetailPanel({
-  errorMessage,
   isDismissingDrift,
   isResolvingIssue,
   inventorySnapshot,
@@ -524,7 +519,6 @@ function McpDetailPanel({
   onSelectProblem,
   onSelectVariant,
 }: {
-  errorMessage: string | null;
   isDismissingDrift: boolean;
   isResolvingIssue: boolean;
   inventorySnapshot: SkillInventorySnapshot | null;
@@ -547,7 +541,6 @@ function McpDetailPanel({
     <DetailInspectorPanel
       ariaLabel="MCP detail"
       entityKind="mcp"
-      errorMessage={errorMessage}
       footerActions={[
         ...(mcpInspectorModel.activeProblem.primaryActionLabel
           ? [{

--- a/src/renderer/src/views/OnboardingFlow.tsx
+++ b/src/renderer/src/views/OnboardingFlow.tsx
@@ -4,13 +4,11 @@ import { ArrowRight, Check, Folder, GitBranch, Info, X } from 'lucide-react';
 import skillIndexMarkCream from '../assets/skill-index-mark-cream.svg';
 
 export function OnboardingFlow({
-  errorMessage,
   isCompleting,
   onChoosePreferredSource,
   onComplete,
   universalSkillsPath,
 }: {
-  errorMessage: string | null;
   isCompleting: boolean;
   onChoosePreferredSource: () => Promise<string | null>;
   onComplete: (preferredSourcePath: string | null) => Promise<void>;
@@ -48,7 +46,6 @@ export function OnboardingFlow({
             <StepOne onContinue={() => setStep(2)} />
           ) : (
             <StepTwo
-              errorMessage={errorMessage}
               isChoosingPreferredSource={isChoosingPreferredSource}
               isCompleting={isCompleting}
               preferredSourcePath={preferredSourcePath}
@@ -141,7 +138,6 @@ function StepOne({ onContinue }: { onContinue: () => void }) {
 }
 
 function StepTwo({
-  errorMessage,
   isChoosingPreferredSource,
   isCompleting,
   preferredSourcePath,
@@ -151,7 +147,6 @@ function StepTwo({
   onClearPreferredSource,
   onComplete,
 }: {
-  errorMessage: string | null;
   isChoosingPreferredSource: boolean;
   isCompleting: boolean;
   preferredSourcePath: string | null;
@@ -244,8 +239,6 @@ function StepTwo({
         <Info aria-hidden="true" size={14} />
         <span>Manage these later in <strong>Settings {'->'} Custom scan paths</strong>. Skill Index never moves files without your approval.</span>
       </div>
-
-      {errorMessage ? <p className="onboarding-error" role="alert">{errorMessage}</p> : null}
 
       <div className="onboarding-pane-spacer" />
 

--- a/src/renderer/src/views/PluginsWorkspaceView.tsx
+++ b/src/renderer/src/views/PluginsWorkspaceView.tsx
@@ -2,6 +2,7 @@ import type {
   PluginMcpRef,
   PluginRecord,
   PluginSkillRef,
+  PluginSubagentRef,
   PluginUnsupportedAssetRef,
   SkillInventorySnapshot,
 } from '@shared/contracts';
@@ -18,7 +19,6 @@ import {
 import { formatInspectorDisplayPath } from '../lib/inventory-presentation';
 
 export function PluginsWorkspaceView({
-  errorMessage,
   inventorySnapshot,
   isRescanning,
   onRescan,
@@ -26,6 +26,7 @@ export function PluginsWorkspaceView({
   onSelectMcpAsset,
   onSelectPlugin,
   onSelectSkillAsset,
+  onSelectSubagentAsset,
   onClearSelection,
   rows,
   sandboxRoot,
@@ -34,7 +35,6 @@ export function PluginsWorkspaceView({
   selectedPlugin,
   selectedPluginKey,
 }: {
-  errorMessage: string | null;
   inventorySnapshot: SkillInventorySnapshot | null;
   isRescanning: boolean;
   onRescan: () => Promise<void>;
@@ -42,6 +42,7 @@ export function PluginsWorkspaceView({
   onSelectMcpAsset: (mcpName: string) => void;
   onSelectPlugin: (plugin: PluginRecord) => void;
   onSelectSkillAsset: (skillName: string) => void;
+  onSelectSubagentAsset: (subagentName: string) => void;
   onClearSelection: () => void;
   rows: PluginRecord[];
   sandboxRoot: string | null;
@@ -78,7 +79,6 @@ export function PluginsWorkspaceView({
       <div className="page-scroll page-scroll--split">
         <div className={`split-workspace split-workspace--detail${selectedPlugin ? '' : ' split-workspace--detail-collapsed'}`}>
           <section aria-label="Plugins list" className="master-list-panel">
-            {errorMessage ? <p className="inline-error-banner">{errorMessage}</p> : null}
             {inventorySnapshot ? (
               sections.length > 0 ? (
                 sections.map((section) => (
@@ -115,6 +115,7 @@ export function PluginsWorkspaceView({
               onClose={onClearSelection}
               onSelectMcpAsset={onSelectMcpAsset}
               onSelectSkillAsset={onSelectSkillAsset}
+              onSelectSubagentAsset={onSelectSubagentAsset}
               plugin={selectedPlugin}
             />
           ) : null}
@@ -137,6 +138,7 @@ function PluginInventoryRow({
 }) {
   const displayPath = formatInspectorDisplayPath(plugin.rootPath, { sandboxRoot });
   const unsupportedHooksCount = plugin.unsupportedHooksCount ?? 0;
+  const bundledSubagentsCount = plugin.bundledSubagents?.length ?? 0;
 
   return (
     <button
@@ -164,6 +166,10 @@ function PluginInventoryRow({
           <strong>{plugin.bundledMcps.length}</strong>
           <span>MCPs</span>
         </span>
+        <span className="plugin-inventory-row__stat">
+          <strong>{bundledSubagentsCount}</strong>
+          <span>subagents</span>
+        </span>
         <span className={`plugin-inventory-row__stat${unsupportedHooksCount > 0 ? ' plugin-inventory-row__stat--warn' : ''}`}>
           <strong>{unsupportedHooksCount}</strong>
           <span>hooks</span>
@@ -180,16 +186,19 @@ function PluginDetailPanel({
   onClose,
   onSelectMcpAsset,
   onSelectSkillAsset,
+  onSelectSubagentAsset,
   plugin,
 }: {
   inventorySnapshot: SkillInventorySnapshot | null;
   onClose: () => void;
   onSelectMcpAsset: (mcpName: string) => void;
   onSelectSkillAsset: (skillName: string) => void;
+  onSelectSubagentAsset: (subagentName: string) => void;
   plugin: PluginRecord;
 }) {
   const [activeTab, setActiveTab] = useState<PluginDetailTab>('assets');
   const unsupportedHooksCount = plugin.unsupportedHooksCount ?? 0;
+  const bundledSubagents = plugin.bundledSubagents ?? [];
 
   useEffect(() => {
     setActiveTab('assets');
@@ -205,8 +214,9 @@ function PluginDetailPanel({
               {plugin.version ? <span>{plugin.version}</span> : null}
             </h3>
             <p>
-              Bundles {plugin.bundledSkills.length} {pluralize('skill', plugin.bundledSkills.length)}
-              {' '}and {plugin.bundledMcps.length} {pluralize('MCP', plugin.bundledMcps.length)}.
+              Bundles {plugin.bundledSkills.length} {pluralize('skill', plugin.bundledSkills.length)},{' '}
+              {plugin.bundledMcps.length} {pluralize('MCP', plugin.bundledMcps.length)}, and{' '}
+              {bundledSubagents.length} {pluralize('subagent', bundledSubagents.length)}.
             </p>
           </div>
           <button className="detail-inspector-panel__close-button" type="button" onClick={onClose}>
@@ -224,7 +234,7 @@ function PluginDetailPanel({
           onClick={() => setActiveTab('assets')}
         >
           Bundled Assets
-          <span>{plugin.bundledSkills.length + plugin.bundledMcps.length}</span>
+          <span>{plugin.bundledSkills.length + plugin.bundledMcps.length + bundledSubagents.length}</span>
         </button>
         <button
           aria-selected={activeTab === 'overview'}
@@ -276,6 +286,15 @@ function PluginDetailPanel({
                 onSelect: () => onSelectMcpAsset(resolveBundledMcpName(inventorySnapshot, mcp)),
               }))}
               title="Bundled MCPs"
+            />
+            <PluginAssetList
+              emptyLabel="No bundled subagents found."
+              items={bundledSubagents.map((subagent) => ({
+                key: `${subagent.sourceId}:${subagent.path}:${subagent.name}`,
+                label: subagent.name,
+                onSelect: () => onSelectSubagentAsset(resolveBundledSubagentName(inventorySnapshot, subagent)),
+              }))}
+              title="Bundled subagents"
             />
             <div className="plugin-detail-panel__asset-section plugin-detail-panel__asset-section--unsupported">
               <div className="plugin-detail-panel__section-label">
@@ -425,6 +444,12 @@ function resolveBundledMcpName(snapshot: SkillInventorySnapshot | null, asset: P
     mcp.locations.some((location) =>
       location.agentId === asset.sourceId
       && location.configPath === asset.configPath))?.name
+    ?? asset.name;
+}
+
+function resolveBundledSubagentName(snapshot: SkillInventorySnapshot | null, asset: PluginSubagentRef): string {
+  return snapshot?.subagents?.find((subagent) =>
+    subagent.locations.some((location) => location.path === asset.path))?.name
     ?? asset.name;
 }
 

--- a/src/renderer/src/views/SettingsWorkspaceView.tsx
+++ b/src/renderer/src/views/SettingsWorkspaceView.tsx
@@ -13,7 +13,6 @@ import {
 export function SettingsWorkspaceView({
   customScanPathInput,
   devToolsEnabled,
-  errorMessage,
   handleAddCustomScanPath,
   handleClearPreferredCanonicalSourcePath,
   handleInventorySourceModeChange,
@@ -39,7 +38,6 @@ export function SettingsWorkspaceView({
 }: {
   customScanPathInput: string;
   devToolsEnabled: boolean;
-  errorMessage: string | null;
   handleAddCustomScanPath: (event: FormEvent<HTMLFormElement>) => Promise<void>;
   handleClearPreferredCanonicalSourcePath: () => Promise<void>;
   handleInventorySourceModeChange: (mode: InventorySourceMode) => Promise<void>;
@@ -78,8 +76,6 @@ export function SettingsWorkspaceView({
       />
 
       <div className="page-scroll">
-        {errorMessage ? <p className="inline-error-banner">{errorMessage}</p> : null}
-
         <div className="settings-card-stack">
           <section className="settings-card">
             <SettingsGroupHeader

--- a/src/renderer/src/views/SkillsWorkspaceView.tsx
+++ b/src/renderer/src/views/SkillsWorkspaceView.tsx
@@ -36,7 +36,6 @@ import {
 
 export function SkillsWorkspaceView({
   isAddingSkill,
-  errorMessage,
   inventorySnapshot,
   isDismissingDrift,
   isApplyingCapabilityAction,
@@ -66,7 +65,6 @@ export function SkillsWorkspaceView({
   statusFilter,
 }: {
   isAddingSkill: boolean;
-  errorMessage: string | null;
   inventorySnapshot: SkillInventorySnapshot | null;
   isDismissingDrift: boolean;
   isApplyingCapabilityAction: boolean;
@@ -166,7 +164,6 @@ export function SkillsWorkspaceView({
 
           <div className={`split-workspace split-workspace--detail${selectedSkill ? '' : ' split-workspace--detail-collapsed'}`}>
             <section className="master-list-panel" aria-label="Skills list">
-              {errorMessage ? <p className="inline-error-banner">{errorMessage}</p> : null}
               {inventorySnapshot ? (
                 sections.length > 0 ? (
                   sections.map((section) => (
@@ -205,7 +202,6 @@ export function SkillsWorkspaceView({
 
             {selectedSkill ? (
               <SkillDetailPanel
-                errorMessage={errorMessage}
                 isDismissingDrift={isDismissingDrift}
                 isApplyingCapabilityAction={isApplyingCapabilityAction}
                 isResolvingIssue={isResolvingIssue}
@@ -275,7 +271,6 @@ function getSkillsEmptyStateMessage({
 }
 
 function SkillDetailPanel({
-  errorMessage,
   isDismissingDrift,
   isApplyingCapabilityAction,
   isResolvingIssue,
@@ -292,7 +287,6 @@ function SkillDetailPanel({
   setSelectedSkillVariantPath,
   sourceIndex,
 }: {
-  errorMessage: string | null;
   isDismissingDrift: boolean;
   isApplyingCapabilityAction: boolean;
   isResolvingIssue: boolean;
@@ -320,7 +314,6 @@ function SkillDetailPanel({
   return (
     <DetailInspectorPanel
       entityKind="skill"
-      errorMessage={errorMessage}
       footerActions={[
         ...(activeProblem?.primaryActionLabel
           ? [{

--- a/src/renderer/src/views/SubagentsWorkspaceView.tsx
+++ b/src/renderer/src/views/SubagentsWorkspaceView.tsx
@@ -1,0 +1,323 @@
+import type {
+  DismissDriftRequest,
+  ResolveIssueRequest,
+  SkillInventorySnapshot,
+  SubagentIssueReason,
+  SubagentRecord,
+} from '@shared/contracts';
+import { useEffect, type RefObject } from 'react';
+
+import {
+  getSubagentDisplayName,
+  getSubagentSections,
+  hasSearchQuery,
+} from '../inventory-view-model';
+import {
+  filterVisibleSections,
+  getPillToneForSubagent,
+  getSubagentStatusLabels,
+  type SubagentStatusFilter,
+} from '../lib/inventory-presentation';
+import type { InspectorModel } from '../lib/detail-inspector-model';
+import { getSubagentResolveActionState } from '../lib/issue-resolution';
+import { DetailInspectorPanel } from '../components/DetailInspectorPanel';
+import {
+  EmptyStatePanel,
+  HeaderSearch,
+  InventoryKeyboardHint,
+  InventoryListRow,
+  InventorySectionBlock,
+  PageTopBar,
+  PLUGIN_SUBAGENT_TOOLTIP,
+  RescanToolbarButton,
+  WorkspaceFilterBar,
+} from '../components/ui';
+
+export function SubagentsWorkspaceView({
+  inventorySnapshot,
+  isDismissingDrift,
+  isResolvingIssue,
+  isRescanning,
+  onClearSelection,
+  onDismissDrift,
+  onResolveIssue,
+  onRescan,
+  onSearchQueryChange,
+  onSelectProblem,
+  onSelectSubagent,
+  onSelectVariant,
+  onStatusFilterChange,
+  rows,
+  sandboxRoot,
+  searchInputRef,
+  searchQuery,
+  selectedSubagent,
+  selectedSubagentInspectorModel,
+  selectedSubagentProblemKey,
+  statusFilter,
+}: {
+  inventorySnapshot: SkillInventorySnapshot | null;
+  isDismissingDrift: boolean;
+  isResolvingIssue: boolean;
+  isRescanning: boolean;
+  onClearSelection: () => void;
+  onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
+  onResolveIssue: (request: ResolveIssueRequest) => Promise<void>;
+  onRescan: () => Promise<void>;
+  onSearchQueryChange: (query: string) => void;
+  onSelectProblem: (problemKey: SubagentIssueReason | null) => void;
+  onSelectSubagent: (name: string | null) => void;
+  onSelectVariant: (path: string | null) => void;
+  onStatusFilterChange: (filter: SubagentStatusFilter) => void;
+  rows: SubagentRecord[];
+  sandboxRoot: string | null;
+  searchInputRef: RefObject<HTMLInputElement | null>;
+  searchQuery: string;
+  selectedSubagent: SubagentRecord | null;
+  selectedSubagentInspectorModel: InspectorModel | null;
+  selectedSubagentProblemKey: SubagentIssueReason | null;
+  statusFilter: SubagentStatusFilter;
+}) {
+  const sections = filterVisibleSections(inventorySnapshot ? getSubagentSections(inventorySnapshot) : [], rows);
+  const filters = inventorySnapshot?.subagentCounts
+    ? [
+        { label: 'All', count: inventorySnapshot.subagentCounts.totalSubagents, value: 'all' as const, tone: 'neutral' as const },
+        { label: 'Needs attention', count: inventorySnapshot.subagentCounts.attentionSubagents, value: 'active' as const, tone: 'attention' as const },
+        { label: 'Dismissed', count: inventorySnapshot.subagentCounts.dismissedAttentionSubagents, value: 'dismissed' as const, tone: 'muted' as const },
+        { label: 'Healthy', count: inventorySnapshot.subagentCounts.healthySubagents, value: 'none' as const, tone: 'healthy' as const },
+      ]
+    : [];
+  const emptyStateMessage = inventorySnapshot?.subagentCounts
+    ? getSubagentEmptyStateMessage({
+        searchQuery,
+        statusFilter,
+        totalSubagents: inventorySnapshot.subagentCounts.totalSubagents,
+      })
+    : 'Scanning your subagent inventory...';
+
+  useEffect(() => {
+    if (!selectedSubagent) {
+      return;
+    }
+
+    scrollSelectedInventoryRowIntoView('Subagent list');
+  }, [selectedSubagent]);
+
+  return (
+    <main className="workspace-view">
+      <PageTopBar
+        actions={<RescanToolbarButton isRescanning={isRescanning} onRescan={onRescan} />}
+        search={(
+          <HeaderSearch
+            inputRef={searchInputRef}
+            label="Search subagents"
+            onChange={onSearchQueryChange}
+            placeholder="Search subagents..."
+            query={searchQuery}
+          />
+        )}
+        title="Subagents"
+      />
+
+      <div className="page-scroll page-scroll--split">
+        <WorkspaceFilterBar
+          activeFilter={statusFilter}
+          ariaLabel="Subagent filters"
+          filters={filters}
+          onFilterChange={onStatusFilterChange}
+          trailing={<InventoryKeyboardHint />}
+        />
+
+        <div className={`split-workspace split-workspace--detail${selectedSubagent ? '' : ' split-workspace--detail-collapsed'}`}>
+          <section className="master-list-panel" aria-label="Subagent list">
+            {inventorySnapshot ? (
+              sections.length > 0 ? (
+                sections.map((section) => (
+                  <InventorySectionBlock
+                    key={section.title}
+                    count={section.rows.length}
+                    title={section.title.toUpperCase()}
+                  >
+                    {section.rows.map((row) => (
+                      <InventoryListRow
+                        badges={getSubagentStatusLabels(row).map((label) => ({
+                          label,
+                          tone: getPillToneForSubagent(row),
+                        }))}
+                        description={row.description ?? undefined}
+                        isLocked={hasPluginSubagentLocation(row)}
+                        isSelected={selectedSubagent?.name === row.name}
+                        lockedTooltip={PLUGIN_SUBAGENT_TOOLTIP}
+                        key={row.name}
+                        name={getSubagentDisplayName(row)}
+                        onClick={() => onSelectSubagent(row.name)}
+                      />
+                    ))}
+                  </InventorySectionBlock>
+                ))
+              ) : (
+                <EmptyStatePanel message={emptyStateMessage} />
+              )
+            ) : (
+              <EmptyStatePanel message="Scanning your subagent inventory..." />
+            )}
+          </section>
+
+          {selectedSubagent ? (
+            <SubagentDetailPanel
+              isDismissingDrift={isDismissingDrift}
+              isResolvingIssue={isResolvingIssue}
+              inventorySnapshot={inventorySnapshot}
+              onClearSelection={onClearSelection}
+              onDismissDrift={onDismissDrift}
+              onSelectProblem={onSelectProblem}
+              onSelectVariant={onSelectVariant}
+              onResolveIssue={onResolveIssue}
+              sandboxRoot={sandboxRoot}
+              selectedSubagentInspectorModel={selectedSubagentInspectorModel}
+              selectedSubagentProblemKey={selectedSubagentProblemKey}
+              subagent={selectedSubagent}
+            />
+          ) : null}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function SubagentDetailPanel({
+  isDismissingDrift,
+  isResolvingIssue,
+  inventorySnapshot,
+  onClearSelection,
+  onDismissDrift,
+  onSelectProblem,
+  onSelectVariant,
+  onResolveIssue,
+  sandboxRoot,
+  selectedSubagentInspectorModel,
+  selectedSubagentProblemKey,
+  subagent,
+}: {
+  isDismissingDrift: boolean;
+  isResolvingIssue: boolean;
+  inventorySnapshot: SkillInventorySnapshot | null;
+  onClearSelection: () => void;
+  onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
+  onSelectProblem: (problemKey: SubagentIssueReason | null) => void;
+  onSelectVariant: (path: string | null) => void;
+  onResolveIssue: (request: ResolveIssueRequest) => Promise<void>;
+  sandboxRoot: string | null;
+  selectedSubagentInspectorModel: InspectorModel | null;
+  selectedSubagentProblemKey: SubagentIssueReason | null;
+  subagent: SubagentRecord;
+}) {
+  if (!selectedSubagentInspectorModel) {
+    return null;
+  }
+
+  const resolveAction = getSubagentResolveActionState(subagent, selectedSubagentInspectorModel, inventorySnapshot);
+
+  return (
+    <DetailInspectorPanel
+      entityKind="subagent"
+      footerActions={[
+        ...(selectedSubagentInspectorModel.activeProblem.primaryActionLabel
+          ? [{
+            disabled: !resolveAction.request || isResolvingIssue,
+            label: isResolvingIssue ? 'Applying…' : selectedSubagentInspectorModel.activeProblem.primaryActionLabel,
+            onClick: () => {
+              if (!resolveAction.request) {
+                return;
+              }
+
+              void onResolveIssue(resolveAction.request);
+            },
+            shortcut: 'F',
+            title: resolveAction.disabledReason ?? undefined,
+            variant: 'strong' as const,
+          }]
+          : []),
+        ...(subagent.status === 'needs-attention'
+          ? [{
+            disabled: isDismissingDrift,
+            label: getSubagentDismissActionLabel(subagent, isDismissingDrift),
+            onClick: () => {
+              void onDismissDrift({ subagentName: subagent.name });
+            },
+            shortcut: 'D',
+            variant: 'subtle' as const,
+          }]
+          : []),
+        ...(selectedSubagentInspectorModel.activeProblem.key === 'invalid-definition'
+          ? [{
+            label: 'Click a file name above to open it, then fix the definition.',
+            variant: 'note' as const,
+          }]
+          : []),
+      ]}
+      model={selectedSubagentInspectorModel}
+      ariaLabel="Subagent detail"
+      paneClassName={`subagent-inspector-panel${selectedSubagentProblemKey ? ' subagent-inspector-panel--problem-selected' : ''}`}
+      sandboxRoot={sandboxRoot}
+      onClose={onClearSelection}
+      onProblemSelect={(problemKey: InspectorModel['problems'][number]['key']) => {
+        onSelectProblem(problemKey as SubagentIssueReason);
+      }}
+      onVariantSelect={(path: string) => {
+        onSelectVariant(path);
+      }}
+    />
+  );
+}
+
+function getSubagentEmptyStateMessage({
+  searchQuery,
+  statusFilter,
+  totalSubagents,
+}: {
+  searchQuery: string;
+  statusFilter: SubagentStatusFilter;
+  totalSubagents: number;
+}): string {
+  if (hasSearchQuery(searchQuery)) {
+    return `No subagents match "${searchQuery.trim()}".`;
+  }
+
+  if (totalSubagents === 0) {
+    return 'No subagents were found in the agent folders Skill Index scanned.';
+  }
+
+  switch (statusFilter) {
+    case 'active':
+      return 'No subagents needing attention found.';
+    case 'none':
+      return 'No healthy subagents found.';
+    case 'dismissed':
+      return 'No dismissed subagents found.';
+    default:
+      return 'No subagents found.';
+  }
+}
+
+function getSubagentDismissActionLabel(subagent: SubagentRecord, isDismissingDrift: boolean): string {
+  const isDismissed = subagent.presentation === 'dismissed';
+
+  if (isDismissingDrift) {
+    return isDismissed ? 'Undismissing issues with this subagent…' : 'Dismissing issues with this subagent…';
+  }
+
+  return isDismissed ? 'Undismiss issues with this subagent' : 'Dismiss issues with this subagent';
+}
+
+function hasPluginSubagentLocation(subagent: SubagentRecord): boolean {
+  return subagent.locations.some((location) => location.provenance?.kind === 'plugin');
+}
+
+function scrollSelectedInventoryRowIntoView(ariaLabel: string) {
+  window.requestAnimationFrame(() => {
+    const list = document.querySelector<HTMLElement>(`[aria-label="${ariaLabel}"]`);
+    const selectedRow = list?.querySelector<HTMLElement>('.master-list-row--selected');
+    selectedRow?.scrollIntoView?.({ block: 'nearest' });
+  });
+}

--- a/src/renderer/src/views/SubagentsWorkspaceView.tsx
+++ b/src/renderer/src/views/SubagentsWorkspaceView.tsx
@@ -313,7 +313,9 @@ function getSubagentDismissActionLabel(subagent: SubagentRecord, isDismissingDri
 }
 
 function hasPluginSubagentLocation(subagent: SubagentRecord): boolean {
-  return subagent.locations.some((location) => location.provenance?.kind === 'plugin');
+  return subagent.locations.some((location) =>
+    location.agentId.startsWith('plugin:')
+    || location.provenance?.kind === 'plugin');
 }
 
 function scrollSelectedInventoryRowIntoView(ariaLabel: string) {

--- a/src/shared/agent-catalog-overrides.ts
+++ b/src/shared/agent-catalog-overrides.ts
@@ -5,6 +5,9 @@ import type {
   AgentMcpSupportedTransport,
   AgentMcpWriteDialect,
   AgentMetadataSource,
+  AgentSubagentConfigKind,
+  AgentSubagentParserKind,
+  AgentSubagentWriteDialect,
 } from './contracts';
 import type { UpstreamAgentResolutionContext } from './upstream-agent-catalog';
 import { resolveUpstreamAgentContext } from './upstream-agent-catalog';
@@ -17,13 +20,19 @@ export interface KnownAgentFamilyOverrideDefinition {
   ignoredSkillSubpathsByDisplayPath?: Record<string, string[]>;
   resolveLiveMcpConfigPathOverride?: (context?: UpstreamAgentResolutionContext) => string;
   resolveLiveAgentConfigPathOverride?: (context?: UpstreamAgentResolutionContext) => string;
+  resolveLiveSubagentsDirOverride?: (context?: UpstreamAgentResolutionContext) => string;
   mcpConfigRelativeParts?: string[];
   agentConfigRelativeParts?: string[];
+  subagentGlobalDirRelativeParts?: string[];
+  subagentProjectDir?: string;
   expectedExecutableNames?: string[];
   mcpConfigKind?: AgentMcpConfigKind;
   mcpParserKind?: AgentMcpParserKind;
   mcpWriteDialect?: AgentMcpWriteDialect;
   mcpSupportedTransports?: AgentMcpSupportedTransport[];
+  subagentConfigKind?: AgentSubagentConfigKind;
+  subagentParserKind?: AgentSubagentParserKind;
+  subagentWriteDialect?: AgentSubagentWriteDialect;
   metadataSources?: AgentMetadataSource[];
   icon?: AgentIconRecord;
 }
@@ -128,6 +137,8 @@ const RENDERABLE_ICON_FORMATS = new Set([
 export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   {
     family: 'adal',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.adal', 'settings.json'],
     agentConfigRelativeParts: ['.adal', 'settings.json'],
     mcpConfigKind: 'agent-config',
@@ -141,6 +152,8 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'amp',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.config', 'amp', 'settings.json'],
     agentConfigRelativeParts: ['.config', 'amp', 'settings.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) => resolveConfigHomePath(context, 'amp', 'settings.json'),
@@ -157,6 +170,8 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'antigravity',
+    subagentConfigKind: 'plugin-only',
+    subagentParserKind: 'unknown',
     mcpConfigRelativeParts: ['.gemini', 'antigravity', 'mcp_config.json'],
     mcpConfigKind: 'dedicated-file',
     mcpParserKind: 'json-mcpServers',
@@ -168,6 +183,11 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'augment',
+    subagentGlobalDirRelativeParts: ['.augment', 'agents'],
+    subagentProjectDir: '.augment/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.augment', 'settings.json'],
     agentConfigRelativeParts: ['.augment', 'settings.json'],
     mcpConfigKind: 'agent-config',
@@ -176,6 +196,7 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://docs.augmentcode.com/cli/config', 'Config reference'),
       source('https://docs.augmentcode.com/cli/integrations', 'MCP and integrations'),
+      source('https://docs.augmentcode.com/cli/subagents', 'Subagent directory and Markdown format'),
     ],
     icon: icon(
       'https://www.augmentcode.com/favicon.svg',
@@ -185,6 +206,8 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'bob',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.bob', 'mcp_settings.json'],
     agentConfigRelativeParts: ['.bob', 'settings.json'],
     mcpConfigKind: 'dedicated-file',
@@ -200,6 +223,11 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     family: 'claude',
     label: 'Claude Code',
     aliases: ['claude-code'],
+    subagentGlobalDirRelativeParts: ['.claude', 'agents'],
+    subagentProjectDir: '.claude/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigKind: 'dedicated-file',
     mcpParserKind: 'json-mcpServers',
     mcpWriteDialect: 'json-type-url',
@@ -211,6 +239,7 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://code.claude.com/docs/en/settings', 'Settings path and config root'),
       source('https://code.claude.com/docs/en/mcp', 'MCP file layout'),
+      source('https://code.claude.com/docs/en/sub-agents', 'Subagent directory and Markdown format'),
       source('https://code.claude.com/docs/en/env-vars', 'CLAUDE_CONFIG_DIR override'),
     ],
     icon: icon(
@@ -223,6 +252,8 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     family: 'claude-desktop',
     label: 'Claude Desktop',
     aliases: ['claude-for-desktop'],
+    subagentConfigKind: 'account-managed',
+    subagentParserKind: 'none',
     mcpConfigKind: 'dedicated-file',
     mcpParserKind: 'json-mcpServers',
     mcpWriteDialect: 'json-url',
@@ -234,6 +265,7 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://modelcontextprotocol.io/docs/develop/connect-local-servers', 'Claude Desktop local MCP config path and mcpServers JSON format'),
       source('https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop', 'Desktop extensions and MCPB are the current local MCP install path'),
       source('https://support.claude.com/en/articles/12512180-use-skills-in-claude', 'Claude app skills are managed from claude.ai Customize > Skills'),
+      source('https://support.claude.com/en/articles/13837440-use-plugins-in-claude-cowork', 'Claude Cowork plugins can bundle sub-agents; no standalone local agent path is documented'),
     ],
     icon: icon(
       'https://cdn.prod.website-files.com/6889473510b50328dbb70ae6/68c33859cc6cd903686c66a2_apple-touch-icon.png',
@@ -243,6 +275,8 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'cline',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.cline', 'data', 'settings', 'cline_mcp_settings.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) =>
       joinPath(resolveClineConfigDir(context), 'data', 'settings', 'cline_mcp_settings.json'),
@@ -252,17 +286,24 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://docs.cline.bot/cline-cli/configuration#setting-up-mcp-servers', 'Official Cline CLI MCP settings path and format'),
       source('https://docs.cline.bot/cline-cli/configuration#configuration-directory', 'Official Cline configuration directory layout'),
+      source('https://docs.cline.bot/features/subagents', 'Built-in read-only subagents; no documented custom local subagent files'),
     ],
     icon: icon('https://cline.bot/assets/branding/brand/App%20Icons/PNG/APP_ICON_LIGHT.png', 'png', 'Official square app icon'),
   },
   {
     family: 'codebuddy',
+    subagentGlobalDirRelativeParts: ['.codebuddy', 'agents'],
+    subagentProjectDir: '.codebuddy/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.codebuddy', '.mcp.json'],
     mcpConfigKind: 'dedicated-file',
     mcpParserKind: 'jsonc-mcpServers',
     mcpWriteDialect: 'json-url',
     metadataSources: [
       source('https://www.codebuddy.ai/docs/cli/mcp#configuration-files', 'Official CodeBuddy CLI MCP configuration files'),
+      source('https://www.codebuddy.ai/docs/cli/sub-agents', 'Sub-agent directory and Markdown format'),
     ],
     icon: icon('https://cdn.prod.website-files.com/65a6a15ecd9b4909597c6be5/689dfd72095849f4e1693503_Stack-Icon-Thin.svg', 'svg', 'Official square stack icon'),
   },
@@ -271,6 +312,12 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     ignoredSkillSubpathsByDisplayPath: {
       '~/.codex/skills': ['.system'],
     },
+    subagentGlobalDirRelativeParts: ['.codex', 'agents'],
+    subagentProjectDir: '.codex/agents',
+    resolveLiveSubagentsDirOverride: (context = {}) => joinPath(resolveCodexConfigDir(context), 'agents'),
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'codex-toml',
+    subagentWriteDialect: 'codex-toml',
     mcpConfigRelativeParts: ['.codex', 'config.toml'],
     agentConfigRelativeParts: ['.codex', 'config.toml'],
     resolveLiveMcpConfigPathOverride: (context = {}) => joinPath(resolveCodexConfigDir(context), 'config.toml'),
@@ -282,22 +329,31 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://platform.openai.com/docs/codex/cli/configuration', 'Codex config path and settings'),
       source('https://platform.openai.com/docs/codex/cli/mcp', 'Codex MCP config in TOML'),
+      source('https://developers.openai.com/codex/subagents', 'Codex subagent directory and TOML format'),
     ],
     icon: icon('https://openai.com/favicon.ico', 'ico', 'OpenAI favicon fallback for Codex'),
   },
   {
     family: 'command-code',
+    subagentGlobalDirRelativeParts: ['.commandcode', 'agents'],
+    subagentProjectDir: '.commandcode/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.commandcode', 'mcp.json'],
     mcpConfigKind: 'dedicated-file',
     mcpParserKind: 'json-mcpServers',
     metadataSources: [
       source('https://commandcode.ai/docs/mcp/manage', 'MCP config'),
       source('https://commandcode.ai/docs/skills/manage', 'Skills directory and local state'),
+      source('https://commandcode.ai/docs/core-concepts/custom-agents', 'Custom agents directory and Markdown format'),
     ],
     icon: icon('https://commandcode.ai/favicon/2024/safari-pinned-tab.svg', 'svg'),
   },
   {
     family: 'continue',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.continue', 'mcpServers'],
     agentConfigRelativeParts: ['.continue', 'config.yaml'],
     mcpConfigKind: 'directory',
@@ -306,6 +362,7 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://docs.continue.dev/customize/deep-dives/configuration', 'Continue config'),
       source('https://docs.continue.dev/customize/deep-dives/mcp', 'Continue MCP directory support'),
+      source('https://docs.continue.dev/hub/agents/overview', 'Hosted agents; no documented local subagent directory'),
     ],
     icon: icon(
       'https://www.continue.dev/favicon.png',
@@ -315,6 +372,11 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'cortex',
+    subagentGlobalDirRelativeParts: ['.snowflake', 'cortex', 'agents'],
+    subagentProjectDir: '.cortex/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.snowflake', 'cortex', 'mcp.json'],
     agentConfigRelativeParts: ['.snowflake', 'cortex', 'settings.json'],
     mcpConfigKind: 'dedicated-file',
@@ -322,6 +384,7 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://docs.snowflake.com/en/user-guide/cortex-code/settings', 'Cortex settings'),
       source('https://docs.snowflake.com/en/user-guide/cortex-code/extensibility', 'Cortex MCP extensibility'),
+      source('https://docs.snowflake.com/en/user-guide/cortex-code/extensibility', 'Cortex custom subagents and agent directories'),
     ],
     icon: icon(
       'https://www.snowflake.com/etc.clientlibs/snowflake-site/clientlibs/clientlib-react/resources/apple-touch-icon.png?v=3',
@@ -331,6 +394,8 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'crush',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.config', 'crush', 'crush.json'],
     agentConfigRelativeParts: ['.config', 'crush', 'crush.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) =>
@@ -348,6 +413,8 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'cursor',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.cursor', 'mcp.json'],
     agentConfigRelativeParts: ['.cursor', 'cli-config.json'],
     mcpConfigKind: 'dedicated-file',
@@ -356,6 +423,7 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://docs.cursor.com/en/cli/reference/configuration', 'Cursor CLI config'),
       source('https://docs.cursor.com/context/model-context-protocol', 'Cursor MCP config'),
+      source('https://docs.cursor.com/agent', 'Cursor modes; no documented local custom subagent files'),
       source('https://cursor.com/brand', 'Brand assets'),
     ],
     icon: icon(
@@ -366,6 +434,8 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'deepagents',
+    subagentConfigKind: 'unknown',
+    subagentParserKind: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.deepagents', '.mcp.json'],
     agentConfigRelativeParts: ['.deepagents', 'config.toml'],
     mcpConfigKind: 'dedicated-file',
@@ -373,6 +443,7 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://docs.langchain.com/oss/python/deepagents/cli/configuration', 'Config path'),
       source('https://docs.langchain.com/oss/python/deepagents/cli/mcp-tools', 'Dedicated MCP file'),
+      source('https://docs.langchain.com/oss/python/deepagents/cli/subagents', 'Subagent format; user path is agent-name dependent'),
     ],
     icon: icon(
       'https://deepagents.org/deep_icon.svg',
@@ -384,6 +455,11 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     family: 'factory',
     label: 'Factory',
     aliases: ['droid'],
+    subagentGlobalDirRelativeParts: ['.factory', 'droids'],
+    subagentProjectDir: '.factory/droids',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.factory', 'mcp.json'],
     agentConfigRelativeParts: ['.factory', 'settings.json'],
     expectedExecutableNames: ['factory'],
@@ -393,11 +469,14 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://docs.factory.ai/cli/configuration/settings', 'Factory settings'),
       source('https://docs.factory.ai/factory-cli/configuration/mcp', 'Factory MCP config'),
+      source('https://docs.factory.ai/cli/configuration/custom-droids', 'Custom droids directory and Markdown format'),
     ],
     icon: icon('https://factory.ai/favicon.svg', 'svg'),
   },
   {
     family: 'firebender',
+    subagentConfigKind: 'agent-config',
+    subagentParserKind: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.firebender', 'firebender.json'],
     agentConfigRelativeParts: ['.firebender', 'firebender.json'],
     mcpConfigKind: 'agent-config',
@@ -405,11 +484,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://firebender.com/docs/configuration', 'Config file location'),
       source('https://firebender.com/docs/mcp', 'Inline MCP config'),
+      source('https://docs.firebender.com/multi-agent/subagents', 'Subagents are files referenced from config'),
     ],
     icon: icon('https://firebender.com/icon.svg', 'svg'),
   },
   {
     family: 'gemini-cli',
+    subagentGlobalDirRelativeParts: ['.gemini', 'agents'],
+    subagentProjectDir: '.gemini/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.gemini', 'settings.json'],
     agentConfigRelativeParts: ['.gemini', 'settings.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) =>
@@ -422,11 +507,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/configuration.md', 'Gemini CLI config'),
       source('https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md', 'Gemini CLI MCP'),
+      source('https://github.com/google-gemini/gemini-cli/blob/main/docs/core/subagents.md', 'Subagent directory and Markdown format'),
     ],
     icon: icon('https://geminicli.com/icon.png', 'png'),
   },
   {
     family: 'github-copilot',
+    subagentGlobalDirRelativeParts: ['.copilot', 'agents'],
+    subagentProjectDir: '.github/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.copilot', 'mcp-config.json'],
     agentConfigRelativeParts: ['.copilot', 'config.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) => joinPath(resolveCopilotConfigDir(context), 'mcp-config.json'),
@@ -437,12 +528,15 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://docs.github.com/en/copilot/customizing-copilot/configuring-github-copilot-in-your-environment', 'Copilot config'),
       source('https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-chat-with-mcp', 'Copilot MCP'),
+      source('https://docs.github.com/en/copilot/reference/custom-agents-configuration', 'Copilot custom agents paths and Markdown format'),
       source('https://brand.github.com/', 'Brand assets'),
     ],
     icon: icon('https://github.com/github.png', 'png', 'Use the square GitHub logo for compact Copilot badges'),
   },
   {
     family: 'goose',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.config', 'goose', 'config.yaml'],
     agentConfigRelativeParts: ['.config', 'goose', 'config.yaml'],
     resolveLiveMcpConfigPathOverride: (context = {}) => joinPath(resolveGooseConfigDir(context), 'config.yaml'),
@@ -453,11 +547,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://block.github.io/goose/docs/getting-started/configuration/', 'Goose config'),
       source('https://block.github.io/goose/docs/mcp/configuration/', 'Goose MCP in YAML'),
+      source('https://block.github.io/goose/docs/guides/subagents/', 'Subagents use runtime delegation/recipes, not a documented local agents directory'),
     ],
     icon: icon('https://goose-docs.ai/img/favicon.ico', 'ico', 'Official square favicon for compact badges'),
   },
   {
     family: 'iflow-cli',
+    subagentGlobalDirRelativeParts: ['.iflow', 'agents'],
+    subagentProjectDir: '.iflow/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.iflow', 'mcp', 'config.json'],
     agentConfigRelativeParts: ['.iflow', 'settings.json'],
     resolveLiveAgentConfigPathOverride: (context = {}) =>
@@ -467,11 +567,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://iflow-cli.ai/docs/configuration', 'iFlow config'),
       source('https://iflow-cli.ai/docs/mcp', 'Dedicated and inline MCP support'),
+      source('https://platform.iflow.cn/en/cli/examples/subagent', 'Subagent directory and Markdown frontmatter fields'),
     ],
     icon: icon('https://img.alicdn.com/imgextra/i4/O1CN01VFxaDc1s3EZKig0PM_!!6000000005710-0-tps-300-300.jpg', 'jpg'),
   },
   {
     family: 'junie',
+    subagentGlobalDirRelativeParts: ['.junie', 'agents'],
+    subagentProjectDir: '.junie/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.junie', 'mcp', 'mcp.json'],
     agentConfigRelativeParts: ['.junie', 'AGENTS.md'],
     resolveLiveAgentConfigPathOverride: (context = {}) =>
@@ -481,11 +587,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://www.jetbrains.com/help/junie/configure-guidelines.html', 'Guidelines/config file'),
       source('https://www.jetbrains.com/help/junie/model-context-protocol.html', 'MCP settings'),
+      source('https://junie.jetbrains.com/docs/junie-cli-subagents.html', 'Custom subagents directories and Markdown format'),
     ],
     icon: icon('https://resources.jetbrains.com/help/img/idea/2026.1/junie-logo.svg', 'svg'),
   },
   {
     family: 'kilo',
+    subagentGlobalDirRelativeParts: ['.config', 'kilo', 'agents'],
+    subagentProjectDir: '.kilo/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.config', 'kilo', 'kilo.jsonc'],
     agentConfigRelativeParts: ['.config', 'kilo', 'kilo.jsonc'],
     resolveLiveMcpConfigPathOverride: (context = {}) => resolveConfigHomePath(context, 'kilo', 'kilo.jsonc'),
@@ -494,11 +606,14 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     mcpParserKind: 'jsonc-mcp',
     metadataSources: [
       source('https://kilo.ai/docs/automate/mcp/using-in-kilo-code', 'Kilo MCP in config'),
+      source('https://kilo.ai/docs/customize/custom-subagents', 'Custom subagents directory and Markdown/JSONC formats'),
     ],
     icon: icon('https://avatars.githubusercontent.com/u/201822503?s=512&v=4', 'png'),
   },
   {
     family: 'kimi-cli',
+    subagentConfigKind: 'unknown',
+    subagentParserKind: 'yaml',
     mcpConfigRelativeParts: ['.kimi', 'mcp.json'],
     agentConfigRelativeParts: ['.kimi', 'config.toml'],
     resolveLiveMcpConfigPathOverride: (context = {}) => joinPath(resolveKimiConfigDir(context), 'mcp.json'),
@@ -508,11 +623,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://github.com/MoonshotAI/Kimi-K2/blob/main/docs/kimi-cli/configuration.md', 'Kimi config'),
       source('https://github.com/MoonshotAI/Kimi-K2/blob/main/docs/kimi-cli/mcp.md', 'Kimi MCP'),
+      source('https://moonshotai.github.io/kimi-cli/en/customization/agents.html', 'Agent YAML supports nested subagents but no documented scanned global directory'),
     ],
     icon: icon('https://moonshotai.github.io/Branding-Guide/scenarios/04-k-only/k-only-light.svg', 'svg'),
   },
   {
     family: 'kiro-cli',
+    subagentGlobalDirRelativeParts: ['.kiro', 'agents'],
+    subagentProjectDir: '.kiro/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'json',
+    subagentWriteDialect: 'json',
     mcpConfigRelativeParts: ['.kiro', 'settings', 'mcp.json'],
     agentConfigRelativeParts: ['.kiro', 'agents'],
     mcpConfigKind: 'dedicated-file',
@@ -521,11 +642,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://kiro.dev/docs/configuration', 'Kiro config layout'),
       source('https://kiro.dev/docs/mcp', 'Kiro MCP settings'),
+      source('https://kiro.dev/docs/cli/custom-agents/creating/', 'Custom agents directory and JSON format'),
     ],
     icon: icon('https://kiro.dev/icon.svg?fe599162bb293ea0', 'svg'),
   },
   {
     family: 'kode',
+    subagentGlobalDirRelativeParts: ['.kode', 'agents'],
+    subagentProjectDir: '.kode/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.mcp.json'],
     agentConfigRelativeParts: ['.kode.json'],
     mcpConfigKind: 'dedicated-file',
@@ -533,11 +660,14 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://raw.githubusercontent.com/shareAI-lab/Kode/main/README.md', 'Main README and MCP files'),
       source('https://raw.githubusercontent.com/shareAI-lab/Kode/main/docs/develop/configuration.md', 'Config location'),
+      source('https://github.com/shareAI-lab/Kode-Agent/blob/main/docs/agents-system.md', 'Agents directories and Markdown format'),
     ],
     icon: icon('https://avatars.githubusercontent.com/u/189210346?v=4', 'png', 'Stable square fallback via the ShareAI Lab org avatar'),
   },
   {
     family: 'mcpjam',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigKind: 'none',
     mcpParserKind: 'none',
     metadataSources: [
@@ -548,6 +678,11 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'mistral-vibe',
+    subagentGlobalDirRelativeParts: ['.vibe', 'agents'],
+    subagentProjectDir: '.vibe/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'toml',
+    subagentWriteDialect: 'toml',
     mcpConfigRelativeParts: ['.vibe', 'config.toml'],
     agentConfigRelativeParts: ['.vibe', 'config.toml'],
     mcpConfigKind: 'agent-config',
@@ -556,11 +691,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://github.com/mistralai/mistral-vibe/blob/main/docs/configuration.md', 'Vibe config'),
       source('https://github.com/mistralai/mistral-vibe/blob/main/docs/mcp.md', 'Vibe MCP in TOML'),
+      source('https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/agents/manager.py', 'Agents directory scanning and TOML format'),
     ],
     icon: icon('https://raw.githubusercontent.com/mistralai/mistral-vibe/main/distribution/zed/icons/mistral_vibe.svg', 'svg'),
   },
   {
     family: 'mux',
+    subagentGlobalDirRelativeParts: ['.mux', 'agents'],
+    subagentProjectDir: '.mux/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.mux', 'mcp.jsonc'],
     agentConfigRelativeParts: ['.mux', 'config.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) => joinPath(resolveMuxConfigDir(context), 'mcp.jsonc'),
@@ -570,12 +711,15 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://mux.coder.com/docs/configuration', 'Mux config'),
       source('https://mux.coder.com/docs/mcp', 'Mux MCP config'),
+      source('https://mux.coder.com/agents', 'Agents directory and Markdown format'),
       source('https://mux.coder.com/', 'Brand source page'),
     ],
     icon: icon('https://mux.coder.com/', 'html', 'Official source page only; a stable square asset still needs to be vendored'),
   },
   {
     family: 'neovate',
+    subagentConfigKind: 'unknown',
+    subagentParserKind: 'unknown',
     mcpConfigRelativeParts: ['.neovate', 'config.json'],
     agentConfigRelativeParts: ['.neovate', 'config.json'],
     mcpConfigKind: 'agent-config',
@@ -583,11 +727,14 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://neovate.dev/docs/configuration', 'Neovate config'),
       source('https://neovate.dev/docs/mcp', 'Neovate MCP'),
+      source('https://neovateai.dev/docs/features', 'Subagents exist, but exact local paths were not confirmed'),
     ],
     icon: icon('https://mdn.alipayobjects.com/huamei_9rin5s/afts/img/Q48CQ7a8GLEAAAAAQBAAAAgADiB8AQFr/original', 'svg'),
   },
   {
     family: 'openclaw',
+    subagentConfigKind: 'agent-config',
+    subagentParserKind: 'jsonc',
     mcpConfigRelativeParts: ['.openclaw', 'openclaw.json'],
     agentConfigRelativeParts: ['.openclaw', 'openclaw.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) =>
@@ -601,11 +748,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://github.com/openclaw/openclaw/blob/main/README.md', 'Main README'),
       source('https://github.com/openclaw/openclaw/blob/main/docs/configuration.md', 'Config path and env vars'),
       source('https://github.com/openclaw/openclaw/blob/main/docs/mcp.md', 'Nested MCP config'),
+      source('https://docs.openclaw.ai/tools/subagents', 'Subagents are configured/spawned through OpenClaw config and sessions'),
     ],
     icon: icon('https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png', 'png', 'Official logo image; replace with a square mark if one is published'),
   },
   {
     family: 'opencode',
+    subagentGlobalDirRelativeParts: ['.config', 'opencode', 'agents'],
+    subagentProjectDir: '.opencode/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.config', 'opencode', 'opencode.json'],
     agentConfigRelativeParts: ['.config', 'opencode', 'opencode.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) =>
@@ -618,12 +771,18 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://opencode.ai/docs/config/', 'OpenCode config'),
       source('https://opencode.ai/docs/mcp-servers/', 'OpenCode MCP in config'),
+      source('https://dev.opencode.ai/docs/agents/', 'Agents directories and Markdown/JSON formats'),
       source('https://opencode.ai/brand', 'Brand assets'),
     ],
     icon: icon('https://opencode.ai/apple-touch-icon-v3.png', 'png', 'Official square app icon'),
   },
   {
     family: 'openhands',
+    subagentGlobalDirRelativeParts: ['.openhands', 'agents'],
+    subagentProjectDir: '.openhands/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.openhands', 'mcp.json'],
     agentConfigRelativeParts: ['.openhands', 'agent_settings.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) => joinPath(resolveOpenHandsDir(context), 'mcp.json'),
@@ -634,11 +793,14 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://docs.openhands.dev/openhands/usage/cli/command-reference', 'Explicit agent_settings.json path'),
       source('https://docs.openhands.dev/openhands/usage/settings/mcp-settings', 'Dedicated MCP file'),
       source('https://docs.openhands.dev/openhands/usage/environment-variables', 'OH_PERSISTENCE_DIR'),
+      source('https://docs.openhands.dev/sdk/guides/agent-file-based', 'File-based agents and Markdown format'),
     ],
     icon: icon('https://raw.githubusercontent.com/OpenHands/docs/main/openhands/static/img/logo.png', 'png'),
   },
   {
     family: 'pi',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     agentConfigRelativeParts: ['.pi', 'agent', 'settings.json'],
     resolveLiveAgentConfigPathOverride: (context = {}) => joinPath(resolvePiConfigDir(context), 'settings.json'),
     mcpConfigKind: 'none',
@@ -646,11 +808,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/settings.md', 'Pi settings path'),
       source('https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md', 'Pi explicitly documents no MCP in core'),
+      source('https://pi.dev/packages/pi-subagents', 'Subagents are package-provided, not core Pi local format'),
     ],
     icon: icon('https://framerusercontent.com/images/Hu7aeJCxpUvwSxyA5mfRMSPAqAU.svg', 'svg', 'Official square favicon'),
   },
   {
     family: 'pochi',
+    subagentGlobalDirRelativeParts: ['.pochi', 'agents'],
+    subagentProjectDir: '.pochi/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.pochi', 'config.jsonc'],
     agentConfigRelativeParts: ['.pochi', 'config.jsonc'],
     mcpConfigKind: 'agent-config',
@@ -660,11 +828,17 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://docs.getpochi.com/', 'Pochi global and workspace config'),
       source('https://docs.getpochi.com/mcp/', 'Inline MCP block'),
       source('https://docs.getpochi.com/cli/', 'CLI env vars'),
+      source('https://docs.getpochi.com/custom-agent/', 'Custom agent directories and Markdown format'),
     ],
     icon: icon('https://raw.githubusercontent.com/TabbyML/pochi/main/packages/vscode/assets/icons/pochi-logo.svg', 'svg'),
   },
   {
     family: 'qoder',
+    subagentGlobalDirRelativeParts: ['.qoder', 'agents'],
+    subagentProjectDir: '.qoder/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.qoder.json'],
     agentConfigRelativeParts: ['.qoder', 'settings.json'],
     mcpConfigKind: 'dedicated-file',
@@ -673,6 +847,7 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://docs.qoder.com/cli/using-cli', 'CLI config and MCP file'),
       source('https://docs.qoder.com/extensions/hooks', 'Settings path hierarchy'),
       source('https://docs.qoder.com/user-guide/chat/model-context-protocol', 'MCP UX'),
+      source('https://docs.qoder.com/en/cli/subagent', 'Subagent directory and Markdown format'),
     ],
     icon: icon(
       'https://img.alicdn.com/imgextra/i3/O1CN01KliT1u1jEq947NlKH_!!6000000004517-55-tps-180-180.svg',
@@ -682,6 +857,11 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'qwen-code',
+    subagentGlobalDirRelativeParts: ['.qwen', 'agents'],
+    subagentProjectDir: '.qwen/agents',
+    subagentConfigKind: 'directory',
+    subagentParserKind: 'markdown-frontmatter',
+    subagentWriteDialect: 'markdown-frontmatter',
     mcpConfigRelativeParts: ['.qwen', 'settings.json'],
     agentConfigRelativeParts: ['.qwen', 'settings.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) =>
@@ -695,22 +875,28 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://raw.githubusercontent.com/QwenLM/qwen-code/main/docs/users/configuration/settings.md', 'Qwen Code settings'),
       source('https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/', 'Qwen Code MCP'),
       source('https://qwenlm.github.io/qwen-code-docs/en/developers/tools/mcp-server/', 'Developer MCP reference'),
+      source('https://qwenlm.github.io/qwen-code-docs/en/users/features/sub-agents/', 'Sub-agent directories and Markdown format'),
     ],
     icon: icon('https://avatars.githubusercontent.com/u/141221163?s=200&v=4', 'png'),
   },
   {
     family: 'replit',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigKind: 'none',
     mcpParserKind: 'none',
     metadataSources: [
       source('https://docs.replit.com/replitai/skills', 'Replit skills docs'),
       source('https://docs.replit.com/replitai/mcp/overview', 'MCP is managed through Replit UI, not a documented local file'),
       source('https://docs.replit.com/replitai/mcp/install-links', 'Replit MCP install flow'),
+      source('https://docs.replit.com/replitai/agents-and-automations', 'Hosted agents; no documented local subagent directory'),
     ],
     icon: icon('https://replit.com/public/icons/favicon-prompt-192-rebrand.png', 'png'),
   },
   {
     family: 'roo',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['Library', 'Application Support', 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) =>
       joinPath(
@@ -731,11 +917,14 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://github.com/RooCodeInc/Roo-Code/security/advisories/GHSA-5x8h-m52g-5v54', 'Project-specific MCP override at .roo/mcp.json'),
       source('https://github.com/RooCodeInc/Roo-Code/issues/2273', 'Global mcp_settings.json path example'),
       source('https://github.com/RooCodeInc/Roo-Code/issues/3788', 'customStoragePath and mcp_settings.json migration behavior'),
+      source('https://roocodeinc.github.io/Roo-Code/features/custom-modes/', 'Custom modes, not standalone subagent files'),
     ],
     icon: icon('https://github.com/RooCodeInc.png', 'png', 'Official GitHub org avatar'),
   },
   {
     family: 'trae',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['trae_config.yaml'],
     agentConfigRelativeParts: ['trae_config.yaml'],
     resolveLiveMcpConfigPathOverride: (context = {}) =>
@@ -749,11 +938,14 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://github.com/bytedance/trae-agent/blob/main/README.md', 'Trae Agent README'),
       source('https://github.com/bytedance/trae-agent/blob/main/trae_agent/cli.py', 'TRAE_CONFIG_FILE and --config-file'),
       source('https://github.com/bytedance/trae-agent/blob/main/trae_agent/utils/config.py', 'YAML config parser and mcp_servers'),
+      source('https://docs.trae.ai/ide/custom-agents-ready-for-one-click-import', 'Product custom agents; no local file format confirmed for Trae Agent OSS'),
     ],
     icon: icon('https://avatars.githubusercontent.com/u/192691831?s=200&v=4', 'png'),
   },
   {
     family: 'trae-cn',
+    subagentConfigKind: 'account-managed',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['Library', 'Application Support', 'Trae', 'User', 'settings', 'mcp.json'],
     resolveLiveMcpConfigPathOverride: (context = {}) =>
       joinPath(resolveUpstreamAgentContext(context).homeDir, 'Library', 'Application Support', 'Trae', 'User', 'settings', 'mcp.json'),
@@ -763,11 +955,14 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://forum.trae.cn/t/topic/6780', 'Official community support thread with MCP paths'),
       source('https://forum.trae.cn/t/topic/6433', 'Project-local .trae/mcp.json references'),
       source('https://www.trae.cn/changelog', 'Official product site'),
+      source('https://forum.trae.cn/t/topic/15119', 'Custom agents are UI/account managed; no local file path documented'),
     ],
     icon: icon('https://lf-cdn.trae.com.cn/obj/trae-com-cn/trae_website_prod_cn/favicon.png', 'png', 'Official square favicon'),
   },
   {
     family: 'warp',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     agentConfigRelativeParts: ['.config', 'warp-terminal', 'user_preferences.json'],
     resolveLiveAgentConfigPathOverride: (context = {}) => resolveConfigHomePath(context, 'warp-terminal', 'user_preferences.json'),
     mcpConfigKind: 'none',
@@ -775,12 +970,15 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
     metadataSources: [
       source('https://docs.warp.dev/terminal/warpify/subshells', 'Warp user preferences file'),
       source('https://docs.warp.dev/agent-platform/capabilities/mcp', 'Warp MCP is app-managed; no documented local config file'),
+      source('https://docs.warp.dev/agent-platform/cloud-agents/skills-as-agents', 'Skills as agents, not local custom subagent profiles'),
       source('https://www.warp.dev/', 'Brand/homepage'),
     ],
     icon: icon('https://framerusercontent.com/images/GybmHeNj1WzkgFqIjQYypmhg.png', 'png'),
   },
   {
     family: 'windsurf',
+    subagentConfigKind: 'none',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.codeium', 'windsurf', 'mcp_config.json'],
     mcpConfigKind: 'dedicated-file',
     mcpParserKind: 'json-mcpServers',
@@ -795,6 +993,8 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
   },
   {
     family: 'zencoder',
+    subagentConfigKind: 'account-managed',
+    subagentParserKind: 'none',
     mcpConfigRelativeParts: ['.zencoder', 'settings.json'],
     agentConfigRelativeParts: ['.zencoder', 'settings.json'],
     mcpConfigKind: 'agent-config',
@@ -804,6 +1004,7 @@ export const KNOWN_AGENT_FAMILY_OVERRIDES = [
       source('https://docs.zencoder.ai/features/custom-models-configuration', 'Zencoder settings file path'),
       source('https://docs.zencoder.ai/features/integrations-and-mcp', 'Zencoder MCP in settings'),
       source('https://docs.zencoder.ai/features/autonomous-agents-configuration', 'Related settings evolution'),
+      source('https://docs.zencoder.ai/features/ai-agents', 'UI-managed AI agents; no documented local subagent files'),
     ],
     icon: icon('https://zencoder.ai/hubfs/export.png', 'png'),
   },

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -604,6 +604,7 @@ export interface SubagentLocationRecord {
   modifiedAt: string;
   canonical: boolean;
   format: AgentSubagentParserKind;
+  description?: string | null;
   definitionText?: string;
   definitionComparisonKey?: string;
   localExtrasKeys?: string[];

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -224,6 +224,12 @@ export interface PluginMcpRef {
   sourceId: string;
 }
 
+export interface PluginSubagentRef {
+  name: string;
+  path: string;
+  sourceId: string;
+}
+
 export interface PluginUnsupportedAssetRef {
   kind: 'hook';
   name: string;
@@ -243,6 +249,7 @@ export interface PluginRecord {
   skillRoots?: string[];
   bundledSkills: PluginSkillRef[];
   bundledMcps: PluginMcpRef[];
+  bundledSubagents?: PluginSubagentRef[];
   unsupportedAssets?: PluginUnsupportedAssetRef[];
   unsupportedHooksCount?: number;
   source?: {
@@ -427,6 +434,26 @@ export interface AgentIconRecord {
   note?: string;
 }
 
+export type AgentSubagentConfigKind = 'directory' | 'agent-config' | 'plugin-only' | 'account-managed' | 'none' | 'unknown';
+export type AgentSubagentParserKind =
+  | 'markdown-frontmatter'
+  | 'codex-toml'
+  | 'json'
+  | 'jsonc'
+  | 'toml'
+  | 'yaml'
+  | 'none'
+  | 'unknown';
+export type AgentSubagentWriteDialect =
+  | 'markdown-frontmatter'
+  | 'codex-toml'
+  | 'json'
+  | 'jsonc'
+  | 'toml'
+  | 'yaml'
+  | 'none'
+  | 'unknown';
+
 export interface AgentRecord {
   id: string;
   family: string;
@@ -441,10 +468,14 @@ export interface AgentRecord {
   mcpParserKind?: AgentMcpParserKind;
   mcpWriteDialect?: AgentMcpWriteDialect;
   mcpSupportedTransports?: AgentMcpSupportedTransport[];
+  subagentConfigKind?: AgentSubagentConfigKind;
+  subagentParserKind?: AgentSubagentParserKind;
+  subagentWriteDialect?: AgentSubagentWriteDialect;
   metadataSources?: AgentMetadataSource[];
   icon?: AgentIconRecord;
   skillsLocation: AgentLocationRecord;
   mcpConfigLocation: AgentLocationRecord;
+  subagentsLocation?: AgentLocationRecord;
   configLocation?: AgentLocationRecord;
   executableLocation?: AgentLocationRecord;
 }
@@ -551,6 +582,69 @@ export interface McpInventoryCounts {
   dismissedAttentionMcps: number;
 }
 
+export type SubagentIssueReason =
+  | 'missing-universal'
+  | 'missing-from-agents'
+  | 'definition-mismatch'
+  | 'identical-copies'
+  | 'broken-symlink'
+  | 'wrong-symlink-target'
+  | 'invalid-definition';
+export type SubagentStatus = 'healthy' | 'needs-attention';
+export type SubagentPresentation = 'none' | 'active' | 'dismissed';
+
+export interface SubagentLocationRecord {
+  agentId: string;
+  agentLabel: string;
+  scope: SkillSourceScope;
+  path: string;
+  directoryPath: string;
+  fileType: SkillLocationType;
+  modifiedAt: string;
+  canonical: boolean;
+  format: AgentSubagentParserKind;
+  definitionText?: string;
+  definitionComparisonKey?: string;
+  localExtrasKeys?: string[];
+  invalidDetails?: string[];
+  resolvedPath?: string;
+  symlinkTarget?: string;
+  provenance?: SkillProvenance;
+  canonicalRole?: CanonicalRole;
+  mutability?: Mutability;
+}
+
+export interface SubagentExpectedLocationRecord {
+  agentId: string;
+  agentLabel: string;
+  scope: SkillSourceScope;
+  directoryPath?: string;
+  path?: string;
+  format?: AgentSubagentParserKind;
+  supportStatus?: 'supported' | 'unsupported';
+  unsupportedReason?: 'not-documented' | 'unsupported-format' | 'account-managed';
+}
+
+export interface SubagentRecord {
+  name: string;
+  displayName?: string | null;
+  description?: string | null;
+  status: SubagentStatus;
+  presentation: SubagentPresentation;
+  locations: SubagentLocationRecord[];
+  expectedLocations?: SubagentExpectedLocationRecord[];
+  missingLocations?: SubagentExpectedLocationRecord[];
+  issueReasons: SubagentIssueReason[];
+  signature?: string;
+}
+
+export interface SubagentInventoryCounts {
+  totalSubagents: number;
+  attentionSubagents: number;
+  healthySubagents: number;
+  dismissedAttentionSubagents: number;
+}
+
 export interface HomeSummaryMetric {
   total: number;
   healthy: number;
@@ -572,6 +666,8 @@ export interface SkillInventorySnapshot {
   counts: SkillInventoryCounts;
   mcps?: McpRecord[];
   mcpCounts?: McpInventoryCounts;
+  subagents?: SubagentRecord[];
+  subagentCounts?: SubagentInventoryCounts;
   agents?: AgentRecord[];
   agentCounts?: AgentInventoryCounts;
   homeSummary?: HomeSummary;
@@ -600,6 +696,13 @@ export type SkillResolvableIssue =
   | 'wrong-symlink-target';
 
 export type McpResolvableIssue = 'definition-mismatch' | 'missing-from-agents';
+export type SubagentResolvableIssue =
+  | 'missing-universal'
+  | 'missing-from-agents'
+  | 'definition-mismatch'
+  | 'identical-copies'
+  | 'broken-symlink'
+  | 'wrong-symlink-target';
 
 export type ResolveIssueRequest =
   | {
@@ -615,6 +718,15 @@ export type ResolveIssueRequest =
     issue: McpResolvableIssue;
     selectedVariantPath?: string;
     skillName?: never;
+    subagentName?: never;
+  }
+  | {
+    entity: 'subagent';
+    subagentName: string;
+    issue: SubagentResolvableIssue;
+    selectedVariantPath?: string;
+    skillName?: never;
+    mcpName?: never;
   };
 
 export type CapabilityActionRequest = {
@@ -630,10 +742,17 @@ export type DismissDriftRequest =
   | {
     skillName: string;
     mcpName?: never;
+    subagentName?: never;
   }
   | {
     mcpName: string;
     skillName?: never;
+    subagentName?: never;
+  }
+  | {
+    subagentName: string;
+    skillName?: never;
+    mcpName?: never;
   };
 
 export interface SeededFixtureExpectation {
@@ -686,6 +805,7 @@ export type AddMcpServerRequest =
 export type AuditOperationKind =
   | 'resolve-skill-issue'
   | 'resolve-mcp-issue'
+  | 'resolve-subagent-issue'
   | 'add-skill'
   | 'add-mcp-server'
   | 'settings-update'
@@ -784,7 +904,7 @@ export interface AuditOperation {
   status: AuditOperationStatus;
   actor: 'app';
   sourceMode: InventorySourceMode;
-  entity?: { type: 'skill' | 'mcp' | 'settings' | 'sandbox'; name?: string };
+  entity?: { type: 'skill' | 'mcp' | 'subagent' | 'settings' | 'sandbox'; name?: string };
   failure?: AuditFailureDiagnostic;
   undoState: AuditUndoState;
   actionCount: number;

--- a/src/shared/known-agent-catalog.ts
+++ b/src/shared/known-agent-catalog.ts
@@ -5,6 +5,9 @@ import type {
   AgentMcpSupportedTransport,
   AgentMcpWriteDialect,
   AgentMetadataSource,
+  AgentSubagentConfigKind,
+  AgentSubagentParserKind,
+  AgentSubagentWriteDialect,
 } from './contracts';
 import {
   UPSTREAM_AGENT_FAMILIES,
@@ -36,11 +39,17 @@ export interface KnownAgentFamilyDefinition {
   mcpParserKind?: AgentMcpParserKind;
   mcpWriteDialect?: AgentMcpWriteDialect;
   mcpSupportedTransports?: AgentMcpSupportedTransport[];
+  subagentConfigKind?: AgentSubagentConfigKind;
+  subagentParserKind?: AgentSubagentParserKind;
+  subagentWriteDialect?: AgentSubagentWriteDialect;
+  subagentGlobalDirRelativeParts?: string[];
+  subagentProjectDir?: string;
   metadataSources?: AgentMetadataSource[];
   icon?: AgentIconRecord;
   resolveLiveSkillsDir: (context?: UpstreamAgentResolutionContext) => string;
   resolveLiveMcpConfigPath?: (context?: UpstreamAgentResolutionContext) => string;
   resolveLiveAgentConfigPath?: (context?: UpstreamAgentResolutionContext) => string;
+  resolveLiveSubagentsDir?: (context?: UpstreamAgentResolutionContext) => string;
   detectInstalled: (context?: UpstreamAgentResolutionContext) => boolean;
 }
 
@@ -87,11 +96,17 @@ export const KNOWN_AGENT_FAMILIES: readonly KnownAgentFamilyDefinition[] = (UPST
     mcpParserKind: override.mcpParserKind,
     mcpWriteDialect: override.mcpWriteDialect,
     mcpSupportedTransports: override.mcpSupportedTransports,
+    subagentConfigKind: override.subagentConfigKind,
+    subagentParserKind: override.subagentParserKind,
+    subagentWriteDialect: override.subagentWriteDialect,
+    subagentGlobalDirRelativeParts: override.subagentGlobalDirRelativeParts,
+    subagentProjectDir: override.subagentProjectDir,
     metadataSources,
     icon: override.icon,
     resolveLiveSkillsDir: upstreamFamily.resolveGlobalSkillsDir,
     resolveLiveMcpConfigPath: override.resolveLiveMcpConfigPathOverride,
     resolveLiveAgentConfigPath: override.resolveLiveAgentConfigPathOverride,
+    resolveLiveSubagentsDir: override.resolveLiveSubagentsDirOverride,
     detectInstalled: upstreamFamily.detectInstalled,
   };
 });

--- a/src/shared/skill-index-paths.test.ts
+++ b/src/shared/skill-index-paths.test.ts
@@ -160,6 +160,7 @@ describe('ensureSkillIndexLayout', () => {
           onboardingCompletedAt: null,
           dismissedDriftSignatures: [],
           dismissedMcpSignatures: [],
+          dismissedSubagentSignatures: [],
           skillUniversalDecisions: [],
         },
         null,

--- a/src/shared/skill-index-paths.ts
+++ b/src/shared/skill-index-paths.ts
@@ -42,12 +42,17 @@ export interface SkillIndexConfig {
   onboardingCompletedAt?: string | null;
   dismissedDriftSignatures: string[];
   dismissedMcpSignatures: string[];
+  dismissedSubagentSignatures: string[];
   skillUniversalDecisions?: SkillUniversalDecision[];
 }
 
-export type WritableSkillIndexConfig = Omit<SkillIndexConfig, 'showDevSidebarInventorySourceSwitcher' | 'onboardingCompletedAt'> & {
+export type WritableSkillIndexConfig = Omit<
+  SkillIndexConfig,
+  'showDevSidebarInventorySourceSwitcher' | 'onboardingCompletedAt' | 'dismissedSubagentSignatures'
+> & {
   showDevSidebarInventorySourceSwitcher?: boolean;
   onboardingCompletedAt?: string | null;
+  dismissedSubagentSignatures?: string[];
 };
 
 export const defaultConfig: SkillIndexConfig = {
@@ -57,6 +62,7 @@ export const defaultConfig: SkillIndexConfig = {
   onboardingCompletedAt: null,
   dismissedDriftSignatures: [],
   dismissedMcpSignatures: [],
+  dismissedSubagentSignatures: [],
   skillUniversalDecisions: [],
 };
 
@@ -217,6 +223,7 @@ export async function writeSkillIndexConfig(configFile: string, config: Writable
     ...config,
     showDevSidebarInventorySourceSwitcher: config.showDevSidebarInventorySourceSwitcher ?? true,
     onboardingCompletedAt: config.onboardingCompletedAt ?? null,
+    dismissedSubagentSignatures: config.dismissedSubagentSignatures ?? [],
   }, null, 2)}
 `;
   const tempFile = path.join(
@@ -294,6 +301,9 @@ function parseSkillIndexConfig(raw: string, options: ResolveSkillIndexPathOption
       : [],
     dismissedMcpSignatures: Array.isArray(parsed.dismissedMcpSignatures)
       ? parsed.dismissedMcpSignatures.filter(isString)
+      : [],
+    dismissedSubagentSignatures: Array.isArray(parsed.dismissedSubagentSignatures)
+      ? parsed.dismissedSubagentSignatures.filter(isString)
       : [],
     skillUniversalDecisions: Array.isArray(parsed.skillUniversalDecisions)
       ? parsed.skillUniversalDecisions.filter(isSkillUniversalDecision)

--- a/src/shared/subagent-format-policy.test.ts
+++ b/src/shared/subagent-format-policy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getSubagentFileNameForFormat,
+  inferSubagentParserKindFromPath,
+  isMarkdownSubagentSymlinkCompatible,
+  isSubagentFormatRenderableFromUniversal,
+  isSupportedSubagentDirectoryFormat,
+} from './subagent-format-policy';
+
+describe('subagent format policy', () => {
+  it('treats YAML as a supported directory format', () => {
+    expect(isSupportedSubagentDirectoryFormat('yaml')).toBe(true);
+    expect(inferSubagentParserKindFromPath('/Users/tester/.kimi/agents/reviewer.yaml', 'unknown')).toBe('yaml');
+    expect(inferSubagentParserKindFromPath('/Users/tester/.kimi/agents/reviewer.yml', 'unknown')).toBe('yaml');
+    expect(getSubagentFileNameForFormat({ name: 'reviewer', format: 'yaml' })).toBe('reviewer.yaml');
+  });
+
+  it('centralizes renderability and Markdown symlink compatibility checks', () => {
+    expect(isSubagentFormatRenderableFromUniversal('yaml', 'markdown-frontmatter')).toBe(true);
+    expect(isSubagentFormatRenderableFromUniversal('yaml', 'json')).toBe(false);
+    expect(isMarkdownSubagentSymlinkCompatible('claude')).toBe(true);
+    expect(isMarkdownSubagentSymlinkCompatible('mux')).toBe(false);
+    expect(isMarkdownSubagentSymlinkCompatible('iflow-cli')).toBe(false);
+  });
+});

--- a/src/shared/subagent-format-policy.ts
+++ b/src/shared/subagent-format-policy.ts
@@ -1,0 +1,134 @@
+import type { AgentSubagentParserKind } from './contracts';
+
+export type SupportedSubagentDirectoryFormat = Exclude<AgentSubagentParserKind, 'none' | 'unknown'>;
+
+export const SUPPORTED_SUBAGENT_DIRECTORY_FORMATS = [
+  'markdown-frontmatter',
+  'codex-toml',
+  'json',
+  'jsonc',
+  'toml',
+  'yaml',
+] as const satisfies SupportedSubagentDirectoryFormat[];
+
+const SUPPORTED_SUBAGENT_DIRECTORY_FORMAT_SET = new Set<AgentSubagentParserKind>(
+  SUPPORTED_SUBAGENT_DIRECTORY_FORMATS,
+);
+
+export function isSupportedSubagentDirectoryFormat(
+  format: AgentSubagentParserKind,
+): format is SupportedSubagentDirectoryFormat {
+  return SUPPORTED_SUBAGENT_DIRECTORY_FORMAT_SET.has(format);
+}
+
+export function isSubagentFormatRenderableFromUniversal(
+  targetFormat: AgentSubagentParserKind,
+  universalFormat: AgentSubagentParserKind,
+): boolean {
+  return targetFormat === universalFormat
+    || (universalFormat === 'markdown-frontmatter'
+      && isSupportedSubagentDirectoryFormat(targetFormat));
+}
+
+export function getSubagentFileNameForFormat({
+  name,
+  format,
+  family,
+  canonicalPath,
+}: {
+  name: string;
+  format: AgentSubagentParserKind;
+  family?: string;
+  canonicalPath?: string;
+}): string {
+  const baseName = sanitizeSubagentFileBaseName(name);
+  if (family === 'github-copilot') {
+    return `${baseName}.agent.md`;
+  }
+
+  const extension = getSubagentFileExtensionForFormat(format)
+    ?? getPathExtension(canonicalPath)
+    ?? '.md';
+  return `${baseName}${extension}`;
+}
+
+export function inferSubagentParserKindFromPath(
+  filePath: string,
+  fallback: AgentSubagentParserKind,
+): AgentSubagentParserKind {
+  const extension = getPathExtension(filePath)?.toLowerCase();
+  switch (extension) {
+    case '.md':
+      return 'markdown-frontmatter';
+    case '.toml':
+      return 'toml';
+    case '.json':
+      return 'json';
+    case '.jsonc':
+      return 'jsonc';
+    case '.yaml':
+    case '.yml':
+      return 'yaml';
+    default:
+      return fallback;
+  }
+}
+
+export function isMarkdownSubagentSymlinkCompatible(family: string | undefined): boolean {
+  const requiredFields = getRequiredMarkdownSubagentFields(family);
+  return requiredFields.every((field) => field === 'name' || field === 'description');
+}
+
+export function getRequiredMarkdownSubagentFields(family: string | undefined): string[] {
+  switch (family) {
+    case 'augment':
+    case 'factory':
+    case 'openhands':
+      return ['name'];
+    case 'mux':
+      return ['name', 'subagent.runnable'];
+    case 'github-copilot':
+    case 'junie':
+    case 'kilo':
+    case 'opencode':
+    case 'pochi':
+      return ['description'];
+    case 'iflow-cli':
+      return ['agentType', 'systemPrompt', 'whenToUse'];
+    default:
+      return ['name', 'description'];
+  }
+}
+
+function getSubagentFileExtensionForFormat(format: AgentSubagentParserKind): string | null {
+  switch (format) {
+    case 'markdown-frontmatter':
+      return '.md';
+    case 'codex-toml':
+    case 'toml':
+      return '.toml';
+    case 'json':
+      return '.json';
+    case 'jsonc':
+      return '.jsonc';
+    case 'yaml':
+      return '.yaml';
+    default:
+      return null;
+  }
+}
+
+function sanitizeSubagentFileBaseName(name: string): string {
+  return name.replace(/[^A-Za-z0-9._-]+/gu, '-');
+}
+
+function getPathExtension(filePath: string | undefined): string | null {
+  if (!filePath) {
+    return null;
+  }
+
+  const separatorIndex = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  const fileName = filePath.slice(separatorIndex + 1);
+  const dotIndex = fileName.lastIndexOf('.');
+  return dotIndex > 0 ? fileName.slice(dotIndex) : null;
+}


### PR DESCRIPTION
Changes:

Adds subagent inventory scanning, Subagents UI, plugin subagent discovery, representative sandbox scenarios, resolution and dismissal actions, YAML subagent format support, and entity-prefixed Home auto-resolve grouping.

Validation:
pnpm typecheck
pnpm test -- src/shared/subagent-format-policy.test.ts src/main/subagent-inventory.test.ts src/main/plugin-inventory.test.ts src/main/issue-resolution.test.ts src/renderer/src/lib/issue-resolution.test.ts
pnpm test -- src/renderer/src/views/HomeDashboard.test.tsx
pnpm lint
