### PR TITLE
Reorder homepage stat boxes

### DIFF
--- a/src/renderer/src/views/HomeDashboard.test.tsx
+++ b/src/renderer/src/views/HomeDashboard.test.tsx
@@ -29,13 +29,15 @@ describe('HomeDashboard', () => {
     expect(heading.parentElement).toHaveTextContent(/^Home$/);
   });
 
-  it('renders three inventory stat boxes without the future Commands box', () => {
+  it('renders Skills, MCPs, and Subagents inventory stat boxes in order', () => {
     renderDashboard();
 
     const metrics = screen.getByLabelText('Home inventory metrics');
-    expect(within(metrics).getByText('Skills')).toBeInTheDocument();
-    expect(within(metrics).getByText('Subagents')).toBeInTheDocument();
-    expect(within(metrics).getByText('MCPs')).toBeInTheDocument();
+    expect(within(metrics).getAllByText(/^(Skills|MCPs|Subagents)$/).map((label) => label.textContent)).toEqual([
+      'Skills',
+      'MCPs',
+      'Subagents',
+    ]);
     expect(within(metrics).queryByText('Commands')).not.toBeInTheDocument();
   });
 

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -518,19 +518,19 @@ export function HomeDashboard({
       severity: 'alert',
     },
     {
-      key: 'subagents',
-      label: 'Subagents',
-      total: subagentSummary.total,
-      unit: 'on disk',
-      needsAttention: subagentSummary.needsAttention,
-      severity: 'warn',
-    },
-    {
       key: 'mcps',
       label: 'MCPs',
       total: homeSummary.mcps.total,
       unit: 'servers',
       needsAttention: homeSummary.mcps.needsAttention,
+      severity: 'warn',
+    },
+    {
+      key: 'subagents',
+      label: 'Subagents',
+      total: subagentSummary.total,
+      unit: 'on disk',
+      needsAttention: subagentSummary.needsAttention,
       severity: 'warn',
     },
   ];


### PR DESCRIPTION
Changes:

Render homepage inventory stats as Skills, MCPs, then Subagents, with a test covering that order.

Validation:
pnpm typecheck
pnpm test src/renderer/src/views/HomeDashboard.test.tsx
