### PR TITLE
Add subagent creation flow

### DIFF
--- a/src/main/add-subagent.test.ts
+++ b/src/main/add-subagent.test.ts
@@ -1,0 +1,88 @@
+import { lstat, mkdir, mkdtemp, readFile, readlink, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { addSubagent } from '@main/add-subagent';
+import { resolveSkillIndexPaths } from '@shared/skill-index-paths';
+
+const createdRoots: string[] = [];
+
+describe('addSubagent', () => {
+  afterEach(async () => {
+    await Promise.all(createdRoots.splice(0, createdRoots.length).map((root) =>
+      rm(root, { recursive: true, force: true })));
+  });
+
+  it('creates a universal markdown subagent and installs supported sandbox agent copies', async () => {
+    const paths = await createSandboxPaths();
+    await Promise.all([
+      mkdir(path.join(paths.sandboxRoot, '.claude'), { recursive: true }),
+      mkdir(path.join(paths.sandboxRoot, '.codex'), { recursive: true }),
+      mkdir(path.join(paths.sandboxRoot, '.factory'), { recursive: true }),
+    ]);
+
+    const snapshot = await addSubagent({
+      sourceType: 'fields',
+      name: 'reviewer',
+      description: 'Reviews implementation changes.',
+      prompt: 'Review the diff and call out correctness risks.',
+    }, {
+      includeSandboxSources: true,
+      includeLiveSources: false,
+      paths,
+      homeDir: path.dirname(paths.dataDir),
+    });
+
+    const canonicalPath = path.join(paths.sandboxRoot, '.agents', 'agents', 'reviewer.md');
+    const claudePath = path.join(paths.sandboxRoot, '.claude', 'agents', 'reviewer.md');
+    const codexPath = path.join(paths.sandboxRoot, '.codex', 'agents', 'reviewer.toml');
+    const factoryPath = path.join(paths.sandboxRoot, '.factory', 'droids', 'reviewer.md');
+
+    await expect(readFile(canonicalPath, 'utf8')).resolves.toContain('description: "Reviews implementation changes."');
+    await expect(readlink(claudePath)).resolves.toBe(canonicalPath);
+    await expect(readlink(factoryPath)).resolves.toBe(canonicalPath);
+    await expect(readFile(codexPath, 'utf8')).resolves.toContain('developer_instructions = "Review the diff and call out correctness risks."');
+    expect((await lstat(codexPath)).isFile()).toBe(true);
+    expect(snapshot.subagents?.some((subagent) => subagent.name === 'reviewer')).toBe(true);
+  });
+
+  it('parses pasted Codex TOML definitions before installing them', async () => {
+    const paths = await createSandboxPaths();
+    await mkdir(path.join(paths.sandboxRoot, '.codex'), { recursive: true });
+
+    const snapshot = await addSubagent({
+      sourceType: 'definition',
+      name: 'fallback-reviewer',
+      format: 'codex-toml',
+      definition: [
+        'name = "codex-reviewer"',
+        'description = "Reviews Codex changes."',
+        'developer_instructions = "Use Codex-specific review guidance."',
+        '',
+      ].join('\n'),
+    }, {
+      includeSandboxSources: true,
+      includeLiveSources: false,
+      paths,
+      homeDir: path.dirname(paths.dataDir),
+    });
+
+    const canonicalPath = path.join(paths.sandboxRoot, '.agents', 'agents', 'codex-reviewer.md');
+    await expect(readFile(canonicalPath, 'utf8')).resolves.toContain('Use Codex-specific review guidance.');
+    expect(snapshot.subagents?.some((subagent) => subagent.name === 'codex-reviewer')).toBe(true);
+  });
+});
+
+async function createSandboxPaths() {
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'skillindex-add-subagent-test-'));
+  createdRoots.push(dataRoot);
+  return resolveSkillIndexPaths({
+    env: {
+      ...process.env,
+      SKILL_INDEX_DATA_DIR: dataRoot,
+    },
+    homeDir: path.dirname(dataRoot),
+  });
+}

--- a/src/main/add-subagent.ts
+++ b/src/main/add-subagent.ts
@@ -1,0 +1,260 @@
+import { lstat, mkdir, symlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import type {
+  AddSubagentDefinitionFormat,
+  AddSubagentRequest,
+  AgentRecord,
+  AgentSubagentParserKind,
+  SkillInventorySnapshot,
+} from '@shared/contracts';
+import {
+  ensureSkillIndexLayout,
+  resolveSkillIndexPaths,
+  type SkillIndexPaths,
+} from '@shared/skill-index-paths';
+import {
+  getSubagentFileNameForFormat,
+  isMarkdownSubagentSymlinkCompatible,
+  isSubagentFormatRenderableFromUniversal,
+  isSupportedSubagentDirectoryFormat,
+} from '@shared/subagent-format-policy';
+
+import { buildInventoryAgents } from '@main/inventory-source-model';
+import { scanInventory, type ScanSkillInventoryOptions } from '@main/scan-inventory';
+import {
+  readPortableSubagentDefinitionFromText,
+  renderPortableSubagentDefinition,
+  type PortableSubagentDefinition,
+} from '@main/subagent-inventory';
+
+export interface AddSubagentOptions extends ScanSkillInventoryOptions {
+  paths?: SkillIndexPaths;
+}
+
+interface InstallTargetContext {
+  canonicalSubagentsDir: string;
+  linkedAgents: AgentRecord[];
+  scope: 'sandbox' | 'live';
+}
+
+interface SubagentInstallTarget {
+  family?: string;
+  format: AddSubagentDefinitionFormat;
+  path: string;
+  symlinkToCanonical: boolean;
+}
+
+export async function addSubagent(
+  request: AddSubagentRequest,
+  options: AddSubagentOptions = {},
+): Promise<SkillInventorySnapshot> {
+  const paths = options.paths ?? resolveSkillIndexPaths(options);
+  await ensureSkillIndexLayout(paths);
+
+  const installTargets = await resolveInstallTargetContext({
+    ...options,
+    paths,
+  });
+  const definition = normalizeSubagentDefinitionRequest(request);
+  const canonicalPath = path.join(
+    installTargets.canonicalSubagentsDir,
+    getSubagentFileNameForFormat({ name: definition.name, format: 'markdown-frontmatter' }),
+  );
+  const targetPaths = buildSubagentInstallTargets(definition, canonicalPath, installTargets);
+
+  await assertInstallPathsAreAvailable([canonicalPath, ...targetPaths.map((target) => target.path)]);
+  await mkdir(path.dirname(canonicalPath), { recursive: true });
+  await writeFile(canonicalPath, renderPortableSubagentDefinition(definition, 'markdown-frontmatter'), 'utf8');
+
+  await Promise.all(targetPaths.map(async (target) => {
+    await mkdir(path.dirname(target.path), { recursive: true });
+    if (target.symlinkToCanonical) {
+      await symlink(canonicalPath, target.path);
+      return;
+    }
+
+    await writeFile(
+      target.path,
+      renderPortableSubagentDefinition(definition, target.format, { family: target.family }),
+      'utf8',
+    );
+  }));
+
+  return scanInventory({
+    ...options,
+    includeSandboxSources: installTargets.scope === 'sandbox',
+    includeLiveSources: installTargets.scope === 'live',
+    paths,
+  });
+}
+
+export function resolveAddSubagentName(request: AddSubagentRequest): string {
+  return normalizeSubagentDefinitionRequest(request).name;
+}
+
+function normalizeSubagentDefinitionRequest(request: AddSubagentRequest): PortableSubagentDefinition {
+  if (request.sourceType === 'fields') {
+    return assertPortableDefinitionComplete({
+      name: normalizeSubagentName(request.name),
+      description: normalizeRequiredText(request.description, 'Enter a subagent description before adding a subagent.'),
+      prompt: normalizeRequiredText(request.prompt, 'Enter subagent instructions before adding a subagent.'),
+      extras: {},
+    });
+  }
+
+  const fallbackName = normalizeSubagentName(request.name);
+  const raw = normalizeRequiredText(request.definition, 'Paste subagent definition contents before adding a subagent.');
+  const definition = readPortableSubagentDefinitionFromText({
+    fallbackName,
+    format: request.format,
+    raw,
+  });
+
+  return assertPortableDefinitionComplete({
+    ...definition,
+    name: normalizeSubagentName(definition.name),
+  });
+}
+
+function assertPortableDefinitionComplete(definition: PortableSubagentDefinition): PortableSubagentDefinition {
+  if (!definition.description?.trim()) {
+    throw new Error('Enter a subagent description before adding a subagent.');
+  }
+
+  if (!definition.prompt.trim()) {
+    throw new Error('Enter subagent instructions before adding a subagent.');
+  }
+
+  return {
+    ...definition,
+    description: definition.description.trim(),
+    prompt: definition.prompt.trim(),
+  };
+}
+
+function normalizeSubagentName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error('Enter a subagent name before adding a subagent.');
+  }
+
+  if (trimmed === '.' || trimmed === '..' || trimmed.includes('/') || trimmed.includes('\\')) {
+    throw new Error('Subagent names cannot include path separators.');
+  }
+
+  return trimmed;
+}
+
+function normalizeRequiredText(value: string, message: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(message);
+  }
+
+  return trimmed;
+}
+
+function buildSubagentInstallTargets(
+  definition: PortableSubagentDefinition,
+  canonicalPath: string,
+  installTargets: InstallTargetContext,
+): SubagentInstallTarget[] {
+  const targets: SubagentInstallTarget[] = [];
+  for (const agent of installTargets.linkedAgents) {
+    const format = agent.subagentParserKind ?? 'unknown';
+    if (!isInstallableSubagentFormat(format) || !agent.subagentsLocation?.path) {
+      continue;
+    }
+
+    targets.push({
+      family: agent.family,
+      format,
+      path: path.join(agent.subagentsLocation.path, getSubagentFileNameForFormat({
+        name: definition.name,
+        format,
+        family: agent.family,
+        canonicalPath,
+      })),
+      symlinkToCanonical: format === 'markdown-frontmatter'
+        && isMarkdownSubagentSymlinkCompatible(agent.family),
+    });
+  }
+
+  return targets;
+}
+
+async function resolveInstallTargetContext(
+  options: ScanSkillInventoryOptions & { paths: SkillIndexPaths },
+): Promise<InstallTargetContext> {
+  const scope = resolveInstallScope(options);
+  const liveHomeDir = options.homeDir ?? homedir();
+  const canonicalSkillsDir = scope === 'sandbox'
+    ? options.paths.sandboxCanonicalUserSkillsDir
+    : options.paths.liveCanonicalUserSkillsDir || path.join(liveHomeDir, '.agents', 'skills');
+  const canonicalSubagentsDir = path.join(path.dirname(canonicalSkillsDir), 'agents');
+  const agents = await buildInventoryAgents({
+    ...options,
+    includeSandboxSources: scope === 'sandbox',
+    includeLiveSources: scope === 'live',
+    paths: options.paths,
+  });
+  const linkedAgents = agents.filter((agent) => isLinkableInstalledSubagentAgent(agent, scope));
+
+  await mkdir(canonicalSubagentsDir, { recursive: true });
+
+  return {
+    canonicalSubagentsDir,
+    linkedAgents,
+    scope,
+  };
+}
+
+function isLinkableInstalledSubagentAgent(agent: AgentRecord, scope: 'sandbox' | 'live'): boolean {
+  const format = agent.subagentParserKind ?? 'unknown';
+
+  return agent.scope === scope
+    && agent.installState === 'installed'
+    && agent.writable
+    && agent.subagentsLocation?.state === 'available'
+    && typeof agent.subagentsLocation.path === 'string'
+    && agent.subagentsLocation.path.length > 0
+    && isInstallableSubagentFormat(format);
+}
+
+function isInstallableSubagentFormat(
+  format: AgentSubagentParserKind,
+): format is AddSubagentDefinitionFormat {
+  return isSupportedSubagentDirectoryFormat(format)
+    && isSubagentFormatRenderableFromUniversal(format, 'markdown-frontmatter');
+}
+
+function resolveInstallScope(options: ScanSkillInventoryOptions): 'sandbox' | 'live' {
+  const includeSandboxSources = options.includeSandboxSources ?? false;
+  const includeLiveSources = options.includeLiveSources ?? true;
+
+  if (includeSandboxSources === includeLiveSources) {
+    throw new Error('Add subagent requires a single active inventory scope.');
+  }
+
+  return includeSandboxSources ? 'sandbox' : 'live';
+}
+
+async function assertInstallPathsAreAvailable(filePaths: string[]): Promise<void> {
+  const plannedPaths = [...new Set(filePaths.map((filePath) => path.normalize(filePath)))];
+  for (const filePath of plannedPaths) {
+    if (await pathExists(filePath)) {
+      throw new Error(`A subagent already exists at ${filePath}. Remove or rename it before adding this subagent.`);
+    }
+  }
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await lstat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/main/inventory-runtime.test.ts
+++ b/src/main/inventory-runtime.test.ts
@@ -966,6 +966,53 @@ describe('inventory runtime', () => {
     });
   });
 
