### PR TITLE
Move Agent Directory to secondary navigation

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1389,15 +1389,8 @@ export default function App() {
         icon: 'plugins' as const,
         meta: inventorySnapshot?.plugins?.length ?? 0,
       },
-      {
-        tab: 'agents' as const,
-        label: 'Agents',
-        icon: 'agents' as const,
-        meta: inventorySnapshot?.agentCounts?.installedAgents ?? 0,
-      },
     ],
     [
-      inventorySnapshot?.agentCounts?.installedAgents,
       inventorySnapshot?.counts.driftedSkills,
       inventorySnapshot?.counts.totalSkills,
       inventorySnapshot?.mcpCounts?.attentionMcps,

--- a/src/renderer/src/app-search.test.tsx
+++ b/src/renderer/src/app-search.test.tsx
@@ -39,7 +39,7 @@ describe('App search behavior', () => {
     expect(screen.getByRole('searchbox', { name: /Search MCPs/i })).toBeInTheDocument();
     expect(screen.getByText('⌘F')).toBeInTheDocument();
 
-    await openTab('Agents');
+    await openTab('Agent Directory');
     expect(screen.getByRole('searchbox', { name: /Search agents/i })).toBeInTheDocument();
     expect(screen.getByText('⌘F')).toBeInTheDocument();
 
@@ -51,7 +51,7 @@ describe('App search behavior', () => {
   it('filters agents from the header search field and focuses that field on Command+F', async () => {
     render(<App />);
 
-    await openTab('Agents');
+    await openTab('Agent Directory');
 
     const searchbox = screen.getByRole('searchbox', { name: /Search agents/i });
 
@@ -61,7 +61,7 @@ describe('App search behavior', () => {
     expect(screen.queryByText('Claude')).not.toBeInTheDocument();
     expect(screen.queryByText('Factory')).not.toBeInTheDocument();
 
-    screen.getByRole('button', { name: /^Agents\d*$/i }).focus();
+    screen.getByRole('button', { name: /^Agent Directory\s*\d*$/i }).focus();
     fireEvent.keyDown(window, { key: 'f', metaKey: true });
 
     expect(searchbox).toHaveFocus();
@@ -83,7 +83,7 @@ describe('App search behavior', () => {
   it('matches agents from the header search field by path', async () => {
     render(<App />);
 
-    await openTab('Agents');
+    await openTab('Agent Directory');
 
     const searchbox = screen.getByRole('searchbox', { name: /Search agents/i });
 
@@ -111,7 +111,7 @@ describe('App search behavior', () => {
   it('uses the shared Rescan action in the Agents header', async () => {
     render(<App />);
 
-    await openTab('Agents');
+    await openTab('Agent Directory');
 
     const rescanButton = screen.getByRole('button', { name: /^Rescan$/i });
     expect(rescanButton.querySelector('svg')).not.toBeNull();
@@ -202,8 +202,8 @@ describe('App search behavior', () => {
   });
 });
 
-async function openTab(label: 'Skills' | 'MCPs' | 'Agents' | 'Audit Log' | 'Settings') {
-  fireEvent.click(await screen.findByRole('button', { name: new RegExp(`^${label}\\d*$`, 'i') }));
+async function openTab(label: 'Skills' | 'MCPs' | 'Agent Directory' | 'Audit Log' | 'Settings') {
+  fireEvent.click(await screen.findByRole('button', { name: new RegExp(`^${label}\\s*\\d*$`, 'i') }));
   await waitFor(() => {
     expect(screen.getByRole('heading', { level: 2, name: new RegExp(`^${label}$`, 'i') })).toBeInTheDocument();
   });

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -254,8 +254,8 @@ describe('App shell inventory views', () => {
   }
 
   async function openAgents() {
-    fireEvent.click(within(await getPrimaryNavAsync()).getByRole('button', { name: /^Agents/i }));
-    await screen.findByRole('heading', { name: /^Agents$/i, level: 2 });
+    fireEvent.click(await screen.findByRole('button', { name: /^Agent Directory/i }));
+    await screen.findByRole('heading', { name: /^Agent Directory$/i, level: 2 });
     await waitFor(() => {
       expect(getAgentDataRows().length).toBeGreaterThan(0);
     });
@@ -276,7 +276,7 @@ describe('App shell inventory views', () => {
     return row as HTMLElement;
   }
 
-  it('launches into Home with six primary tabs and keeps Audit Log above Settings', async () => {
+  it('launches into Home with five primary tabs and keeps Agent Directory above Audit Log', async () => {
     readAuditLogMock.mockResolvedValue(createAuditOperations());
     render(<App />);
 
@@ -287,30 +287,30 @@ describe('App shell inventory views', () => {
 
     const installedAgentCount = createInventorySnapshot().agentCounts?.installedAgents ?? 0;
 
-    expect(within(primaryNav).getAllByRole('button')).toHaveLength(6);
+    expect(within(primaryNav).getAllByRole('button')).toHaveLength(5);
     expect(within(primaryNav).getAllByRole('button').map((button) => button.textContent?.replace(/\s+/g, ''))).toEqual([
       'Home',
       'Skills38',
       'MCPs16',
       'Subagents0',
       'Plugins0',
-      `Agents${installedAgentCount}`,
     ]);
     expect(within(primaryNav).getByRole('button', { name: /^Home$/i })).toHaveTextContent(/^Home$/);
     expect(within(primaryNav).getByRole('button', { name: /^Skills/i })).toHaveTextContent(/^Skills38$/);
     expect(within(primaryNav).getByRole('button', { name: /^MCPs/i })).toHaveTextContent(/^MCPs16$/);
     expect(within(primaryNav).getByRole('button', { name: /^Subagents/i })).toHaveTextContent(/^Subagents0$/);
-    expect(within(primaryNav).getByRole('button', { name: /^Agents/i })).toHaveTextContent(
-      new RegExp(`^Agents${installedAgentCount}$`),
-    );
     expect(within(primaryNav).getByRole('button', { name: /^Plugins/i })).toHaveTextContent(/^Plugins0$/);
+    expect(within(primaryNav).queryByRole('button', { name: /^Agent Directory/i })).not.toBeInTheDocument();
     expect(within(primaryNav).queryByRole('button', { name: /^Audit Log$/i })).not.toBeInTheDocument();
     expect(within(primaryNav).queryByRole('button', { name: /^All Skills/i })).not.toBeInTheDocument();
     expect(within(primaryNav).queryByRole('button', { name: /^Drift/i })).not.toBeInTheDocument();
 
+    const agentDirectoryButton = screen.getByRole('button', { name: /^Agent Directory/i });
     const auditLogButton = screen.getByRole('button', { name: /^Audit Log$/i });
     const settingsButton = screen.getByRole('button', { name: /^Settings/i });
-    expect(primaryNav.compareDocumentPosition(auditLogButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(agentDirectoryButton).toHaveTextContent(new RegExp(`^Agent Directory${installedAgentCount}$`));
+    expect(primaryNav.compareDocumentPosition(agentDirectoryButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(agentDirectoryButton.compareDocumentPosition(auditLogButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(auditLogButton.compareDocumentPosition(settingsButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(primaryNav.compareDocumentPosition(settingsButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getByRole('heading', { name: /^Home$/i, level: 2 })).toBeInTheDocument();
@@ -1333,8 +1333,8 @@ describe('App shell inventory views', () => {
 
     expect(within(getPrimaryNav()).getByRole('button', { name: /^Skills/i })).toHaveTextContent(/^Skills38$/);
     expect(within(getPrimaryNav()).getByRole('button', { name: /^MCPs/i })).toHaveTextContent(/^MCPs16$/);
-    expect(within(getPrimaryNav()).getByRole('button', { name: /^Agents/i })).toHaveTextContent(
-      new RegExp(`^Agents${createInventorySnapshot().agentCounts?.installedAgents ?? 0}$`),
+    expect(screen.getByRole('button', { name: /^Agent Directory/i })).toHaveTextContent(
+      new RegExp(`^Agent Directory${createInventorySnapshot().agentCounts?.installedAgents ?? 0}$`),
     );
 
     await openSkills();
@@ -1455,8 +1455,8 @@ describe('App shell inventory views', () => {
     render(<App />);
     await openAgents();
 
-    expect(within(getPrimaryNav()).getByRole('button', { name: /^Agents/i })).toHaveTextContent(
-      new RegExp(`^Agents${createInventorySnapshot().agentCounts?.installedAgents ?? 0}$`),
+    expect(screen.getByRole('button', { name: /^Agent Directory/i })).toHaveTextContent(
+      new RegExp(`^Agent Directory${createInventorySnapshot().agentCounts?.installedAgents ?? 0}$`),
     );
 
     const list = getAgentsList();
@@ -1549,7 +1549,7 @@ describe('App shell inventory views', () => {
     expect(screen.getByRole('searchbox', { name: /Search MCPs/i })).toHaveFocus();
 
     await openAgents();
-    within(getPrimaryNav()).getByRole('button', { name: /^Agents/i }).focus();
+    screen.getByRole('button', { name: /^Agent Directory/i }).focus();
     fireEvent.keyDown(window, { key: 'f', metaKey: true });
     expect(screen.getByRole('searchbox', { name: /Search agents/i })).toHaveFocus();
   });
@@ -1952,8 +1952,8 @@ describe('App shell inventory views', () => {
     render(<App />);
 
     await screen.findByLabelText(/Home inventory metrics/i);
-    expect(within(getPrimaryNav()).getByRole('button', { name: /^Agents/i })).toHaveTextContent(
-      new RegExp(`^Agents${createOperationalBaselineInventorySnapshot().agentCounts?.installedAgents ?? 0}$`),
+    expect(screen.getByRole('button', { name: /^Agent Directory/i })).toHaveTextContent(
+      new RegExp(`^Agent Directory${createOperationalBaselineInventorySnapshot().agentCounts?.installedAgents ?? 0}$`),
     );
 
     fireEvent.click(screen.getByRole('button', { name: /^Rescan$/i }));

--- a/src/renderer/src/components/AppSidebar.tsx
+++ b/src/renderer/src/components/AppSidebar.tsx
@@ -12,7 +12,7 @@ export interface AppNavItem {
   icon: Extract<NavIconName, 'home' | 'skills' | 'mcps' | 'subagents' | 'agents' | 'plugins'>;
   label: string;
   meta?: number;
-  tab: Exclude<PrimaryTab, 'audit' | 'settings'>;
+  tab: Exclude<PrimaryTab, 'agents' | 'audit' | 'settings'>;
   tone?: 'attention';
 }
 
@@ -127,6 +127,21 @@ export function AppSidebar({
 
         <nav aria-label="Secondary">
           <ul className="nav-list nav-list--secondary">
+            <li>
+              <button
+                aria-pressed={activeTab === 'agents'}
+                className={`settings-button${activeTab === 'agents' ? ' settings-button--active' : ''}`}
+                type="button"
+                onClick={() => onSelectTab('agents')}
+              >
+                <span className="nav-button-main">
+                  <span>Agent Directory</span>
+                </span>
+                <span className="nav-button-trailing">
+                  <span className="nav-secondary-count">{inventorySnapshot?.agentCounts?.installedAgents ?? 0}</span>
+                </span>
+              </button>
+            </li>
             <li>
               <button
                 aria-pressed={activeTab === 'audit'}

--- a/src/renderer/src/views/AgentsWorkspaceView.tsx
+++ b/src/renderer/src/views/AgentsWorkspaceView.tsx
@@ -79,7 +79,7 @@ export function AgentsWorkspaceView({
             query={searchQuery}
           />
         )}
-        title="Agents"
+        title="Agent Directory"
       />
 
       <div className="page-scroll page-scroll--agents">


### PR DESCRIPTION
Changes:

Moved Agent Directory out of the primary navigation and into the secondary sidebar above Audit Log, keeping the installed count visible. Renamed the agents workspace header and updated navigation/search tests for the new label.

Validation:
pnpm typecheck
pnpm test -- src/renderer/src/app-shell.test.tsx src/renderer/src/app-search.test.tsx src/renderer/src/views/AgentsWorkspaceView.test.tsx
pnpm lint
Manual renderer check at http://127.0.0.1:5602/
