### PR TITLE
Add subagent homepage attention summary

### DIFF
--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -250,10 +250,7 @@ describe('App shell inventory views', () => {
   }
 
   function getHomeAttentionSection() {
-    const heading = screen.getByRole('heading', { name: /^Skills needing attention$/i, level: 3 });
-    const section = heading.closest('section');
-    expect(section).not.toBeNull();
-    return section as HTMLElement;
+    return screen.getByRole('region', { name: /^Needs attention$/i });
   }
 
   async function openAgents() {
@@ -770,32 +767,33 @@ describe('App shell inventory views', () => {
     expect(screen.queryByText('App-made changes will appear here.')).not.toBeInTheDocument();
   });
 
-  it('shows only the approved Home summary metrics', async () => {
+  it('shows only the approved Home inventory metrics', async () => {
     render(<App />);
 
-    await screen.findByLabelText(/Home summary metrics/i);
+    await screen.findByLabelText(/Home inventory metrics/i);
     expect(document.querySelectorAll('.metric-card-icon')).toHaveLength(0);
-    expect(document.querySelectorAll('.stat-card')).toHaveLength(2);
+    expect(document.querySelectorAll('.home-inventory-cell')).toHaveLength(3);
     expect(getHomeStatValue('Skills', 'on disk')).toBe('8');
     expect(getHomeStatValue('Skills', 'need attention')).toBe('3');
+    expect(getHomeStatValue('Subagents', 'on disk')).toBe('0');
+    expect(getHomeStatValue('Subagents', 'need attention')).toBe('0');
     expect(getHomeStatValue('MCPs', 'servers')).toBe('6');
     expect(getHomeStatValue('MCPs', 'need attention')).toBe('1');
-    expect(document.querySelector('.stat-card-label')?.textContent).not.toBe('Agents');
+    expect(document.querySelector('.home-inventory-label')?.textContent).not.toBe('Agents');
     expect(screen.queryByText(/^All Skills$/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/^Drift$/i)).not.toBeInTheDocument();
-    expect(screen.queryByLabelText(/Home summary metrics/i)).not.toHaveTextContent(/^Plugins$/i);
+    expect(screen.queryByLabelText(/Home inventory metrics/i)).not.toHaveTextContent(/^Plugins$/i);
+    expect(screen.queryByLabelText(/Home inventory metrics/i)).not.toHaveTextContent(/^Commands$/i);
   });
 
-  it('shows positive healthy states on Home when no Skills or MCPs need attention', async () => {
+  it('shows a positive healthy state on Home when no content needs attention', async () => {
     readCachedInventoryMock.mockResolvedValue(createAllHealthyInventorySnapshot());
     scanInventoryMock.mockResolvedValue(createAllHealthyInventorySnapshot());
 
     render(<App />);
 
-    expect(await screen.findByText('All 8 skills are in their expected state')).toBeInTheDocument();
-    expect(screen.getByText(/Canonical sources present, symlinks resolved, no version drift\. Last checked/i)).toBeInTheDocument();
-    expect(screen.getByText('All 6 MCP servers are healthy')).toBeInTheDocument();
-    expect(screen.getByText(/Configs match across all agents, versions aligned, no args drift\. Last checked/i)).toBeInTheDocument();
+    expect(await screen.findByText('Everything is in its expected state')).toBeInTheDocument();
+    expect(screen.getByText(/Canonical sources present, symlinks resolved, no drift across all 3 content types\. Last checked/i)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /diverged-drift-skill/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /broken-mcp/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/Overview queue/i)).not.toBeInTheDocument();
@@ -868,18 +866,17 @@ describe('App shell inventory views', () => {
     render(<App />);
 
     await screen.findByRole('button', { name: /diverged-drift-skill/i });
-    const skillSection = getHomeAttentionSection();
-    const mcpHeading = screen.getByRole('heading', { name: /^MCPs needing attention$/i, level: 3 });
-    const mcpSection = mcpHeading.closest('section');
+    const attentionSection = getHomeAttentionSection();
 
-    expect(mcpSection).not.toBeNull();
     expect(screen.queryByText(/Overview queue/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Open any skill or MCP below/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/deserves a closer look/i)).not.toBeInTheDocument();
-    expect(within(skillSection).queryByRole('table')).not.toBeInTheDocument();
-    expect(within(skillSection).getByRole('button', { name: /diverged-drift-skill/i })).toBeInTheDocument();
-    expect(within(skillSection).getByRole('button', { name: /identical-drift-skill/i })).toBeInTheDocument();
-    expect(within(mcpSection as HTMLElement).getByRole('button', { name: /broken-mcp/i })).toBeInTheDocument();
+    expect(within(attentionSection).queryByRole('table')).not.toBeInTheDocument();
+    expect(within(attentionSection).getByText('Skills')).toBeInTheDocument();
+    expect(within(attentionSection).getByText('MCPs')).toBeInTheDocument();
+    expect(within(attentionSection).getByRole('button', { name: /diverged-drift-skill/i })).toBeInTheDocument();
+    expect(within(attentionSection).getByRole('button', { name: /identical-drift-skill/i })).toBeInTheDocument();
+    expect(within(attentionSection).getByRole('button', { name: /broken-mcp/i })).toBeInTheDocument();
   });
 
   it('keeps Home in a loading state until the first truthful inventory snapshot arrives', async () => {
@@ -892,12 +889,12 @@ describe('App shell inventory views', () => {
 
     expect(await screen.findByRole('heading', { name: /^Home$/i, level: 2 })).toBeInTheDocument();
     expect(screen.getByText(/Loading your inventory summary/i)).toBeInTheDocument();
-    expect(screen.queryByLabelText(/Home summary metrics/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Home inventory metrics/i)).not.toBeInTheDocument();
 
     cachedInventoryDeferred.resolve(null);
     liveInventoryDeferred.resolve(createOperationalBaselineInventorySnapshot());
 
-    await screen.findByLabelText(/Home summary metrics/i);
+    await screen.findByLabelText(/Home inventory metrics/i);
     expect(getHomeStatValue('Skills', 'on disk')).toBe('7');
     expect(getHomeAttentionSection()).toBeInTheDocument();
   });
@@ -916,8 +913,8 @@ describe('App shell inventory views', () => {
     render(<App />);
 
     expect(screen.getByRole('status', { name: /Loading Skill Index/i })).toBeInTheDocument();
-    expect(screen.queryByLabelText(/Home summary metrics/i)).not.toBeInTheDocument();
-    expect(await screen.findByLabelText(/Home summary metrics/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Home inventory metrics/i)).not.toBeInTheDocument();
+    expect(await screen.findByLabelText(/Home inventory metrics/i)).toBeInTheDocument();
     expect(getHomeStatValue('Skills', 'need attention')).toBe('3');
     expect(within(getPrimaryNav()).getByRole('button', { name: /^Skills/i })).toHaveTextContent(/^Skills38$/);
     expect(within(getPrimaryNav()).getByRole('button', { name: /^MCPs/i })).toHaveTextContent(/^MCPs16$/);
@@ -1105,7 +1102,7 @@ describe('App shell inventory views', () => {
 
     render(<App />);
 
-    await screen.findByLabelText(/Home summary metrics/i);
+    await screen.findByLabelText(/Home inventory metrics/i);
     fireEvent.click(screen.getByRole('button', { name: /^Rescan$/i }));
 
     await waitFor(() => {
@@ -1328,7 +1325,7 @@ describe('App shell inventory views', () => {
   it('reconciles Home summary counts with Skills, MCPs, and Agents partitions while keeping dismissed issues out of tab badges', async () => {
     render(<App />);
 
-    await screen.findByLabelText(/Home summary metrics/i);
+    await screen.findByLabelText(/Home inventory metrics/i);
     expect(getHomeStatValue('Skills', 'on disk')).toBe('8');
     expect(getHomeStatValue('Skills', 'need attention')).toBe('3');
     expect(getHomeStatValue('MCPs', 'servers')).toBe('6');
@@ -1774,7 +1771,7 @@ describe('App shell inventory views', () => {
     expect(screen.getByRole('button', { name: /^Skills/i })).toHaveTextContent(/^Skills28$/);
 
     fireEvent.click(screen.getByRole('button', { name: /^Home$/i }));
-    await screen.findByLabelText(/Home summary metrics/i);
+    await screen.findByLabelText(/Home inventory metrics/i);
     expect(getHomeStatValue('Skills', 'on disk')).toBe('8');
     expect(getHomeStatValue('Skills', 'need attention')).toBe('2');
   });
@@ -1954,7 +1951,7 @@ describe('App shell inventory views', () => {
 
     render(<App />);
 
-    await screen.findByLabelText(/Home summary metrics/i);
+    await screen.findByLabelText(/Home inventory metrics/i);
     expect(within(getPrimaryNav()).getByRole('button', { name: /^Agents/i })).toHaveTextContent(
       new RegExp(`^Agents${createOperationalBaselineInventorySnapshot().agentCounts?.installedAgents ?? 0}$`),
     );
@@ -1999,7 +1996,7 @@ describe('App shell inventory views', () => {
     expect(screen.getByText('vanishing-muted-skill')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /^Home$/i }));
-    await screen.findByLabelText(/Home summary metrics/i);
+    await screen.findByLabelText(/Home inventory metrics/i);
     expect(getHomeStatValue('Skills', 'need attention')).toBe('3');
   });
 
@@ -2538,13 +2535,27 @@ function createShellState(overrides: Partial<AppShellState> = {}): AppShellState
 }
 
 function getHomeStatValue(cardLabel: string, subLabel: string): string {
-  const cards = [...document.querySelectorAll<HTMLElement>('.stat-card')];
-  const card = cards.find((candidate) => candidate.querySelector('.stat-card-label')?.textContent === cardLabel);
-  const item = [...(card?.querySelectorAll<HTMLElement>('.stat-item') ?? [])].find(
-    (candidate) => candidate.querySelector('.stat-sub')?.textContent === subLabel,
-  );
+  const cards = [...document.querySelectorAll<HTMLElement>('.home-inventory-cell')];
+  const card = cards.find((candidate) => candidate.querySelector('.home-inventory-label')?.textContent === cardLabel);
+  if (!card) {
+    return '';
+  }
 
-  return item?.querySelector('.stat-num')?.textContent ?? '';
+  if (subLabel === 'need attention') {
+    const attentionText = card.querySelector('.home-inventory-attention')?.textContent ?? '';
+    return attentionText.match(/\d+/)?.[0] ?? '0';
+  }
+
+  const total = card.querySelector('.home-inventory-total');
+  const unit = card.querySelector('.home-inventory-unit');
+  if (unit?.textContent !== subLabel) {
+    return '';
+  }
+
+  return [...(total?.childNodes ?? [])]
+    .filter((node) => node.nodeType === Node.TEXT_NODE)
+    .map((node) => node.textContent?.trim() ?? '')
+    .join('');
 }
 
 function createSettingsState(

--- a/src/renderer/src/components/ui.test.tsx
+++ b/src/renderer/src/components/ui.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { AttentionGroupCard, CalloutCard, InventoryListRow } from './ui';
+import { CalloutCard, InventoryListRow } from './ui';
 
 describe('CalloutCard', () => {
   it('shows a warning icon for attention tone', () => {
@@ -28,41 +28,6 @@ describe('CalloutCard', () => {
     expect(container.querySelector('.callout-card')).toHaveClass('callout-card--iconless');
     expect(container.querySelector('.callout-card-icon')).toBeNull();
     expect(screen.getByText('Healthy across installed locations')).toBeInTheDocument();
-  });
-});
-
-describe('AttentionGroupCard', () => {
-  it('keeps the row clickable without rendering a Fix action pill', () => {
-    const onRowClick = vi.fn();
-
-    render(
-      <AttentionGroupCard
-        actionLabel="View all skills"
-        count={1}
-        emptyMessage="Nothing to fix"
-        items={[
-          {
-            badges: [
-              { label: 'Missing Symlinks', tone: 'attention' },
-              { label: 'Invalid Definition', tone: 'attention' },
-            ],
-            description: 'A drifted skill needs review.',
-            key: 'skill-a',
-            label: 'Skill A',
-            onClick: onRowClick,
-          },
-        ]}
-        onAction={() => {}}
-        title="Needs attention"
-      />,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: /skill a/i }));
-
-    expect(onRowClick).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText(/fix\s*[→-]/i)).not.toBeInTheDocument();
-    expect(screen.getByText('Missing Symlinks')).toBeInTheDocument();
-    expect(screen.getByText('Invalid Definition')).toBeInTheDocument();
   });
 });
 

--- a/src/renderer/src/components/ui.tsx
+++ b/src/renderer/src/components/ui.tsx
@@ -1,5 +1,5 @@
 import type { AgentRecord } from '@shared/contracts';
-import { Check, Plug, Search, X } from 'lucide-react';
+import { Plug, Search, X } from 'lucide-react';
 import {
   useEffect,
   useId,
@@ -365,92 +365,6 @@ export function CalloutCard({
 
 export function StaticSwitch({ active }: { active: boolean }) {
   return <span className={`static-switch${active ? ' static-switch--active' : ''}`} aria-hidden="true" />;
-}
-
-export function AttentionGroupCard({
-  actionLabel,
-  count,
-  emptyState,
-  emptyMessage,
-  items,
-  onAction,
-  title,
-}: {
-  actionLabel: string;
-  count: number;
-  emptyState?: {
-    description: string;
-    title: string;
-  };
-  emptyMessage: string;
-  items: Array<{
-    badges: Array<{
-      label: string;
-      tone: 'attention' | 'warning' | 'healthy' | 'muted';
-    }>;
-    description?: string;
-    isLocked?: boolean;
-    key: string;
-    label: string;
-    lockedTooltip?: string;
-    onClick: () => void;
-  }>;
-  onAction: () => void;
-  title: string;
-}) {
-  const isEmpty = items.length === 0;
-
-  return (
-    <section className={`attention-card${isEmpty && emptyState ? ' attention-card--clean' : ''}`}>
-      <div className="attention-card-header">
-        <div className="attention-card-title">
-          <h3>{title}</h3>
-          {count > 0 ? <span>{count}</span> : null}
-        </div>
-        {items.length > 0 ? (
-          <button className="attention-card-link" type="button" onClick={onAction}>
-            {actionLabel}
-          </button>
-        ) : null}
-      </div>
-
-      {!isEmpty ? (
-        <div className="attention-card-list">
-          {items.map((item) => (
-            <button className="attention-card-row" key={item.key} type="button" onClick={item.onClick}>
-              <div className="attention-card-copy">
-                <strong>
-                  <span>{item.label}</span>
-                  {item.isLocked ? (
-                    <PluginTooltipIndicator
-                      className="attention-card-row__plugin-indicator"
-                      tooltip={item.lockedTooltip ?? PLUGIN_SKILL_TOOLTIP}
-                    />
-                  ) : null}
-                </strong>
-                {item.description ? <p>{item.description}</p> : null}
-              </div>
-              <div className="attention-card-actions">
-                <StatusPillGroup badges={item.badges} />
-              </div>
-            </button>
-          ))}
-        </div>
-      ) : emptyState ? (
-        <div className="attention-card-clean-state">
-          <div className="attention-card-clean-icon" aria-hidden="true">
-            <Check />
-          </div>
-          <div className="attention-card-clean-copy">
-            <strong>{emptyState.title}</strong>
-            <p>{emptyState.description}</p>
-          </div>
-        </div>
-      ) : (
-        <EmptyStatePanel message={emptyMessage} />
-      )}
-    </section>
-  );
 }
 
 export function InventorySectionBlock({

--- a/src/renderer/src/inventory-view-model.test.ts
+++ b/src/renderer/src/inventory-view-model.test.ts
@@ -178,6 +178,12 @@ describe('inventory view ordering', () => {
       attentionMcps: 0,
       dismissedAttentionMcps: 4,
     };
+    snapshot.subagentCounts = {
+      totalSubagents: 6,
+      healthySubagents: 4,
+      attentionSubagents: 2,
+      dismissedAttentionSubagents: 1,
+    };
     snapshot.homeSummary = {
       skills: {
         total: 92,
@@ -198,6 +204,11 @@ describe('inventory view ordering', () => {
       },
       mcps: {
         needsAttention: 0,
+      },
+      subagents: {
+        total: 6,
+        healthy: 4,
+        needsAttention: 2,
       },
       installedAgents: snapshot.agentCounts?.installedAgents,
     });

--- a/src/renderer/src/inventory-view-model.ts
+++ b/src/renderer/src/inventory-view-model.ts
@@ -168,8 +168,17 @@ export function getHomeSummary(snapshot: SkillInventorySnapshot | null): HomeSum
       }
     : snapshot?.homeSummary?.mcps ?? { total: 0, healthy: 0, needsAttention: 0 };
 
+  const subagents = snapshot?.subagentCounts
+    ? {
+        total: snapshot.subagentCounts.totalSubagents,
+        healthy: snapshot.subagentCounts.healthySubagents,
+        needsAttention: snapshot.subagentCounts.attentionSubagents,
+      }
+    : snapshot?.homeSummary?.subagents ?? { total: 0, healthy: 0, needsAttention: 0 };
+
   return {
     skills,
+    subagents,
     mcps,
     installedAgents: snapshot?.agentCounts?.installedAgents ?? snapshot?.homeSummary?.installedAgents ?? 0,
   };

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -941,83 +941,6 @@ body {
   color: var(--text-secondary);
 }
 
-.stat-card-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-}
-
-.stat-card {
-  background: rgba(255, 255, 255, 0.96);
-  border: 1px solid var(--border-color);
-  border-radius: 10px;
-  padding: 12px 16px;
-  box-shadow: var(--shadow-panel);
-}
-
-.stat-card-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--text-secondary);
-  margin-bottom: 10px;
-}
-
-.stat-card-label svg {
-  width: 12px;
-  height: 12px;
-}
-
-.stat-card-row {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-}
-
-.stat-divider {
-  width: 1px;
-  height: 28px;
-  background: var(--border-color);
-  margin: 0 4px;
-  align-self: center;
-  flex-shrink: 0;
-}
-
-.stat-item {
-  flex: 1;
-}
-
-.stat-num {
-  font-size: 26px;
-  font-weight: 600;
-  letter-spacing: -0.025em;
-  line-height: 1;
-  color: var(--text-strong);
-}
-
-.stat-num--alert {
-  color: var(--attention);
-}
-
-.stat-num--warn {
-  color: #b36a14;
-}
-
-.stat-num--muted {
-  color: var(--text-muted);
-}
-
-.stat-sub {
-  font-size: 11.5px;
-  color: var(--text-secondary);
-  margin-top: 3px;
-  line-height: 1.3;
-}
-
 /* Repair surface */
 .repair-surface {
   border: 1px solid var(--border-color);
@@ -1373,7 +1296,6 @@ body {
   color: var(--accent);
 }
 
-.attention-card,
 .agent-group-card,
 .settings-card,
 .master-list-panel,
@@ -1384,15 +1306,6 @@ body {
   box-shadow: var(--shadow-panel);
 }
 
-.attention-card {
-  overflow: hidden;
-}
-
-.attention-card--clean {
-  flex: 0 0 auto;
-}
-
-.attention-card-header,
 .agent-group-header,
 .settings-card-header {
   display: grid;
@@ -1401,7 +1314,6 @@ body {
   border-bottom: 1px solid var(--border-color);
 }
 
-.attention-card-title,
 .inventory-section-title,
 .agent-group-title,
 .inspector-section-header {
@@ -1410,7 +1322,6 @@ body {
   gap: 12px;
 }
 
-.attention-card-header h3,
 .inventory-section-title h3,
 .agent-group-header h3,
 .settings-card-header h3,
@@ -1420,22 +1331,12 @@ body {
   letter-spacing: -0.02em;
 }
 
-.attention-card-title span,
 .inventory-section-title span,
 .agent-group-title span,
 .inspector-section-header span {
   color: var(--text-tertiary);
 }
 
-.attention-card-link {
-  border: 0;
-  background: transparent;
-  color: #6f685d;
-  font-size: 0.95rem;
-  cursor: pointer;
-}
-
-.attention-card-list,
 .inventory-section-list,
 .agent-group-list,
 .settings-card-body {
@@ -1444,7 +1345,6 @@ body {
   flex-direction: column;
 }
 
-.attention-card-row,
 .master-list-row {
   min-width: 0;
   max-width: 100%;
@@ -1462,25 +1362,21 @@ body {
   cursor: pointer;
 }
 
-.attention-card-row:first-child,
 .master-list-row:first-child {
   border-top: 0;
 }
 
-.attention-card-copy,
 .master-list-row-copy {
   min-width: 0;
   display: grid;
   gap: 6px;
 }
 
-.attention-card-copy strong,
 .master-list-row-copy strong,
 .agent-status-copy strong {
   font-size: 0.99rem;
 }
 
-.attention-card-copy strong,
 .master-list-row-copy strong {
   min-width: 0;
   display: inline-flex;
@@ -1488,13 +1384,11 @@ body {
   gap: 6px;
 }
 
-.attention-card-copy strong > span:first-child,
 .master-list-row-copy strong > span:first-child {
   min-width: 0;
   overflow-wrap: anywhere;
 }
 
-.attention-card-row__plugin-indicator,
 .master-list-row__plugin-indicator,
 .detail-inspector-panel__plugin-indicator {
   flex: 0 0 auto;
@@ -1505,7 +1399,6 @@ body {
   position: relative;
 }
 
-.attention-card-row__plugin-indicator svg,
 .master-list-row__plugin-indicator svg {
   width: 13px;
   height: 13px;
@@ -1560,7 +1453,6 @@ body {
   border-radius: 3px;
 }
 
-.attention-card-copy p,
 .master-list-row-copy p,
 .agent-group-header p,
 .settings-card-header p,
@@ -1572,69 +1464,12 @@ body {
   color: var(--text-secondary);
 }
 
-.attention-card-copy p,
 .master-list-row-copy p {
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
   overflow-wrap: anywhere;
   word-break: break-word;
-}
-
-.attention-card-actions {
-  min-width: 0;
-  max-width: 100%;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex: 0 1 auto;
-  justify-content: flex-end;
-}
-
-.attention-card-clean-state {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-height: 58px;
-  padding: 14px 16px;
-}
-
-.attention-card-clean-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  width: 28px;
-  height: 28px;
-  border-radius: 999px;
-  background: var(--pill-healthy-bg);
-  color: var(--pill-healthy-text);
-}
-
-.attention-card-clean-icon svg {
-  width: 15px;
-  height: 15px;
-  stroke-width: 2.4;
-}
-
-.attention-card-clean-copy {
-  min-width: 0;
-  display: grid;
-  gap: 2px;
-}
-
-.attention-card-clean-copy strong {
-  font-size: 13.5px;
-  line-height: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.attention-card-clean-copy p {
-  margin: 0;
-  font-size: 12px;
-  line-height: 16px;
-  color: var(--text-secondary);
 }
 
 .master-list-row-actions,
@@ -6278,26 +6113,6 @@ body {
   color: var(--text-tertiary);
 }
 
-.stat-card-grid {
-  gap: 8px;
-  margin-bottom: 18px;
-}
-
-.stat-card {
-  padding: 10px 14px;
-  border-radius: 7px;
-  border-color: var(--panel-border);
-  box-shadow: none;
-}
-
-.stat-num {
-  font-size: 22px;
-}
-
-.stat-sub {
-  font-size: 11px;
-}
-
 .home-inventory-bar {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -6679,17 +6494,12 @@ body {
   line-height: 16px;
 }
 
-.attention-card,
 .master-list-panel,
 .settings-card,
 .split-workspace--detail {
   border-radius: 7px;
   border-color: var(--panel-border);
   box-shadow: none;
-}
-
-.attention-card + .attention-card {
-  margin-top: 20px;
 }
 
 .repair-surface {
@@ -6767,29 +6577,6 @@ body {
   font-size: 11px;
 }
 
-.page-scroll--dashboard .attention-card {
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 0;
-  min-height: 0;
-}
-
-.page-scroll--dashboard .attention-card--clean {
-  flex: 0 0 auto;
-  min-height: auto;
-}
-
-.attention-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 12px 16px;
-  background: var(--panel-muted-bg);
-  border-bottom: 1px solid var(--panel-border);
-}
-
-.attention-card-title,
 .inventory-section-title,
 .inspector-section-header {
   display: flex;
@@ -6797,7 +6584,6 @@ body {
   gap: 8px;
 }
 
-.attention-card-header h3,
 .inventory-section-title h3,
 .settings-card-header h3,
 .inspector-section-header h4 {
@@ -6806,13 +6592,6 @@ body {
   font-weight: 600;
 }
 
-.attention-card-link {
-  font-size: 12px;
-  line-height: 16px;
-  color: #6f685d;
-}
-
-.page-scroll--dashboard .attention-card-list,
 .page-scroll--dashboard .empty-state-panel {
   flex: 1 1 auto;
   min-height: 0;
@@ -6820,13 +6599,11 @@ body {
   overflow-x: hidden;
 }
 
-.attention-card-row,
 .master-list-row {
   gap: 14px;
   padding: 11px 16px;
 }
 
-.attention-card-copy,
 .master-list-row-copy,
 .location-chip-copy,
 .agent-status-copy,
@@ -6834,7 +6611,6 @@ body {
   gap: 2px;
 }
 
-.attention-card-copy strong,
 .master-list-row-copy strong,
 .agent-status-copy strong,
 .settings-row-copy strong {
@@ -6843,7 +6619,6 @@ body {
   font-weight: 600;
 }
 
-.attention-card-copy p,
 .master-list-row-copy p,
 .agent-group-header p,
 .settings-card-header p,
@@ -6854,15 +6629,6 @@ body {
   font-size: 12px;
   line-height: 16px;
   color: var(--text-secondary);
-}
-
-.attention-card-actions {
-  gap: 8px;
-}
-
-.attention-card-actions .status-pill-group {
-  min-width: 0;
-  flex-wrap: wrap;
 }
 
 .master-list-row-actions,

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -6298,6 +6298,387 @@ body {
   font-size: 11px;
 }
 
+.home-inventory-bar {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  flex: 0 0 auto;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.home-inventory-cell {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 13px 15px 14px;
+  border: 1px solid var(--panel-border);
+  border-radius: 7px;
+  background: var(--panel-bg);
+  cursor: default;
+}
+
+.home-inventory-label {
+  margin-bottom: 11px;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.home-inventory-total {
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 27px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1;
+}
+
+.home-inventory-unit {
+  margin-left: 6px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.home-inventory-attention {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #ededea;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+}
+
+.home-inventory-attention svg {
+  flex: 0 0 auto;
+  width: 13px;
+  height: 13px;
+  stroke-width: 2.4;
+}
+
+.home-inventory-dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.home-inventory-attention--alert {
+  color: var(--attention);
+}
+
+.home-inventory-attention--warn {
+  color: #b36a14;
+}
+
+.home-inventory-attention--clean {
+  color: var(--success);
+}
+
+.home-attention-card {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--panel-border);
+  border-radius: 7px;
+  background: var(--panel-bg);
+}
+
+.home-attention-card--clean {
+  flex: 0 0 auto;
+}
+
+.home-attention-header {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--panel-border);
+  background: var(--panel-muted-bg);
+}
+
+.home-attention-header h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 18px;
+  white-space: nowrap;
+}
+
+.home-attention-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.home-attention-group-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px 8px;
+  border-bottom: 1px solid #ededea;
+  background: var(--panel-muted-bg);
+}
+
+.home-attention-group-header--separated {
+  border-top: 1px solid var(--panel-border);
+}
+
+.home-attention-group-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.home-attention-group-count {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 14px;
+}
+
+.home-attention-group-spacer {
+  flex: 1 1 auto;
+}
+
+.home-attention-group-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--action);
+  cursor: pointer;
+  font-size: 11.5px;
+  line-height: 15px;
+}
+
+.home-attention-group-link svg {
+  width: 11px;
+  height: 11px;
+  stroke-width: 2;
+}
+
+.home-attention-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  min-width: 0;
+  padding: 10px 16px;
+  border: 0;
+  border-bottom: 1px solid #ededea;
+  background: var(--panel-bg);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.home-attention-row:hover {
+  background: var(--panel-muted-bg);
+}
+
+.home-attention-group .home-attention-row:last-child {
+  border-bottom: 0;
+}
+
+.home-attention-row-main {
+  min-width: 0;
+}
+
+.home-attention-row-title {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  margin-bottom: 2px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 17px;
+}
+
+.home-attention-row-title > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-attention-row-description {
+  max-width: 620px;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 17px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-attention-row__plugin-indicator {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--plugin);
+  position: relative;
+}
+
+.home-attention-row__plugin-indicator svg {
+  width: 13px;
+  height: 13px;
+  stroke-width: 2.35;
+}
+
+.home-attention-row-statuses {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  max-width: min(42vw, 380px);
+  flex-wrap: wrap;
+}
+
+.home-attention-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  padding: 3px 9px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 14px;
+  white-space: nowrap;
+}
+
+.home-attention-status-dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.home-attention-status-pill--attention {
+  border-color: #f3d4cf;
+  background: #fbecea;
+  color: #b24434;
+}
+
+.home-attention-status-pill--warning {
+  border-color: #f1dfbf;
+  background: #fbf1e2;
+  color: #b36a14;
+}
+
+.home-attention-status-pill--healthy {
+  border-color: #d8e4d2;
+  background: #edf3ea;
+  color: #437a39;
+}
+
+.home-attention-status-pill--muted {
+  border-color: var(--panel-border);
+  background: var(--panel-muted-bg);
+  color: var(--text-tertiary);
+}
+
+.home-attention-clean-foot {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 11px 16px;
+  border-top: 1px solid var(--panel-border);
+  background: var(--panel-bg);
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.home-attention-clean-foot strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.home-attention-clean-foot-icon,
+.home-attention-clean-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 999px;
+  background: #edf3ea;
+  color: #437a39;
+}
+
+.home-attention-clean-foot-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.home-attention-clean-foot-icon svg {
+  width: 11px;
+  height: 11px;
+  stroke-width: 2.6;
+}
+
+.home-attention-all-clean {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  align-items: center;
+  gap: 13px;
+  padding: 22px 18px;
+}
+
+.home-attention-clean-icon {
+  width: 30px;
+  height: 30px;
+}
+
+.home-attention-clean-icon svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2.4;
+}
+
+.home-attention-clean-title {
+  margin-bottom: 2px;
+  color: var(--text-primary);
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 18px;
+}
+
+.home-attention-clean-copy {
+  color: var(--text-tertiary);
+  font-size: 12px;
+  line-height: 16px;
+}
+
 .attention-card,
 .master-list-panel,
 .settings-card,
@@ -6313,6 +6694,7 @@ body {
 
 .repair-surface {
   border-radius: 7px;
+  flex: 0 0 auto;
   box-shadow: 0 1px 6px color-mix(in srgb, var(--action) 18%, transparent);
 }
 
@@ -10240,5 +10622,29 @@ body {
 
   .audit-table-toolbar__actions {
     flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 880px) {
+  .home-inventory-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .home-attention-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .home-attention-row-statuses {
+    justify-content: flex-start;
+    max-width: 100%;
+  }
+
+  .home-attention-group-header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .home-attention-group-spacer {
+    display: none;
   }
 }

--- a/src/renderer/src/views/HomeDashboard.test.tsx
+++ b/src/renderer/src/views/HomeDashboard.test.tsx
@@ -29,6 +29,31 @@ describe('HomeDashboard', () => {
     expect(heading.parentElement).toHaveTextContent(/^Home$/);
   });
 
+  it('renders three inventory stat boxes without the future Commands box', () => {
+    renderDashboard();
+
+    const metrics = screen.getByLabelText('Home inventory metrics');
+    expect(within(metrics).getByText('Skills')).toBeInTheDocument();
+    expect(within(metrics).getByText('Subagents')).toBeInTheDocument();
+    expect(within(metrics).getByText('MCPs')).toBeInTheDocument();
+    expect(within(metrics).queryByText('Commands')).not.toBeInTheDocument();
+  });
+
+  it('groups skill, subagent, and MCP attention rows in one table', () => {
+    renderDashboard();
+
+    const table = screen.getByRole('region', { name: /^Needs attention$/i });
+    expect(within(table).getByRole('heading', { name: /^Needs attention$/i })).toBeInTheDocument();
+    expect(table.querySelector('.home-attention-body')).not.toBeNull();
+    expect(within(table).getByText('Skills')).toBeInTheDocument();
+    expect(within(table).getByText('Subagents')).toBeInTheDocument();
+    expect(within(table).getByText('MCPs')).toBeInTheDocument();
+    expect(within(table).getByRole('button', { name: /reviewer/i })).toBeInTheDocument();
+    expect(within(table).getByRole('button', { name: /broken-mcp/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^Skills needing attention$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^MCPs needing attention$/i })).not.toBeInTheDocument();
+  });
+
   it('renders MCP attention rows without a subtitle under the title', () => {
     renderDashboard();
 
@@ -69,10 +94,10 @@ describe('HomeDashboard', () => {
       inventorySnapshot,
     });
 
-    expect(screen.getByText('All 53 skills are in their expected state')).toBeInTheDocument();
-    expect(screen.getByText('Canonical sources present, symlinks resolved, no version drift. Last checked 2m ago.')).toBeInTheDocument();
-    expect(screen.getByText('All 5 MCP servers are healthy')).toBeInTheDocument();
-    expect(screen.getByText('Configs match across all agents, versions aligned, no args drift. Last checked 2m ago.')).toBeInTheDocument();
+    expect(screen.getByText('Everything is in its expected state')).toBeInTheDocument();
+    expect(screen.getByText('Canonical sources present, symlinks resolved, no drift across all 3 content types. Last checked 2m ago.')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^Skills needing attention$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^MCPs needing attention$/i })).not.toBeInTheDocument();
   });
 
   it('renders the no-safe-fixes state and routes users to skills', () => {
@@ -373,6 +398,10 @@ describe('HomeDashboard', () => {
     const pluginMcpRow = screen.getByRole('button', { name: /signalMap/i });
     expect(pluginMcpRow).not.toHaveTextContent('signal-tools:');
     expect(pluginMcpRow).toHaveAccessibleName(/This skill was installed via one or more plugins/i);
+
+    const pluginSubagentRow = screen.getByRole('button', { name: /deployment-expert/i });
+    expect(pluginSubagentRow).not.toHaveTextContent('sandbox-plugin-pack:');
+    expect(pluginSubagentRow).toHaveAccessibleName(/This subagent was installed via one or more plugins/i);
   });
 });
 

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -1,7 +1,7 @@
-import { ArrowRight, Check, ChevronUp, Wrench } from 'lucide-react';
+import { ArrowRight, Check, ChevronRight, ChevronUp, Wrench } from 'lucide-react';
 import { useState } from 'react';
 
-import type { McpRecord, ResolveIssueRequest, SkillInventorySnapshot, SkillRecord, SkillScanSource } from '@shared/contracts';
+import type { McpRecord, ResolveIssueRequest, SkillInventorySnapshot, SkillRecord, SkillScanSource, SubagentRecord } from '@shared/contracts';
 
 import {
   getHomeSummary,
@@ -9,23 +9,24 @@ import {
   getMcpSections,
   getSkillDisplayName,
   getSkillSections,
+  getSubagentDisplayName,
   getSubagentSections,
 } from '../inventory-view-model';
 import {
-  getPillToneForMcp,
-  getPillToneForSkill,
   getMcpStatusLabels,
   getSkillStatusLabels,
+  getSubagentStatusLabels,
   getSkillRowDescription,
   getDisplaySkillIssueReasons,
   formatLastScanLabel,
 } from '../lib/inventory-presentation';
 import {
-  AttentionGroupCard,
   EmptyStatePanel,
   PageTopBar,
   PLUGIN_MCP_TOOLTIP,
   PLUGIN_SKILL_TOOLTIP,
+  PLUGIN_SUBAGENT_TOOLTIP,
+  PluginTooltipIndicator,
   RescanToolbarButton,
 } from '../components/ui';
 
@@ -65,6 +66,41 @@ interface PlannedFixGroup {
   issue: ResolveIssueRequest['issue'];
   rows: PlannedFixRow[];
 }
+
+interface HomeMetric {
+  key: string;
+  label: string;
+  needsAttention: number;
+  severity: 'alert' | 'warn';
+  total: number;
+  unit: string;
+}
+
+interface AttentionBadge {
+  label: string;
+  tone: 'attention' | 'warning' | 'healthy' | 'muted';
+}
+
+interface HomeAttentionItem {
+  badges: AttentionBadge[];
+  description?: string;
+  isLocked?: boolean;
+  key: string;
+  label: string;
+  lockedTooltip?: string;
+  onClick: () => void;
+}
+
+interface HomeAttentionGroup {
+  actionLabel: string;
+  count: number;
+  items: HomeAttentionItem[];
+  key: string;
+  label: string;
+  onAction: () => void;
+}
+
+const EMPTY_HOME_METRIC = { total: 0, healthy: 0, needsAttention: 0 };
 
 function getResolveRequestDisplayName(
   request: ResolveIssueRequest,
@@ -115,6 +151,167 @@ function getFixGroupKey(request: ResolveIssueRequest): string {
 
 function formatFixGroupLabel(group: Pick<PlannedFixGroup, 'entity' | 'issue'>): string {
   return `${FIX_ENTITY_LABELS[group.entity]} • ${FIX_TYPE_LABELS[group.issue] ?? group.issue}`;
+}
+
+function HomeInventoryMetrics({ metrics }: { metrics: HomeMetric[] }) {
+  return (
+    <section aria-label="Home inventory metrics" className="home-inventory-bar">
+      {metrics.map((metric) => {
+        const isClean = metric.needsAttention === 0;
+        const attentionTone = isClean ? 'clean' : metric.severity;
+
+        return (
+          <div className="home-inventory-cell" key={metric.key}>
+            <div className="home-inventory-label">{metric.label}</div>
+            <div className="home-inventory-total">
+              {metric.total}
+              <span className="home-inventory-unit">{metric.unit}</span>
+            </div>
+            <div className={`home-inventory-attention home-inventory-attention--${attentionTone}`}>
+              {isClean ? (
+                <>
+                  <Check aria-hidden="true" />
+                  All clean
+                </>
+              ) : (
+                <>
+                  <span className="home-inventory-dot" aria-hidden="true" />
+                  {metric.needsAttention} {metric.needsAttention === 1 ? 'needs' : 'need'} attention
+                </>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+function HomeNeedsAttentionCard({
+  groups,
+  lastCheckedLabel,
+}: {
+  groups: HomeAttentionGroup[];
+  lastCheckedLabel: string;
+}) {
+  const attentionGroups = groups.filter((group) => group.items.length > 0);
+  const cleanGroups = groups.filter((group) => group.items.length === 0);
+  const totalAttention = attentionGroups.reduce((total, group) => total + group.items.length, 0);
+  const cleanCopy = formatCleanGroupCopy(cleanGroups.map((group) => group.label));
+
+  return (
+    <section
+      aria-labelledby="home-needs-attention-title"
+      className={`home-attention-card${totalAttention === 0 ? ' home-attention-card--clean' : ''}`}
+      role="region"
+    >
+      <div className="home-attention-header">
+        <h3 id="home-needs-attention-title">Needs attention</h3>
+      </div>
+
+      <div className="home-attention-body">
+        {totalAttention === 0 ? (
+          <div className="home-attention-all-clean">
+            <div className="home-attention-clean-icon" aria-hidden="true">
+              <Check />
+            </div>
+            <div>
+              <div className="home-attention-clean-title">Everything is in its expected state</div>
+              <div className="home-attention-clean-copy">
+                Canonical sources present, symlinks resolved, no drift across all 3 content types. Last checked {lastCheckedLabel}.
+              </div>
+            </div>
+          </div>
+        ) : (
+          <>
+            {attentionGroups.map((group, index) => (
+              <div className="home-attention-group" key={group.key}>
+                <div className={`home-attention-group-header${index > 0 ? ' home-attention-group-header--separated' : ''}`}>
+                  <span className="home-attention-group-label">{group.label}</span>
+                  <span className="home-attention-group-count">· {group.count}</span>
+                  <span className="home-attention-group-spacer" />
+                  <button className="home-attention-group-link" type="button" onClick={group.onAction}>
+                    {group.actionLabel}
+                    <ChevronRight aria-hidden="true" />
+                  </button>
+                </div>
+
+                {group.items.map((item) => (
+                  <button className="home-attention-row" key={item.key} type="button" onClick={item.onClick}>
+                    <div className="home-attention-row-main">
+                      <div className="home-attention-row-title">
+                        <span>{item.label}</span>
+                        {item.isLocked ? (
+                          <PluginTooltipIndicator
+                            className="home-attention-row__plugin-indicator"
+                            tooltip={item.lockedTooltip ?? PLUGIN_SKILL_TOOLTIP}
+                          />
+                        ) : null}
+                      </div>
+                      {item.description ? <div className="home-attention-row-description">{item.description}</div> : null}
+                    </div>
+                    <div className="home-attention-row-statuses">
+                      {item.badges.map((badge) => (
+                        <span className={`home-attention-status-pill home-attention-status-pill--${badge.tone}`} key={badge.label}>
+                          <span className="home-attention-status-dot" aria-hidden="true" />
+                          {badge.label}
+                        </span>
+                      ))}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ))}
+
+            {cleanCopy ? (
+              <div className="home-attention-clean-foot">
+                <div className="home-attention-clean-foot-icon" aria-hidden="true">
+                  <Check />
+                </div>
+                <div>
+                  <strong>{cleanCopy.label}</strong> {cleanCopy.verb} fully in sync - no action needed.
+                </div>
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function formatCleanGroupCopy(labels: string[]): { label: string; verb: 'is' | 'are' } | null {
+  if (labels.length === 0) {
+    return null;
+  }
+
+  return {
+    label: labels.join(' & '),
+    verb: labels.length === 1 ? 'is' : 'are',
+  };
+}
+
+function getHomeAttentionBadgeTone(label: string): AttentionBadge['tone'] {
+  if (label === 'Healthy') {
+    return 'healthy';
+  }
+
+  if (label === 'Dismissed') {
+    return 'muted';
+  }
+
+  if (label.includes('Diverged') || label.includes('Definition Mismatch')) {
+    return 'attention';
+  }
+
+  return 'warning';
+}
+
+function toHomeAttentionBadges(labels: string[]): AttentionBadge[] {
+  return labels.map((label) => ({
+    label,
+    tone: getHomeAttentionBadgeTone(label),
+  }));
 }
 
 function RepairSurface({
@@ -307,9 +504,85 @@ export function HomeDashboard({
   const mcpAttentionRows = mcpSections.find((section) => section.tone === 'attention')?.rows ?? [];
   const subagentAttentionRows = subagentSections.find((section) => section.tone === 'attention')?.rows ?? [];
   const lastCheckedLabel = formatLastScanLabel(inventorySnapshot?.scannedAt);
+  const subagentSummary = homeSummary.subagents ?? EMPTY_HOME_METRIC;
   const sourceIndex = inventorySnapshot
     ? new Map(inventorySnapshot.sources.map((source) => [source.id, source]))
     : new Map<string, SkillScanSource>();
+  const homeMetrics: HomeMetric[] = [
+    {
+      key: 'skills',
+      label: 'Skills',
+      total: homeSummary.skills.total,
+      unit: 'on disk',
+      needsAttention: homeSummary.skills.needsAttention,
+      severity: 'alert',
+    },
+    {
+      key: 'subagents',
+      label: 'Subagents',
+      total: subagentSummary.total,
+      unit: 'on disk',
+      needsAttention: subagentSummary.needsAttention,
+      severity: 'warn',
+    },
+    {
+      key: 'mcps',
+      label: 'MCPs',
+      total: homeSummary.mcps.total,
+      unit: 'servers',
+      needsAttention: homeSummary.mcps.needsAttention,
+      severity: 'warn',
+    },
+  ];
+  const attentionGroups: HomeAttentionGroup[] = [
+    {
+      key: 'skills',
+      label: 'Skills',
+      count: skillAttentionRows.length,
+      actionLabel: 'View all skills',
+      onAction: onNavigateToSkills,
+      items: skillAttentionRows.map((skill) => ({
+        badges: toHomeAttentionBadges(getSkillStatusLabels(skill)),
+        description: getSkillRowDescription(skill),
+        isLocked: hasPluginSkillLocation(skill, sourceIndex),
+        key: skill.name,
+        label: getSkillDisplayName(skill),
+        lockedTooltip: PLUGIN_SKILL_TOOLTIP,
+        onClick: () => onSelectSkill(skill.name),
+      })),
+    },
+    {
+      key: 'subagents',
+      label: 'Subagents',
+      count: subagentAttentionRows.length,
+      actionLabel: 'View all subagents',
+      onAction: () => onSelectSubagent(subagentAttentionRows[0]?.name ?? ''),
+      items: subagentAttentionRows.map((subagent) => ({
+        badges: toHomeAttentionBadges(getSubagentStatusLabels(subagent)),
+        description: subagent.description,
+        isLocked: hasPluginSubagentLocation(subagent),
+        key: subagent.name,
+        label: getSubagentDisplayName(subagent),
+        lockedTooltip: PLUGIN_SUBAGENT_TOOLTIP,
+        onClick: () => onSelectSubagent(subagent.name),
+      })),
+    },
+    {
+      key: 'mcps',
+      label: 'MCPs',
+      count: mcpAttentionRows.length,
+      actionLabel: 'View all MCPs',
+      onAction: () => onSelectMcp(mcpAttentionRows[0]?.name ?? ''),
+      items: mcpAttentionRows.map((mcp) => ({
+        badges: toHomeAttentionBadges(getMcpStatusLabels(mcp)),
+        isLocked: hasPluginMcpLocation(mcp),
+        key: mcp.name,
+        label: getMcpDisplayName(mcp),
+        lockedTooltip: PLUGIN_MCP_TOOLTIP,
+        onClick: () => onSelectMcp(mcp.name),
+      })),
+    },
+  ];
   const manualReviewTarget = skillAttentionRows.length > 0
     ? {
         label: 'Skills tab',
@@ -337,41 +610,7 @@ export function HomeDashboard({
       <div className="page-scroll page-scroll--dashboard">
         {inventorySnapshot ? (
           <>
-            <section aria-label="Home summary metrics" className="stat-card-grid">
-              <div className="stat-card">
-                <div className="stat-card-label">Skills</div>
-                <div className="stat-card-row">
-                  <div className="stat-item">
-                    <div className="stat-num">{homeSummary.skills.total}</div>
-                    <div className="stat-sub">on disk</div>
-                  </div>
-                  <div className="stat-divider" />
-                  <div className="stat-item">
-                    <div className={`stat-num${homeSummary.skills.needsAttention > 0 ? ' stat-num--alert' : ' stat-num--muted'}`}>
-                      {homeSummary.skills.needsAttention}
-                    </div>
-                    <div className="stat-sub">need attention</div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="stat-card">
-                <div className="stat-card-label">MCPs</div>
-                <div className="stat-card-row">
-                  <div className="stat-item">
-                    <div className="stat-num">{homeSummary.mcps.total}</div>
-                    <div className="stat-sub">servers</div>
-                  </div>
-                  <div className="stat-divider" />
-                  <div className="stat-item">
-                    <div className={`stat-num${homeSummary.mcps.needsAttention > 0 ? ' stat-num--warn' : ' stat-num--muted'}`}>
-                      {homeSummary.mcps.needsAttention}
-                    </div>
-                    <div className="stat-sub">need attention</div>
-                  </div>
-                </div>
-              </div>
-            </section>
+            <HomeInventoryMetrics metrics={homeMetrics} />
 
             <RepairSurface
               autoResolvableRequests={autoResolvableRequests}
@@ -387,52 +626,7 @@ export function HomeDashboard({
               onViewManualIssues={manualReviewTarget.onClick}
             />
 
-            <AttentionGroupCard
-              actionLabel="View all skills"
-              count={skillAttentionRows.length}
-              emptyState={{
-                title: `All ${homeSummary.skills.total} ${homeSummary.skills.total === 1 ? 'skill is' : 'skills are'} in their expected state`,
-                description: `Canonical sources present, symlinks resolved, no version drift. Last checked ${lastCheckedLabel}.`,
-              }}
-              emptyMessage="Nothing needs attention right now."
-              items={skillAttentionRows.map((skill) => ({
-                badges: getSkillStatusLabels(skill).map((label) => ({
-                  label,
-                  tone: getPillToneForSkill(skill),
-                })),
-                description: getSkillRowDescription(skill),
-                isLocked: hasPluginSkillLocation(skill, sourceIndex),
-                key: skill.name,
-                label: getSkillDisplayName(skill),
-                lockedTooltip: PLUGIN_SKILL_TOOLTIP,
-                onClick: () => onSelectSkill(skill.name),
-              }))}
-              onAction={() => onSelectSkill(skillAttentionRows[0]?.name ?? '')}
-              title="Skills needing attention"
-            />
-
-            <AttentionGroupCard
-              actionLabel="View all MCPs"
-              count={mcpAttentionRows.length}
-              emptyState={{
-                title: `All ${homeSummary.mcps.total} MCP ${homeSummary.mcps.total === 1 ? 'server is' : 'servers are'} healthy`,
-                description: `Configs match across all agents, versions aligned, no args drift. Last checked ${lastCheckedLabel}.`,
-              }}
-              emptyMessage="No MCPs need attention right now."
-              items={mcpAttentionRows.map((mcp) => ({
-                badges: getMcpStatusLabels(mcp).map((label) => ({
-                  label,
-                  tone: getPillToneForMcp(mcp),
-                })),
-                isLocked: hasPluginMcpLocation(mcp),
-                key: mcp.name,
-                label: getMcpDisplayName(mcp),
-                lockedTooltip: PLUGIN_MCP_TOOLTIP,
-                onClick: () => onSelectMcp(mcp.name),
-              }))}
-              onAction={() => onSelectMcp(mcpAttentionRows[0]?.name ?? '')}
-              title="MCPs needing attention"
-            />
+            <HomeNeedsAttentionCard groups={attentionGroups} lastCheckedLabel={lastCheckedLabel} />
           </>
         ) : (
           <EmptyStatePanel message="Loading your inventory summary…" />
@@ -449,4 +643,8 @@ function hasPluginSkillLocation(skill: SkillRecord, sourceIndex: Map<string, Ski
 
 function hasPluginMcpLocation(mcp: McpRecord): boolean {
   return mcp.locations.some((location) => location.provenance?.kind === 'plugin');
+}
+
+function hasPluginSubagentLocation(subagent: SubagentRecord): boolean {
+  return subagent.locations.some((location) => location.provenance?.kind === 'plugin');
 }

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -655,6 +655,7 @@ export interface HomeSummaryMetric {
 
 export interface HomeSummary {
   skills: HomeSummaryMetric;
+  subagents?: HomeSummaryMetric;
   mcps: HomeSummaryMetric;
   installedAgents: number;
 }


### PR DESCRIPTION
Changes:

- Adds Subagents to the homepage inventory metrics while leaving Commands out for later.
- Replaces the separate attention cards with one grouped, scrollable Needs attention table for skills, subagents, and MCPs.
- Keeps attention section headers sticky while scrolling and preserves the auto-resolve surface.
- Updates app-shell integration expectations for the new Home metrics and attention table.
- Removes obsolete Home stat-card and attention-card component/styles after the reorganization.

Validation:
pnpm exec vitest run src/renderer/src/components/ui.test.tsx src/renderer/src/views/HomeDashboard.test.tsx src/renderer/src/app-shell.test.tsx
pnpm test -- --maxWorkers=4
pnpm typecheck
pnpm lint
Rendered browser check confirmed old stat-card/attention-card DOM is absent and the grouped table remains scrollable with sticky headers.