+  it('audits pasted subagent definitions under the parsed subagent name', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-runtime-subagent-audit-'));
+    const env = {
+      SKILL_INDEX_DATA_DIR: root,
+    };
+    const paths = resolveSkillIndexPaths({ env });
+
+    const runtime = createInventoryRuntime();
+    runtimes.push(runtime);
+
+    await mkdir(path.join(paths.sandboxRoot, '.codex'), { recursive: true });
+    await runtime.scanInventory({
+      env,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+    await runtime.addSubagent({
+      sourceType: 'definition',
+      name: 'fallback-reviewer',
+      format: 'codex-toml',
+      definition: [
+        'name = "codex-reviewer"',
+        'description = "Reviews Codex changes."',
+        'developer_instructions = "Use Codex-specific review guidance."',
+        '',
+      ].join('\n'),
+    }, {
+      env,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+
+    const [operation] = await runtime.readAuditLog();
+    expect(operation).toMatchObject({
+      entity: { type: 'subagent', name: 'codex-reviewer' },
+      kind: 'add-subagent',
+      sourceMode: 'sandbox',
+      title: 'Added subagent codex-reviewer',
+    });
+    expect(operation.actions.map((action) => action.path)).toContain(
+      path.join(paths.sandboxRoot, '.agents', 'agents', 'codex-reviewer.md'),
+    );
+    expect(operation.actions.map((action) => action.path)).not.toContain(
+      path.join(paths.sandboxRoot, '.agents', 'agents', 'fallback-reviewer.md'),
+    );
+  });
+
   it('audits failed issue resolutions with a shareable failure trace', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-runtime-failed-resolution-audit-'));
     const paths = resolveSkillIndexPaths({

--- a/src/main/inventory-runtime.ts
+++ b/src/main/inventory-runtime.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import path from 'node:path';
 
 import { addSkill as addSkillToInventory } from '@main/add-skill';
+import { addSubagent as addSubagentToInventory, resolveAddSubagentName } from '@main/add-subagent';
 import { createAuditLogService, type AuditOperationRequest } from '@main/audit-log';
 import { applyCapabilityAction as applyCapabilityActionToInventory } from '@main/capability-actions';
 import {
@@ -17,6 +18,7 @@ import { addMcpServer as addMcpServerToInventory, resolveInventoryIssue } from '
 import type {
   AddMcpServerRequest,
   AddSkillRequest,
+  AddSubagentRequest,
   AuditOperation,
   CapabilityActionRequest,
   DismissDriftRequest,
@@ -27,6 +29,11 @@ import type {
   UndoAuditOperationResult,
 } from '@shared/contracts';
 import { resolveSkillIndexPathsForScanOptions, type SkillIndexPaths } from '@shared/skill-index-paths';
+import {
+  getSubagentFileNameForFormat,
+  isSubagentFormatRenderableFromUniversal,
+  isSupportedSubagentDirectoryFormat,
+} from '@shared/subagent-format-policy';
 import { createStartupObservationAid, type StartupObservationAid } from '@main/startup-observation';
 
 interface ClosableWatcher {
@@ -69,6 +76,7 @@ export interface InventoryRuntime {
   cancelMcpConnectivityTest(): void;
   addSkill(request: AddSkillRequest, options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
   addMcpServer(request: AddMcpServerRequest, options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
+  addSubagent(request: AddSubagentRequest, options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
   resolveIssue(request: ResolveIssueRequest): Promise<SkillInventorySnapshot>;
   applyCapabilityAction(request: CapabilityActionRequest, options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
   dismissDrift(request: DismissDriftRequest): Promise<SkillInventorySnapshot>;
@@ -430,6 +438,21 @@ export function createInventoryRuntime(options: CreateInventoryRuntimeOptions = 
       await emitAudit(lastScanOptions);
       return nextSnapshot;
     },
+    async addSubagent(request, optionsOverride = {}) {
+      if (refreshInFlight) {
+        await refreshInFlight;
+      }
+
+      lastScanOptions = { ...lastScanOptions, ...optionsOverride };
+      const beforeSnapshot = currentSnapshot ?? await scanInventory(lastScanOptions);
+      const { result: nextSnapshot } = await getAuditService(lastScanOptions).runOperation(
+        buildAddSubagentAuditRequest(request, beforeSnapshot, lastScanOptions),
+        () => addSubagentToInventory(request, lastScanOptions),
+      );
+      commitSnapshot(nextSnapshot);
+      await emitAudit(lastScanOptions);
+      return nextSnapshot;
+    },
     async resolveIssue(request) {
       if (refreshInFlight) {
         await refreshInFlight;
@@ -679,6 +702,49 @@ function buildAddMcpServerAuditRequest(
     entity: { type: 'mcp', name: request.name.trim() },
     affectedPaths,
     undoable: affectedPaths.length > 0,
+  };
+}
+
+function buildAddSubagentAuditRequest(
+  request: AddSubagentRequest,
+  snapshot: SkillInventorySnapshot,
+  options: ScanSkillInventoryOptions,
+): AuditOperationRequest {
+  const sourceMode = resolveAuditSourceMode(options);
+  const subagentName = resolveAddSubagentName(request);
+  const paths = resolveAuditPathsForOptions(options);
+  const canonicalSkillsDir = sourceMode === 'sandbox'
+    ? paths.sandboxCanonicalUserSkillsDir
+    : paths.liveCanonicalUserSkillsDir || path.join(options.homeDir ?? homedir(), '.agents', 'skills');
+  const canonicalPath = path.join(
+    path.dirname(canonicalSkillsDir),
+    'agents',
+    getSubagentFileNameForFormat({ name: subagentName, format: 'markdown-frontmatter' }),
+  );
+  const linkedPaths = (snapshot.agents ?? [])
+    .filter((agent) =>
+      agent.scope === sourceMode
+      && agent.installState === 'installed'
+      && agent.writable
+      && agent.subagentsLocation?.state === 'available'
+      && Boolean(agent.subagentsLocation.path)
+      && isSupportedSubagentDirectoryFormat(agent.subagentParserKind ?? 'unknown')
+      && isSubagentFormatRenderableFromUniversal(agent.subagentParserKind ?? 'unknown', 'markdown-frontmatter'))
+    .map((agent) => path.join(agent.subagentsLocation?.path as string, getSubagentFileNameForFormat({
+      name: subagentName,
+      format: agent.subagentParserKind ?? 'markdown-frontmatter',
+      family: agent.family,
+      canonicalPath,
+    })));
+
+  return {
+    kind: 'add-subagent',
+    title: `Added subagent ${subagentName}`,
+    summary: `${1 + linkedPaths.length} ${linkedPaths.length === 0 ? 'path' : 'paths'} created.`,
+    sourceMode,
+    entity: { type: 'subagent', name: subagentName },
+    affectedPaths: dedupePaths([canonicalPath, ...linkedPaths]),
+    undoable: true,
   };
 }
 

--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -23,6 +23,7 @@ const { inventoryRuntime } = vi.hoisted(() => ({
     cancelMcpConnectivityTest: vi.fn(),
     addSkill: vi.fn(),
     addMcpServer: vi.fn(),
+    addSubagent: vi.fn(),
     resolveIssue: vi.fn(),
     applyCapabilityAction: vi.fn(),
     dismissDrift: vi.fn(),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -6,6 +6,7 @@ import { BrowserWindow, dialog, ipcMain, shell } from 'electron';
 import {
   type AddMcpServerRequest,
   type AddSkillRequest,
+  type AddSubagentRequest,
   type AuditOperation,
   type CapabilityActionRequest,
   type ChooseDirectoryRequest,
@@ -69,6 +70,7 @@ export function registerIpcHandlers(): void {
   ipcMain.removeHandler(IPC_CHANNELS.cancelMcpConnectivityTest);
   ipcMain.removeHandler(IPC_CHANNELS.addSkill);
   ipcMain.removeHandler(IPC_CHANNELS.addMcpServer);
+  ipcMain.removeHandler(IPC_CHANNELS.addSubagent);
   ipcMain.removeHandler(IPC_CHANNELS.resolveIssue);
   ipcMain.removeHandler(IPC_CHANNELS.applyCapabilityAction);
   ipcMain.removeHandler(IPC_CHANNELS.dismissDrift);
@@ -152,6 +154,11 @@ export function registerIpcHandlers(): void {
     IPC_CHANNELS.addMcpServer,
     (_event, request: AddMcpServerRequest) =>
       inventoryRuntime.addMcpServer(request, resolveInventoryScanOptions()),
+  );
+  ipcMain.handle(
+    IPC_CHANNELS.addSubagent,
+    (_event, request: AddSubagentRequest) =>
+      inventoryRuntime.addSubagent(request, resolveInventoryScanOptions()),
   );
   ipcMain.handle(IPC_CHANNELS.resolveIssue, (_event, request: ResolveIssueRequest) =>
     inventoryRuntime.resolveIssue(request),

--- a/src/main/subagent-inventory.ts
+++ b/src/main/subagent-inventory.ts
@@ -489,6 +489,34 @@ export function readPortableSubagentDefinitionFromFile({
   return toPortableSubagentDefinition(parsed);
 }
 
+export function readPortableSubagentDefinitionFromText({
+  family,
+  fallbackName,
+  format,
+  raw,
+}: {
+  family?: string;
+  fallbackName?: string;
+  format: AgentSubagentParserKind;
+  raw: string;
+}): PortableSubagentDefinition {
+  const parsed = parseSubagentDefinitionText(raw, {
+    agentId: 'portable-reader',
+    agentLabel: 'Portable Reader',
+    family,
+    scope: 'live',
+    directoryPath: '',
+    format,
+    writable: false,
+    canonical: false,
+  }, fallbackName ?? 'subagent');
+  if (parsed.invalidDetails.length > 0) {
+    throw new Error(parsed.invalidDetails.join(' '));
+  }
+
+  return toPortableSubagentDefinition(parsed);
+}
+
 export function renderPortableSubagentDefinition(
   definition: PortableSubagentDefinition,
   format: AgentSubagentParserKind,
@@ -543,7 +571,6 @@ function readSubagentDefinition(
   fallbackName = getSubagentNameFromPath(filePath),
 ): ParsedSubagentDefinition {
   let raw = '';
-  const invalidDetails: string[] = [];
   try {
     raw = readFileSync(filePath, 'utf8');
   } catch {
@@ -564,6 +591,15 @@ function readSubagentDefinition(
     };
   }
 
+  return parseSubagentDefinitionText(raw, owner, fallbackName);
+}
+
+function parseSubagentDefinitionText(
+  raw: string,
+  owner: SubagentOwnerRecord,
+  fallbackName: string,
+): ParsedSubagentDefinition {
+  const invalidDetails: string[] = [];
   try {
     switch (owner.format) {
       case 'codex-toml':

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2064,13 +2064,17 @@ function getAddedSubagentName(
   nextInventorySnapshot: SkillInventorySnapshot,
 ): string {
   const requestedName = request.name.trim();
+  const previousNames = new Set(previousSnapshot?.subagents?.map((subagent) => subagent.name) ?? []);
+  const addedSubagent = nextInventorySnapshot.subagents?.find((subagent) => !previousNames.has(subagent.name));
+  if (addedSubagent) {
+    return addedSubagent.name;
+  }
+
   if (nextInventorySnapshot.subagents?.some((subagent) => subagent.name === requestedName)) {
     return requestedName;
   }
 
-  const previousNames = new Set(previousSnapshot?.subagents?.map((subagent) => subagent.name) ?? []);
-  const addedSubagent = nextInventorySnapshot.subagents?.find((subagent) => !previousNames.has(subagent.name));
-  return addedSubagent?.name ?? requestedName;
+  return requestedName;
 }
 
 function StartupScreen({ appName }: { appName: string }) {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { Check, ChevronDown, ChevronUp, Copy, Undo2 } from 'lucide-react';
 import {
   type AddSkillRequest,
   type AddMcpServerRequest,
+  type AddSubagentRequest,
   APP_NAME,
   type AppShellState,
   type AuditOperation,
@@ -35,6 +36,7 @@ import {
 import { getAutoResolvableMcpRequests, getAutoResolvableSkillRequests, getAutoResolvableSubagentRequests } from './lib/issue-resolution';
 import type { PendingInventoryOperation } from './lib/pending-inventory-operation';
 import { AppSidebar } from './components/AppSidebar';
+import { AddActionDropdown, type AddActionDropdownItem } from './components/ui';
 import {
   buildMcpInspectorModel,
   buildSkillInspectorModel,
@@ -66,12 +68,12 @@ import {
 import { AgentsWorkspaceView } from './views/AgentsWorkspaceView';
 import { AuditWorkspaceView } from './views/AuditWorkspaceView';
 import { HomeDashboard } from './views/HomeDashboard';
-import { McpWorkspaceView } from './views/McpWorkspaceView';
+import { AddServerModal, McpWorkspaceView } from './views/McpWorkspaceView';
 import { OnboardingFlow } from './views/OnboardingFlow';
 import { PluginsWorkspaceView } from './views/PluginsWorkspaceView';
 import { SettingsWorkspaceView } from './views/SettingsWorkspaceView';
-import { SkillsWorkspaceView } from './views/SkillsWorkspaceView';
-import { SubagentsWorkspaceView } from './views/SubagentsWorkspaceView';
+import { AddSkillModal, SkillsWorkspaceView } from './views/SkillsWorkspaceView';
+import { AddSubagentModal, SubagentsWorkspaceView } from './views/SubagentsWorkspaceView';
 
 function getAutoResolvableRequestsForSnapshot(snapshot: SkillInventorySnapshot): ResolveIssueRequest[] {
   const sourceIndex = new Map(snapshot.sources.map((source) => [source.id, source]));
@@ -184,6 +186,8 @@ export default function App() {
   const [isTestingMcpConnectivity, setIsTestingMcpConnectivity] = useState(false);
   const [isAddingSkill, setIsAddingSkill] = useState(false);
   const [isAddingMcpServer, setIsAddingMcpServer] = useState(false);
+  const [isAddingSubagent, setIsAddingSubagent] = useState(false);
+  const [activeAddModal, setActiveAddModal] = useState<'skill' | 'mcp' | 'subagent' | null>(null);
   const [appToast, setAppToast] = useState<{
     description: string;
     id: number;
@@ -796,6 +800,24 @@ export default function App() {
       throw error instanceof Error ? error : new Error(message);
     } finally {
       setIsAddingMcpServer(false);
+    }
+  }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo, showErrorToast]);
+
+  const handleAddSubagent = useCallback(async (request: AddSubagentRequest) => {
+    setIsAddingSubagent(true);
+
+    try {
+      const previousSnapshot = latestInventorySnapshotRef.current;
+      const nextInventorySnapshot = await desktopApi.addSubagent(request);
+      const addedSubagentName = getAddedSubagentName(request, previousSnapshot, nextInventorySnapshot);
+      applyInventorySnapshot(nextInventorySnapshot);
+      setSelectedSubagentName(addedSubagentName);
+      await showAppToastWithLatestUndo('Subagent added', `${addedSubagentName} was added.`);
+    } catch (error) {
+      const message = showErrorToast('Subagent add failed', error);
+      throw error instanceof Error ? error : new Error(message);
+    } finally {
+      setIsAddingSubagent(false);
     }
   }, [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo, showErrorToast]);
 
@@ -1516,6 +1538,27 @@ export default function App() {
   const isInventoryRefreshActive = isRescanning;
   const isRescanActionBusy = isRescanning || isTestingMcpConnectivity;
   const onCancelMcpConnectivityTest = isTestingMcpConnectivity ? cancelMcpConnectivityTest : undefined;
+  const addActionItems = useMemo<AddActionDropdownItem[]>(() => [
+    {
+      id: 'skill',
+      label: 'Skill',
+      onSelect: () => setActiveAddModal('skill'),
+    },
+    {
+      id: 'mcp',
+      label: 'MCP',
+      onSelect: () => setActiveAddModal('mcp'),
+    },
+    {
+      id: 'subagent',
+      label: 'Subagent',
+      onSelect: () => setActiveAddModal('subagent'),
+    },
+  ], []);
+  const renderAddActionControl = useCallback((defaultItemId?: 'skill' | 'mcp' | 'subagent') => (
+    <AddActionDropdown defaultItemId={defaultItemId} items={addActionItems} />
+  ), [addActionItems]);
+
   if (!hasLoadedStartupState) {
     return <StartupScreen appName={APP_NAME} />;
   }
@@ -1527,6 +1570,7 @@ export default function App() {
     case 'home':
       mainContent = (
         <HomeDashboard
+          addActionControl={renderAddActionControl()}
           autoResolvableRequests={autoResolvableRequests}
           homeSummary={homeSummary}
           inventorySnapshot={inventorySnapshot}
@@ -1545,13 +1589,12 @@ export default function App() {
     case 'skills':
       mainContent = (
         <SkillsWorkspaceView
-          isAddingSkill={isAddingSkill}
+          addActionControl={renderAddActionControl('skill')}
           inventorySnapshot={inventorySnapshot}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
           isApplyingCapabilityAction={isApplyingCapabilityAction}
           isRescanning={isRescanActionBusy}
-          onAddSkill={handleAddSkill}
           onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onDismissDrift={handleDismissDrift}
           onResolveIssue={handleResolveIssue}
@@ -1580,15 +1623,14 @@ export default function App() {
     case 'mcps':
       mainContent = (
         <McpWorkspaceView
+          addActionControl={renderAddActionControl('mcp')}
           inventorySnapshot={inventorySnapshot}
-          isAddingMcpServer={isAddingMcpServer}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
           isRescanning={isRescanActionBusy}
           mcp={selectedMcp}
           mcpInspectorModel={selectedMcpInspectorModel}
           sandboxRoot={shellState?.devTools?.sandboxRoot ?? null}
-          onAddMcpServer={handleAddMcpServer}
           onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onClearSelection={resetMcpSelection}
           onDismissDrift={handleDismissDrift}
@@ -1609,6 +1651,7 @@ export default function App() {
     case 'subagents':
       mainContent = (
         <SubagentsWorkspaceView
+          addActionControl={renderAddActionControl('subagent')}
           inventorySnapshot={inventorySnapshot}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
@@ -1637,6 +1680,7 @@ export default function App() {
     case 'agents':
       mainContent = (
         <AgentsWorkspaceView
+          addActionControl={renderAddActionControl()}
           inventorySnapshot={inventorySnapshot}
           isRescanning={isRescanActionBusy}
           onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
@@ -1651,6 +1695,7 @@ export default function App() {
     case 'plugins':
       mainContent = (
         <PluginsWorkspaceView
+          addActionControl={renderAddActionControl()}
           inventorySnapshot={inventorySnapshot}
           isRescanning={isRescanActionBusy}
           onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
@@ -1677,6 +1722,7 @@ export default function App() {
     case 'audit':
       mainContent = (
         <AuditWorkspaceView
+          addActionControl={renderAddActionControl()}
           auditOperations={auditOperations}
           isRescanning={isRescanActionBusy}
           isUndoingOperation={isUndoingToastOperation}
@@ -1694,6 +1740,7 @@ export default function App() {
     case 'settings':
       mainContent = (
         <SettingsWorkspaceView
+          addActionControl={renderAddActionControl()}
           customScanPathInput={customScanPathInput}
           handleAddCustomScanPath={handleAddCustomScanPath}
           handleClearPreferredCanonicalSourcePath={handleClearPreferredCanonicalSourcePath}
@@ -1811,6 +1858,46 @@ export default function App() {
       </section>
     </div>
   ) : null;
+  const addModalElement = activeAddModal === 'skill' ? (
+    <AddSkillModal
+      isSubmitting={isAddingSkill}
+      onClose={() => {
+        if (!isAddingSkill) {
+          setActiveAddModal(null);
+        }
+      }}
+      onSubmit={async (request) => {
+        await handleAddSkill(request);
+        setActiveAddModal(null);
+      }}
+    />
+  ) : activeAddModal === 'mcp' ? (
+    <AddServerModal
+      isSubmitting={isAddingMcpServer}
+      onClose={() => {
+        if (!isAddingMcpServer) {
+          setActiveAddModal(null);
+        }
+      }}
+      onSubmit={async (request) => {
+        await handleAddMcpServer(request);
+        setActiveAddModal(null);
+      }}
+    />
+  ) : activeAddModal === 'subagent' ? (
+    <AddSubagentModal
+      isSubmitting={isAddingSubagent}
+      onClose={() => {
+        if (!isAddingSubagent) {
+          setActiveAddModal(null);
+        }
+      }}
+      onSubmit={async (request) => {
+        await handleAddSubagent(request);
+        setActiveAddModal(null);
+      }}
+    />
+  ) : null;
 
   if (shouldShowOnboarding) {
     return (
@@ -1869,6 +1956,7 @@ export default function App() {
         <div className="app-main">{mainContent}</div>
       </div>
 
+      {addModalElement}
       {appToastRegion}
 
       <AutoUpdateDialog
@@ -1968,6 +2056,21 @@ function getUpdateDownloadSizeLabel(status: AutoUpdateStatus): string | null {
 
 function formatMegabytes(bytes: number): string {
   return `${(bytes / 1_000_000).toFixed(1)} MB`;
+}
+
+function getAddedSubagentName(
+  request: AddSubagentRequest,
+  previousSnapshot: SkillInventorySnapshot | null,
+  nextInventorySnapshot: SkillInventorySnapshot,
+): string {
+  const requestedName = request.name.trim();
+  if (nextInventorySnapshot.subagents?.some((subagent) => subagent.name === requestedName)) {
+    return requestedName;
+  }
+
+  const previousNames = new Set(previousSnapshot?.subagents?.map((subagent) => subagent.name) ?? []);
+  const addedSubagent = nextInventorySnapshot.subagents?.find((subagent) => !previousNames.has(subagent.name));
+  return addedSubagent?.name ?? requestedName;
 }
 
 function StartupScreen({ appName }: { appName: string }) {

--- a/src/renderer/src/app-search.test.tsx
+++ b/src/renderer/src/app-search.test.tsx
@@ -243,6 +243,7 @@ function createDesktopApi(inventorySnapshot: SkillInventorySnapshot): SkillIndex
     cancelMcpConnectivityTest: vi.fn().mockResolvedValue(undefined),
     addSkill: vi.fn().mockResolvedValue(inventorySnapshot),
     addMcpServer: vi.fn().mockResolvedValue(inventorySnapshot),
+    addSubagent: vi.fn().mockResolvedValue(inventorySnapshot),
     resolveIssue: vi.fn().mockResolvedValue(inventorySnapshot),
     dismissDrift: vi.fn().mockResolvedValue(inventorySnapshot),
     applyCapabilityAction: vi.fn().mockResolvedValue(inventorySnapshot),

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -1473,6 +1473,8 @@ describe('App shell inventory views', () => {
   });
 
   it('uses markdown copy for the Add Subagent content path', async () => {
+    readCachedInventoryMock.mockResolvedValue(structuredClone(representativeInventorySnapshot));
+    scanInventoryMock.mockResolvedValue(structuredClone(representativeInventorySnapshot));
     addSubagentMock.mockResolvedValueOnce(createInventorySnapshotWithAddedSubagent('markdown-reviewer'));
     render(<App />);
     fireEvent.click(within(await getPrimaryNavAsync()).getByRole('button', { name: /^Subagents/i }));
@@ -1487,7 +1489,7 @@ describe('App shell inventory views', () => {
     expect(within(dialog).getByRole('textbox', { name: /Markdown contents/i })).toBeInTheDocument();
 
     fireEvent.change(within(dialog).getByRole('textbox', { name: /Subagent name/i }), {
-      target: { value: 'fallback-reviewer' },
+      target: { value: 'reviewer' },
     });
     fireEvent.change(within(dialog).getByRole('textbox', { name: /Markdown contents/i }), {
       target: {
@@ -1506,7 +1508,7 @@ describe('App shell inventory views', () => {
     await waitFor(() => {
       expect(addSubagentMock).toHaveBeenCalledWith({
         sourceType: 'definition',
-        name: 'fallback-reviewer',
+        name: 'reviewer',
         format: 'markdown-frontmatter',
         definition: [
           '---',
@@ -3057,7 +3059,7 @@ function createInventorySnapshot(): SkillInventorySnapshot {
 }
 
 function createInventorySnapshotWithAddedSubagent(name: string): SkillInventorySnapshot {
-  const snapshot = createInventorySnapshot();
+  const snapshot = structuredClone(representativeInventorySnapshot);
   const addedSubagent: NonNullable<SkillInventorySnapshot['subagents']>[number] = {
     name,
     displayName: name,

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -48,6 +48,7 @@ describe('App shell inventory views', () => {
   let cancelMcpConnectivityTestMock: Mock<SkillIndexDesktopApi['cancelMcpConnectivityTest']>;
   let addSkillMock: Mock<SkillIndexDesktopApi['addSkill']>;
   let addMcpServerMock: Mock<SkillIndexDesktopApi['addMcpServer']>;
+  let addSubagentMock: Mock<SkillIndexDesktopApi['addSubagent']>;
   let makeCanonicalMock: Mock<SkillIndexDesktopApi['resolveIssue']>;
   let dismissDriftMock: Mock<SkillIndexDesktopApi['dismissDrift']>;
   let applyCapabilityActionMock: Mock<SkillIndexDesktopApi['applyCapabilityAction']>;
@@ -80,6 +81,7 @@ describe('App shell inventory views', () => {
     cancelMcpConnectivityTestMock = vi.fn().mockResolvedValue(undefined);
     addSkillMock = vi.fn().mockResolvedValue(createInventorySnapshot());
     addMcpServerMock = vi.fn().mockResolvedValue(createInventorySnapshot());
+    addSubagentMock = vi.fn().mockResolvedValue(createInventorySnapshot());
     makeCanonicalMock = vi.fn().mockResolvedValue(createCanonicalizedDivergedInventorySnapshot());
     dismissDriftMock = vi.fn().mockResolvedValue(createDismissedIdenticalDriftInventorySnapshot());
     applyCapabilityActionMock = vi.fn().mockResolvedValue(createInventorySnapshot());
@@ -134,6 +136,7 @@ describe('App shell inventory views', () => {
       cancelMcpConnectivityTest: cancelMcpConnectivityTestMock,
       addSkill: addSkillMock,
       addMcpServer: addMcpServerMock,
+      addSubagent: addSubagentMock,
       resolveIssue: makeCanonicalMock,
       dismissDrift: dismissDriftMock,
       applyCapabilityAction: applyCapabilityActionMock,
@@ -1144,7 +1147,7 @@ describe('App shell inventory views', () => {
     fireEvent.click(getSkillRow('identical-drift-skill'));
 
     expect(await screen.findByRole('button', { name: /^Convert Copies to Symlinks$/i })).toBeEnabled();
-    expect(screen.getByRole('button', { name: /^\+ Add Skill$/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /^Add Skill$/i })).toBeEnabled();
 
     fireEvent.click(screen.getByRole('button', { name: /^Convert Copies to Symlinks$/i }));
 
@@ -1250,7 +1253,7 @@ describe('App shell inventory views', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Add Skill/i }));
 
-    expect(await screen.findByRole('dialog', { name: /Add skill/i })).toBeInTheDocument();
+    const dialog = await screen.findByRole('dialog', { name: /Add skill/i });
     fireEvent.click(screen.getByRole('tab', { name: /Paste Markdown/i }));
     fireEvent.change(screen.getByRole('textbox', { name: /Skill name/i }), {
       target: { value: 'my-skill-name' },
@@ -1259,7 +1262,7 @@ describe('App shell inventory views', () => {
       target: { value: '# my-skill\n\nUse this skill.\n' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /^Add skill$/i }));
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Add skill$/i }));
 
     await waitFor(() => {
       expect(addSkillMock).toHaveBeenCalledWith({
@@ -1284,11 +1287,12 @@ describe('App shell inventory views', () => {
     await openSkills();
     fireEvent.click(screen.getByRole('button', { name: /Add Skill/i }));
 
-    const sourceInput = await screen.findByRole('textbox', { name: /Repository or skill URL/i });
+    const dialog = await screen.findByRole('dialog', { name: /Add skill/i });
+    const sourceInput = within(dialog).getByRole('textbox', { name: /Repository or skill URL/i });
     fireEvent.change(sourceInput, {
       target: { value: 'https://github.com/example/agent-skills' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /^Add skill$/i }));
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Add skill$/i }));
 
     await waitFor(() => {
       expect(addSkillMock).toHaveBeenCalledWith({
@@ -1381,7 +1385,7 @@ describe('App shell inventory views', () => {
     render(<App />);
     await openMcps();
 
-    fireEvent.click(screen.getByRole('button', { name: /Add Server/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Add MCP/i }));
 
     expect(await screen.findByRole('dialog', { name: /Add Server/i })).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/One argument per line/i)).toBeInTheDocument();
@@ -1420,6 +1424,115 @@ describe('App shell inventory views', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog', { name: /Add Server/i })).not.toBeInTheDocument();
     });
+  });
+
+  it('opens the Add Subagent modal from the global Add menu and submits it through the desktop API', async () => {
+    render(<App />);
+    await openAgents();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Open Add menu$/i }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Add Subagent$/i }));
+
+    expect(await screen.findByRole('dialog', { name: /Add Subagent/i })).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('textbox', { name: /Subagent name/i }), {
+      target: { value: 'reviewer' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /Markdown contents/i }), {
+      target: {
+        value: [
+          '---',
+          'name: reviewer',
+          'description: Reviews implementation changes.',
+          '---',
+          'Review the diff and call out correctness risks.',
+          '',
+        ].join('\n'),
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Add Subagent$/i }));
+
+    await waitFor(() => {
+      expect(addSubagentMock).toHaveBeenCalledWith({
+        sourceType: 'definition',
+        name: 'reviewer',
+        format: 'markdown-frontmatter',
+        definition: [
+          '---',
+          'name: reviewer',
+          'description: Reviews implementation changes.',
+          '---',
+          'Review the diff and call out correctness risks.',
+          '',
+        ].join('\n'),
+      });
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /Add Subagent/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('uses markdown copy for the Add Subagent content path', async () => {
+    addSubagentMock.mockResolvedValueOnce(createInventorySnapshotWithAddedSubagent('markdown-reviewer'));
+    render(<App />);
+    fireEvent.click(within(await getPrimaryNavAsync()).getByRole('button', { name: /^Subagents/i }));
+    await screen.findByRole('heading', { name: /^Subagents$/i, level: 2 });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Add Subagent$/i }));
+    const dialog = await screen.findByRole('dialog', { name: /Add Subagent/i });
+
+    expect(within(dialog).queryByRole('tab', { name: /^Write$/i })).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole('tab', { name: /^Paste Definition$/i })).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole('combobox', { name: /Format/i })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole('textbox', { name: /Markdown contents/i })).toBeInTheDocument();
+
+    fireEvent.change(within(dialog).getByRole('textbox', { name: /Subagent name/i }), {
+      target: { value: 'fallback-reviewer' },
+    });
+    fireEvent.change(within(dialog).getByRole('textbox', { name: /Markdown contents/i }), {
+      target: {
+        value: [
+          '---',
+          'name: markdown-reviewer',
+          'description: Reviews Markdown changes.',
+          '---',
+          'Use Markdown review guidance.',
+          '',
+        ].join('\n'),
+      },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Add Subagent$/i }));
+
+    await waitFor(() => {
+      expect(addSubagentMock).toHaveBeenCalledWith({
+        sourceType: 'definition',
+        name: 'fallback-reviewer',
+        format: 'markdown-frontmatter',
+        definition: [
+          '---',
+          'name: markdown-reviewer',
+          'description: Reviews Markdown changes.',
+          '---',
+          'Use Markdown review guidance.',
+          '',
+        ].join('\n'),
+      });
+    });
+    expect(await screen.findByRole('status')).toHaveTextContent('markdown-reviewer was added.');
+  });
+
+  it('defaults the Add dropdown to the current inventory kind', async () => {
+    render(<App />);
+
+    await openSkills();
+    expect(screen.getByRole('button', { name: /^Add Skill$/i })).toBeInTheDocument();
+
+    await openMcps();
+    expect(screen.getByRole('button', { name: /^Add MCP$/i })).toBeInTheDocument();
+
+    fireEvent.click(within(await getPrimaryNavAsync()).getByRole('button', { name: /^Subagents/i }));
+    await screen.findByRole('heading', { name: /^Subagents$/i, level: 2 });
+    expect(screen.getByRole('button', { name: /^Add Subagent$/i })).toBeInTheDocument();
   });
 
   it('filters MCPs from the summary badges above the table', async () => {
@@ -2941,6 +3054,46 @@ function createInventorySnapshot(): SkillInventorySnapshot {
       dismissedDriftSkills: 1,
     },
   });
+}
+
+function createInventorySnapshotWithAddedSubagent(name: string): SkillInventorySnapshot {
+  const snapshot = createInventorySnapshot();
+  const addedSubagent: NonNullable<SkillInventorySnapshot['subagents']>[number] = {
+    name,
+    displayName: name,
+    description: 'Reviews Codex changes.',
+    status: 'healthy',
+    presentation: 'none',
+    issueReasons: [],
+    locations: [
+      {
+        agentId: 'sandbox-agents-subagents',
+        agentLabel: 'Sandbox .agents',
+        scope: 'sandbox',
+        path: `${DEFAULT_SANDBOX_ROOT}/.agents/agents/${name}.md`,
+        directoryPath: `${DEFAULT_SANDBOX_ROOT}/.agents/agents`,
+        fileType: 'real-file',
+        modifiedAt: '2026-04-09T00:00:10.000Z',
+        canonical: true,
+        format: 'markdown-frontmatter',
+        description: 'Reviews Codex changes.',
+      },
+    ],
+  };
+
+  const subagents = [...(snapshot.subagents ?? []), addedSubagent];
+  return {
+    ...snapshot,
+    subagents,
+    subagentCounts: {
+      totalSubagents: subagents.length,
+      attentionSubagents: subagents.filter((subagent) =>
+        subagent.status === 'needs-attention' && subagent.presentation === 'active').length,
+      healthySubagents: subagents.filter((subagent) => subagent.status === 'healthy').length,
+      dismissedAttentionSubagents: subagents.filter((subagent) =>
+        subagent.status === 'needs-attention' && subagent.presentation === 'dismissed').length,
+    },
+  };
 }
 
 function createInventorySnapshotWithAcceptedPluginAlternate(): SkillInventorySnapshot {

--- a/src/renderer/src/app/browser-preview-adapter.ts
+++ b/src/renderer/src/app/browser-preview-adapter.ts
@@ -1,6 +1,7 @@
 import {
   type AddMcpServerRequest,
   type AddSkillRequest,
+  type AddSubagentRequest,
   APP_NAME,
   type DismissDriftRequest,
   type McpPresentation,
@@ -80,6 +81,10 @@ const browserPreviewApi: SkillIndexDesktopApi = {
     return Promise.resolve(cloneInventorySnapshot(browserPreviewSnapshot));
   },
   addMcpServer: (request: AddMcpServerRequest) => {
+    void request;
+    return Promise.resolve(cloneInventorySnapshot(browserPreviewSnapshot));
+  },
+  addSubagent: (request: AddSubagentRequest) => {
     void request;
     return Promise.resolve(cloneInventorySnapshot(browserPreviewSnapshot));
   },

--- a/src/renderer/src/components/ui.tsx
+++ b/src/renderer/src/components/ui.tsx
@@ -1,5 +1,5 @@
 import type { AgentRecord } from '@shared/contracts';
-import { Plug, Search, X } from 'lucide-react';
+import { ChevronDown, Plug, Plus, Search, X } from 'lucide-react';
 import {
   useEffect,
   useId,
@@ -257,6 +257,104 @@ export function ToolbarButton({
       ) : null}
       <span>{variant === 'strong' ? `+ ${visibleLabel}` : visibleLabel}</span>
     </button>
+  );
+}
+
+export interface AddActionDropdownItem {
+  id: string;
+  label: string;
+  onSelect: () => void;
+}
+
+export function AddActionDropdown({
+  defaultItemId,
+  items,
+}: {
+  defaultItemId?: string;
+  items: AddActionDropdownItem[];
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const defaultItem = items.find((item) => item.id === defaultItemId) ?? null;
+  const primaryLabel = defaultItem ? `Add ${defaultItem.label}` : 'Add';
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  const runAction = (item: AddActionDropdownItem) => {
+    setIsOpen(false);
+    item.onSelect();
+  };
+
+  return (
+    <div className="add-action-dropdown" ref={rootRef}>
+      <button
+        aria-label={primaryLabel}
+        className="toolbar-button toolbar-button--strong add-action-dropdown__primary"
+        type="button"
+        onClick={() => {
+          if (defaultItem) {
+            runAction(defaultItem);
+            return;
+          }
+
+          setIsOpen((current) => !current);
+        }}
+      >
+        <span className="toolbar-button-icon" aria-hidden="true">
+          <Plus />
+        </span>
+        <span>{primaryLabel}</span>
+      </button>
+      <button
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        aria-label="Open Add menu"
+        className="toolbar-button toolbar-button--strong add-action-dropdown__toggle"
+        type="button"
+        onClick={() => {
+          setIsOpen((current) => !current);
+        }}
+      >
+        <ChevronDown aria-hidden="true" />
+      </button>
+      {isOpen ? (
+        <div className="add-action-dropdown__menu" role="menu">
+          {items.map((item) => (
+            <button
+              className="add-action-dropdown__item"
+              key={item.id}
+              role="menuitem"
+              type="button"
+              onClick={() => runAction(item)}
+            >
+              Add {item.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -5653,6 +5653,66 @@ body {
   height: 12px;
 }
 
+.add-action-dropdown {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.add-action-dropdown__primary {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.add-action-dropdown__toggle {
+  width: 30px;
+  justify-content: center;
+  padding: 0;
+  border-left-color: rgba(255, 253, 248, 0.24);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.add-action-dropdown__toggle svg {
+  width: 13px;
+  height: 13px;
+}
+
+.add-action-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  min-width: 148px;
+  padding: 4px;
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  background: #ffffff;
+  box-shadow: 0 14px 36px rgba(18, 18, 16, 0.18);
+}
+
+.add-action-dropdown__item {
+  display: flex;
+  width: 100%;
+  min-height: 28px;
+  align-items: center;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.add-action-dropdown__item:hover,
+.add-action-dropdown__item:focus-visible {
+  outline: none;
+  background: var(--bg-panel-muted);
+}
+
 .toolbar-button-icon--loading svg {
   animation: toolbar-button-spin 900ms linear infinite;
   transform-origin: center;

--- a/src/renderer/src/views/AgentsWorkspaceView.tsx
+++ b/src/renderer/src/views/AgentsWorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type RefObject } from 'react';
+import { useMemo, useState, type ReactNode, type RefObject } from 'react';
 
 import type { AgentInstallState, AgentRecord, SkillInventorySnapshot } from '@shared/contracts';
 
@@ -8,6 +8,7 @@ import { AgentStatusRow, EmptyStatePanel, HeaderSearch, InventorySectionBlock, P
 type AgentStatusFilter = 'all' | AgentInstallState;
 
 export function AgentsWorkspaceView({
+  addActionControl,
   inventorySnapshot,
   isRescanning,
   onCancelMcpConnectivityTest,
@@ -17,6 +18,7 @@ export function AgentsWorkspaceView({
   searchInputRef,
   searchQuery,
 }: {
+  addActionControl?: ReactNode;
   inventorySnapshot: SkillInventorySnapshot | null;
   isRescanning: boolean;
   onCancelMcpConnectivityTest?: () => void;
@@ -68,7 +70,10 @@ export function AgentsWorkspaceView({
     <main className="workspace-view">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+          <div className="header-action-cluster">
+            <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+            {addActionControl}
+          </div>
         )}
         search={(
           <HeaderSearch

--- a/src/renderer/src/views/AuditWorkspaceView.tsx
+++ b/src/renderer/src/views/AuditWorkspaceView.tsx
@@ -15,6 +15,7 @@ interface AuditEventRow {
 }
 
 export function AuditWorkspaceView({
+  addActionControl,
   auditOperations,
   isRescanning,
   isUndoingOperation,
@@ -25,6 +26,7 @@ export function AuditWorkspaceView({
   searchQuery,
   setSearchQuery,
 }: {
+  addActionControl?: ReactNode;
   auditOperations: AuditOperation[];
   isRescanning: boolean;
   isUndoingOperation: boolean;
@@ -78,7 +80,10 @@ export function AuditWorkspaceView({
     <main className="workspace-view workspace-view--audit">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+          <div className="header-action-cluster">
+            <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+            {addActionControl}
+          </div>
         )}
         title="Audit Log"
         search={(

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -1,5 +1,5 @@
 import { ArrowRight, Check, ChevronRight, ChevronUp, Wrench } from 'lucide-react';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import type { McpRecord, ResolveIssueRequest, SkillInventorySnapshot, SkillRecord, SkillScanSource, SubagentRecord } from '@shared/contracts';
 
@@ -471,6 +471,7 @@ function RepairSurface({
 }
 
 export function HomeDashboard({
+  addActionControl,
   autoResolvableRequests,
   homeSummary,
   inventorySnapshot,
@@ -484,6 +485,7 @@ export function HomeDashboard({
   onSelectSkill,
   onSelectSubagent,
 }: {
+  addActionControl?: ReactNode;
   autoResolvableRequests: ResolveIssueRequest[];
   homeSummary: ReturnType<typeof getHomeSummary>;
   inventorySnapshot: SkillInventorySnapshot | null;
@@ -602,7 +604,10 @@ export function HomeDashboard({
     <main className="workspace-view">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+          <div className="header-action-cluster">
+            <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+            {addActionControl}
+          </div>
         )}
         title="Home"
       />

--- a/src/renderer/src/views/InventoryViewChrome.test.tsx
+++ b/src/renderer/src/views/InventoryViewChrome.test.tsx
@@ -27,13 +27,11 @@ function renderSkillsWorkspaceView({
 } = {}) {
   return render(
     <SkillsWorkspaceView
-      isAddingSkill={false}
       inventorySnapshot={inventorySnapshot}
       isDismissingDrift={false}
       isApplyingCapabilityAction={false}
       isResolvingIssue={false}
       isRescanning={isRescanning}
-      onAddSkill={vi.fn(() => Promise.resolve())}
       onClearSelection={vi.fn()}
       onDismissDrift={vi.fn(() => Promise.resolve())}
       onApplyCapabilityAction={vi.fn(() => Promise.resolve())}
@@ -77,14 +75,12 @@ function renderMcpWorkspaceView({
   render(
     <McpWorkspaceView
       inventorySnapshot={inventorySnapshot}
-      isAddingMcpServer={false}
       isDismissingDrift={false}
       isResolvingIssue={false}
       isRescanning={isRescanning}
       mcp={null}
       mcpInspectorModel={null}
       sandboxRoot={null}
-      onAddMcpServer={vi.fn(() => Promise.resolve())}
       onClearSelection={vi.fn()}
       onDismissDrift={vi.fn(() => Promise.resolve())}
       onResolveIssue={vi.fn(() => Promise.resolve())}
@@ -436,14 +432,12 @@ describe('inventory view chrome', () => {
     render(
       <McpWorkspaceView
         inventorySnapshot={representativeInventorySnapshot}
-        isAddingMcpServer={false}
         isDismissingDrift={false}
         isResolvingIssue={false}
         isRescanning={false}
         mcp={null}
         mcpInspectorModel={null}
         sandboxRoot={null}
-        onAddMcpServer={vi.fn(() => Promise.resolve())}
         onClearSelection={vi.fn()}
         onDismissDrift={vi.fn(() => Promise.resolve())}
         onResolveIssue={vi.fn(() => Promise.resolve())}
@@ -577,13 +571,11 @@ describe('inventory view chrome', () => {
 
     const { rerender } = render(
       <SkillsWorkspaceView
-        isAddingSkill={false}
         inventorySnapshot={representativeInventorySnapshot}
         isDismissingDrift={false}
         isApplyingCapabilityAction={false}
         isResolvingIssue={false}
         isRescanning={false}
-        onAddSkill={vi.fn(() => Promise.resolve())}
         onClearSelection={vi.fn()}
         onDismissDrift={vi.fn(() => Promise.resolve())}
         onApplyCapabilityAction={vi.fn(() => Promise.resolve())}
@@ -616,7 +608,6 @@ describe('inventory view chrome', () => {
     rerender(
       <McpWorkspaceView
         inventorySnapshot={representativeInventorySnapshot}
-        isAddingMcpServer={false}
         isDismissingDrift={false}
         isResolvingIssue={false}
         isRescanning={false}
@@ -626,7 +617,6 @@ describe('inventory view chrome', () => {
           selectedVariantPath: '~/.skillindex/sandbox/.agents/mcp.json',
         }, agentIndex) : null}
         sandboxRoot={null}
-        onAddMcpServer={vi.fn(() => Promise.resolve())}
         onClearSelection={vi.fn()}
         onDismissDrift={vi.fn(() => Promise.resolve())}
         onResolveIssue={vi.fn(() => Promise.resolve())}

--- a/src/renderer/src/views/McpWorkspaceView.tsx
+++ b/src/renderer/src/views/McpWorkspaceView.tsx
@@ -7,7 +7,7 @@ import type {
   ResolveIssueRequest,
   SkillInventorySnapshot,
 } from '@shared/contracts';
-import { useEffect, useState, type RefObject } from 'react';
+import { useEffect, useState, type ReactNode, type RefObject } from 'react';
 
 import { getMcpDisplayName, getMcpSections, hasSearchQuery } from '../inventory-view-model';
 import {
@@ -28,20 +28,18 @@ import {
   PageTopBar,
   PLUGIN_MCP_TOOLTIP,
   RescanToolbarButton,
-  ToolbarButton,
   WorkspaceFilterBar,
 } from '../components/ui';
 
 export function McpWorkspaceView({
+  addActionControl,
   inventorySnapshot,
-  isAddingMcpServer,
   isDismissingDrift,
   isResolvingIssue,
   isRescanning,
   mcp,
   mcpInspectorModel,
   sandboxRoot,
-  onAddMcpServer,
   onCancelMcpConnectivityTest,
   onClearSelection,
   onDismissDrift,
@@ -57,15 +55,14 @@ export function McpWorkspaceView({
   searchQuery,
   statusFilter,
 }: {
+  addActionControl?: ReactNode;
   inventorySnapshot: SkillInventorySnapshot | null;
-  isAddingMcpServer: boolean;
   isDismissingDrift: boolean;
   isResolvingIssue: boolean;
   isRescanning: boolean;
   mcp: McpRecord | null;
   mcpInspectorModel: InspectorModel | null;
   sandboxRoot: string | null;
-  onAddMcpServer: (request: AddMcpServerRequest) => Promise<void>;
   onCancelMcpConnectivityTest?: () => void;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
@@ -96,7 +93,6 @@ export function McpWorkspaceView({
         totalMcps: inventorySnapshot.mcpCounts.totalMcps,
       })
     : 'Scanning your MCP inventory…';
-  const [isAddServerModalOpen, setIsAddServerModalOpen] = useState(false);
 
   useEffect(() => {
     if (!mcp) {
@@ -113,13 +109,7 @@ export function McpWorkspaceView({
           actions={(
             <div className="header-action-cluster">
               <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
-              <ToolbarButton
-                label="Add Server"
-                variant="strong"
-                onClick={() => {
-                  setIsAddServerModalOpen(true);
-                }}
-              />
+              {addActionControl}
             </div>
           )}
           search={(
@@ -196,20 +186,6 @@ export function McpWorkspaceView({
         </div>
       </main>
 
-      {isAddServerModalOpen ? (
-        <AddServerModal
-          isSubmitting={isAddingMcpServer}
-          onClose={() => {
-            if (!isAddingMcpServer) {
-              setIsAddServerModalOpen(false);
-            }
-          }}
-          onSubmit={async (request) => {
-            await onAddMcpServer(request);
-            setIsAddServerModalOpen(false);
-          }}
-        />
-      ) : null}
     </>
   );
 }
@@ -247,7 +223,7 @@ function getMcpEmptyStateMessage({
 
 type AddServerMode = 'stdio' | 'remote';
 
-function AddServerModal({
+export function AddServerModal({
   isSubmitting,
   onClose,
   onSubmit,

--- a/src/renderer/src/views/PluginsWorkspaceView.tsx
+++ b/src/renderer/src/views/PluginsWorkspaceView.tsx
@@ -6,7 +6,7 @@ import type {
   PluginUnsupportedAssetRef,
   SkillInventorySnapshot,
 } from '@shared/contracts';
-import { useEffect, useState, type RefObject } from 'react';
+import { useEffect, useState, type ReactNode, type RefObject } from 'react';
 
 import { hasSearchQuery } from '../inventory-view-model';
 import {
@@ -19,6 +19,7 @@ import {
 import { formatInspectorDisplayPath } from '../lib/inventory-presentation';
 
 export function PluginsWorkspaceView({
+  addActionControl,
   inventorySnapshot,
   isRescanning,
   onCancelMcpConnectivityTest,
@@ -36,6 +37,7 @@ export function PluginsWorkspaceView({
   selectedPlugin,
   selectedPluginKey,
 }: {
+  addActionControl?: ReactNode;
   inventorySnapshot: SkillInventorySnapshot | null;
   isRescanning: boolean;
   onCancelMcpConnectivityTest?: () => void;
@@ -64,7 +66,10 @@ export function PluginsWorkspaceView({
     <main className="workspace-view">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+          <div className="header-action-cluster">
+            <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+            {addActionControl}
+          </div>
         )}
         search={(
           <HeaderSearch

--- a/src/renderer/src/views/SettingsWorkspaceView.tsx
+++ b/src/renderer/src/views/SettingsWorkspaceView.tsx
@@ -11,6 +11,7 @@ import {
 } from '../components/ui';
 
 export function SettingsWorkspaceView({
+  addActionControl,
   customScanPathInput,
   devToolsEnabled,
   handleAddCustomScanPath,
@@ -37,6 +38,7 @@ export function SettingsWorkspaceView({
   setPreferredCanonicalSourcePathInput,
   shellState,
 }: {
+  addActionControl?: ReactNode;
   customScanPathInput: string;
   devToolsEnabled: boolean;
   handleAddCustomScanPath: (event: FormEvent<HTMLFormElement>) => Promise<void>;
@@ -72,7 +74,10 @@ export function SettingsWorkspaceView({
     <main className="workspace-view">
       <PageTopBar
         actions={(
-          <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+          <div className="header-action-cluster">
+            <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+            {addActionControl}
+          </div>
         )}
         title="Settings"
       />

--- a/src/renderer/src/views/SkillsWorkspaceView.tsx
+++ b/src/renderer/src/views/SkillsWorkspaceView.tsx
@@ -8,7 +8,7 @@ import type {
   SkillRecord,
   SkillScanSource,
 } from '@shared/contracts';
-import { useEffect, useState, type RefObject } from 'react';
+import { useEffect, useState, type ReactNode, type RefObject } from 'react';
 
 import { getSkillDisplayName, getSkillSections, hasSearchQuery } from '../inventory-view-model';
 import {
@@ -30,18 +30,15 @@ import {
   PageTopBar,
   PLUGIN_SKILL_TOOLTIP,
   RescanToolbarButton,
-  ToolbarButton,
   WorkspaceFilterBar,
 } from '../components/ui';
 
 export function SkillsWorkspaceView({
-  isAddingSkill,
   inventorySnapshot,
   isDismissingDrift,
   isApplyingCapabilityAction,
   isResolvingIssue,
   isRescanning,
-  onAddSkill,
   onCancelMcpConnectivityTest,
   onClearSelection,
   onDismissDrift,
@@ -64,14 +61,13 @@ export function SkillsWorkspaceView({
   setStatusFilter,
   sourceIndex,
   statusFilter,
+  addActionControl,
 }: {
-  isAddingSkill: boolean;
   inventorySnapshot: SkillInventorySnapshot | null;
   isDismissingDrift: boolean;
   isApplyingCapabilityAction: boolean;
   isResolvingIssue: boolean;
   isRescanning: boolean;
-  onAddSkill: (request: AddSkillRequest) => Promise<void>;
   onCancelMcpConnectivityTest?: () => void;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
@@ -94,6 +90,7 @@ export function SkillsWorkspaceView({
   setStatusFilter: (filter: SkillStatusFilter) => void;
   sourceIndex: Map<string, SkillScanSource>;
   statusFilter: SkillStatusFilter;
+  addActionControl?: ReactNode;
 }) {
   const sections = filterVisibleSections(inventorySnapshot ? getSkillSections(inventorySnapshot) : [], rows);
   const filters = inventorySnapshot
@@ -111,7 +108,6 @@ export function SkillsWorkspaceView({
         totalSkills: inventorySnapshot.counts.totalSkills,
       })
     : 'Scanning your skill inventory…';
-  const [isAddSkillModalOpen, setIsAddSkillModalOpen] = useState(false);
 
   useEffect(() => {
     if (!selectedSkill) {
@@ -128,13 +124,7 @@ export function SkillsWorkspaceView({
           actions={(
             <div className="header-action-cluster">
               <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
-              <ToolbarButton
-                label="Add Skill"
-                variant="strong"
-                onClick={() => {
-                  setIsAddSkillModalOpen(true);
-                }}
-              />
+              {addActionControl}
             </div>
           )}
           search={(
@@ -225,20 +215,6 @@ export function SkillsWorkspaceView({
         </div>
       </main>
 
-      {isAddSkillModalOpen ? (
-        <AddSkillModal
-          isSubmitting={isAddingSkill}
-          onClose={() => {
-            if (!isAddingSkill) {
-              setIsAddSkillModalOpen(false);
-            }
-          }}
-          onSubmit={async (request) => {
-            await onAddSkill(request);
-            setIsAddSkillModalOpen(false);
-          }}
-        />
-      ) : null}
     </>
   );
 }
@@ -394,7 +370,7 @@ function hasPluginSkillLocation(skill: SkillRecord, sourceIndex: Map<string, Ski
     location.provenance?.kind === 'plugin' || sourceIndex.get(location.sourceId)?.kind === 'plugin');
 }
 
-function AddSkillModal({
+export function AddSkillModal({
   isSubmitting,
   onClose,
   onSubmit,

--- a/src/renderer/src/views/SubagentsWorkspaceView.tsx
+++ b/src/renderer/src/views/SubagentsWorkspaceView.tsx
@@ -1,11 +1,12 @@
 import type {
+  AddSubagentRequest,
   DismissDriftRequest,
   ResolveIssueRequest,
   SkillInventorySnapshot,
   SubagentIssueReason,
   SubagentRecord,
 } from '@shared/contracts';
-import { useEffect, type RefObject } from 'react';
+import { useEffect, useState, type ReactNode, type RefObject } from 'react';
 
 import {
   getSubagentDisplayName,
@@ -34,6 +35,7 @@ import {
 } from '../components/ui';
 
 export function SubagentsWorkspaceView({
+  addActionControl,
   inventorySnapshot,
   isDismissingDrift,
   isResolvingIssue,
@@ -57,6 +59,7 @@ export function SubagentsWorkspaceView({
   selectedSubagentProblemKey,
   statusFilter,
 }: {
+  addActionControl?: ReactNode;
   inventorySnapshot: SkillInventorySnapshot | null;
   isDismissingDrift: boolean;
   isResolvingIssue: boolean;
@@ -108,7 +111,12 @@ export function SubagentsWorkspaceView({
   return (
     <main className="workspace-view">
       <PageTopBar
-        actions={<RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />}
+        actions={(
+          <div className="header-action-cluster">
+            <RescanToolbarButton isRescanning={isRescanning} onCancel={onCancelMcpConnectivityTest} onRescan={onRescan} />
+            {addActionControl}
+          </div>
+        )}
         search={(
           <HeaderSearch
             inputRef={searchInputRef}
@@ -300,6 +308,126 @@ function getSubagentEmptyStateMessage({
     default:
       return 'No subagents found.';
   }
+}
+
+export function AddSubagentModal({
+  isSubmitting,
+  onClose,
+  onSubmit,
+}: {
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (request: AddSubagentRequest) => Promise<void>;
+}) {
+  const [name, setName] = useState('');
+  const [markdown, setMarkdown] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !isSubmitting) {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isSubmitting, onClose]);
+
+  useEffect(() => {
+    setSubmitError(null);
+  }, [markdown, name]);
+
+  const canSubmit = name.trim().length > 0 && markdown.trim().length > 0;
+
+  return (
+    <div className="add-skill-modal-root" role="presentation">
+      <div className="add-skill-modal-backdrop" />
+      <section aria-label="Add Subagent" aria-modal="true" className="add-skill-modal add-subagent-modal" role="dialog">
+        <div className="add-skill-modal__header">
+          <h3>Add Subagent</h3>
+          <button
+            aria-label="Close Add Subagent modal"
+            className="add-skill-modal__close"
+            disabled={isSubmitting}
+            type="button"
+            onClick={onClose}
+          >
+            x
+          </button>
+        </div>
+
+        <form
+          className="add-skill-modal__body"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!canSubmit || isSubmitting) {
+              return;
+            }
+
+            const request: AddSubagentRequest = {
+              sourceType: 'definition',
+              name,
+              format: 'markdown-frontmatter',
+              definition: markdown,
+            };
+
+            void onSubmit(request).catch((error) => {
+              setSubmitError(error instanceof Error ? error.message : 'Unable to add Subagent.');
+            });
+          }}
+        >
+          <label className="add-skill-modal__field">
+            <span>Subagent name</span>
+            <input
+              className="add-skill-modal__input add-skill-modal__input--mono"
+              placeholder="reviewer"
+              type="text"
+              value={name}
+              onChange={(event) => {
+                setName(event.target.value);
+              }}
+            />
+          </label>
+
+          <label className="add-skill-modal__field">
+            <span>Markdown contents</span>
+            <textarea
+              className="add-skill-modal__textarea add-skill-modal__input--mono"
+              placeholder={'---\nname: reviewer\ndescription: Reviews implementation changes.\n---\nReview the diff and call out correctness risks.'}
+              value={markdown}
+              onChange={(event) => {
+                setMarkdown(event.target.value);
+              }}
+            />
+          </label>
+
+          {submitError ? <p className="add-skill-modal__error">{submitError}</p> : null}
+
+          <div className="add-skill-modal__actions">
+            <button
+              className="add-skill-modal__button add-skill-modal__button--secondary"
+              disabled={isSubmitting}
+              type="button"
+              onClick={onClose}
+            >
+              Cancel
+            </button>
+            <button
+              className="add-skill-modal__button add-skill-modal__button--primary"
+              disabled={!canSubmit || isSubmitting}
+              type="submit"
+            >
+              {isSubmitting ? 'Adding Subagent…' : 'Add Subagent'}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
 }
 
 function getSubagentDismissActionLabel(subagent: SubagentRecord, isDismissingDrift: boolean): string {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -17,6 +17,7 @@ export const IPC_CHANNELS = {
   cancelMcpConnectivityTest: 'inventory:cancel-mcp-connectivity-test',
   addSkill: 'inventory:add-skill',
   addMcpServer: 'inventory:add-mcp-server',
+  addSubagent: 'inventory:add-subagent',
   resolveIssue: 'inventory:resolve-issue',
   applyCapabilityAction: 'inventory:apply-capability-action',
   dismissDrift: 'inventory:dismiss-drift',
@@ -805,12 +806,33 @@ export type AddMcpServerRequest =
     env?: never;
   };
 
+export type AddSubagentDefinitionFormat = Exclude<AgentSubagentParserKind, 'none' | 'unknown'>;
+
+export type AddSubagentRequest =
+  | {
+    sourceType: 'fields';
+    name: string;
+    description: string;
+    prompt: string;
+    definition?: never;
+    format?: never;
+  }
+  | {
+    sourceType: 'definition';
+    name: string;
+    format: AddSubagentDefinitionFormat;
+    definition: string;
+    description?: never;
+    prompt?: never;
+  };
+
 export type AuditOperationKind =
   | 'resolve-skill-issue'
   | 'resolve-mcp-issue'
   | 'resolve-subagent-issue'
   | 'add-skill'
   | 'add-mcp-server'
+  | 'add-subagent'
   | 'settings-update'
   | 'capability-action'
   | 'dismiss-drift'
@@ -937,6 +959,7 @@ export interface SkillIndexDesktopApi {
   cancelMcpConnectivityTest(): Promise<void>;
   addSkill(request: AddSkillRequest): Promise<SkillInventorySnapshot>;
   addMcpServer(request: AddMcpServerRequest): Promise<SkillInventorySnapshot>;
+  addSubagent(request: AddSubagentRequest): Promise<SkillInventorySnapshot>;
   resolveIssue(request: ResolveIssueRequest): Promise<SkillInventorySnapshot>;
   applyCapabilityAction(request: CapabilityActionRequest): Promise<SkillInventorySnapshot>;
   dismissDrift(request: DismissDriftRequest): Promise<SkillInventorySnapshot>;
@@ -1013,6 +1036,9 @@ export function createSkillIndexDesktopApi(invoke: InvokeLike, subscribe: Subscr
     },
     async addMcpServer(request) {
       return invoke(IPC_CHANNELS.addMcpServer, request) as Promise<SkillInventorySnapshot>;
+    },
+    async addSubagent(request) {
+      return invoke(IPC_CHANNELS.addSubagent, request) as Promise<SkillInventorySnapshot>;
     },
     async resolveIssue(request) {
       return invoke(IPC_CHANNELS.resolveIssue, request) as Promise<SkillInventorySnapshot>;


### PR DESCRIPTION
Changes:

- Add subagent creation through IPC, audit logging, and portable subagent parsing/rendering.
- Install new subagents into the universal Markdown directory and supported writable agent locations.
- Add a shared top-bar Add dropdown with Skill, MCP, and Subagent actions, including a Markdown-based Add Subagent modal.

Validation:
pnpm typecheck
pnpm exec vitest run src/main/add-subagent.test.ts src/main/ipc.test.ts src/renderer/src/app-shell.test.tsx src/renderer/src/views/InventoryViewChrome.test.tsx
pnpm lint
Real rendered browser check of the Add Subagent Markdown modal
