### PR TITLE
Add remove actions to detail panes

### DIFF
--- a/src/main/inventory-runtime.test.ts
+++ b/src/main/inventory-runtime.test.ts
@@ -894,6 +894,69 @@ describe('inventory runtime', () => {
     expect(undoResult.inventorySnapshot?.skills.find((skill) => skill.name === skillName)?.issueReasons).toContain('missing-symlinks');
   });
 
+  it('audits and undoes removing a skill package moved to Trash', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-runtime-remove-audit-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+    const trashedPaths: string[] = [];
+
+    const runtime = createInventoryRuntime();
+    runtimes.push(runtime);
+
+    const skillName = 'trashable-skill';
+    const skillPath = path.join(paths.sandboxAgentsSkillsDir, skillName);
+    await writeSkillFile(paths.sandboxAgentsSkillsDir, skillName, '# Trashable skill\n', '2026-04-09T00:00:00.000Z');
+    await runtime.scanInventory({
+      paths,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+
+    const removedSnapshot = await runtime.removeInventoryItem(
+      { entity: 'skill', skillName },
+      {
+        paths,
+        includeSandboxSources: true,
+        includeLiveSources: false,
+        trashItem: async (targetPath) => {
+          trashedPaths.push(targetPath);
+          await rm(targetPath, { recursive: true, force: true });
+        },
+      },
+    );
+
+    expect(trashedPaths).toEqual([skillPath]);
+    expect(removedSnapshot.skills.some((skill) => skill.name === skillName)).toBe(false);
+    await expect(pathExists(skillPath)).resolves.toBe(false);
+
+    const [operation] = await runtime.readAuditLog();
+    expect(operation).toMatchObject({
+      kind: 'remove-inventory-item',
+      title: `Removed ${skillName}`,
+      undoState: 'available',
+    });
+    expect(operation.actions).toHaveLength(1);
+    expect(operation.actions[0]).toMatchObject({
+      kind: 'delete-path',
+      path: skillPath,
+      before: { kind: 'directory' },
+      after: { kind: 'absent' },
+    });
+
+    const undoResult = await runtime.undoAuditOperation(operation.id);
+
+    await expect(pathExists(path.join(skillPath, 'SKILL.md'))).resolves.toBe(true);
+    expect(undoResult.auditLog[0]).toMatchObject({
+      id: operation.id,
+      status: 'undone',
+      undoState: 'used',
+    });
+    expect(undoResult.inventorySnapshot?.skills.some((skill) => skill.name === skillName)).toBe(true);
+  });
+
   it('audits Universal decision config writes when resolving plugin-backed skills', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-runtime-plugin-audit-'));
     const paths = resolveSkillIndexPaths({

--- a/src/main/inventory-runtime.ts
+++ b/src/main/inventory-runtime.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { addSkill as addSkillToInventory } from '@main/add-skill';
 import { createAuditLogService, type AuditOperationRequest } from '@main/audit-log';
 import { applyCapabilityAction as applyCapabilityActionToInventory } from '@main/capability-actions';
+import { removeInventoryItem as removeInventoryItemFromInventory, type RemoveInventoryItemOptions } from '@main/remove-inventory-item';
 import {
   dismissDrift,
   readCachedInventory,
@@ -20,6 +21,7 @@ import type {
   AuditOperation,
   CapabilityActionRequest,
   DismissDriftRequest,
+  RemoveInventoryItemRequest,
   ResolveIssueRequest,
   SkillInventorySnapshot,
   SkillRecord,
@@ -72,6 +74,7 @@ export interface InventoryRuntime {
   resolveIssue(request: ResolveIssueRequest): Promise<SkillInventorySnapshot>;
   applyCapabilityAction(request: CapabilityActionRequest, options?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot>;
   dismissDrift(request: DismissDriftRequest): Promise<SkillInventorySnapshot>;
+  removeInventoryItem(request: RemoveInventoryItemRequest, options?: RemoveInventoryItemOptions): Promise<SkillInventorySnapshot>;
   readAuditLog(options?: { limit?: number }, scanOptions?: ScanSkillInventoryOptions): Promise<AuditOperation[]>;
   undoAuditOperation(operationId: string): Promise<UndoAuditOperationResult>;
   releaseStartupObservation(): void;
@@ -500,6 +503,21 @@ export function createInventoryRuntime(options: CreateInventoryRuntimeOptions = 
       await emitAudit(lastScanOptions);
       return nextSnapshot;
     },
+    async removeInventoryItem(request, optionsOverride = {}) {
+      if (refreshInFlight) {
+        await refreshInFlight;
+      }
+
+      lastScanOptions = { ...lastScanOptions, ...optionsOverride };
+      const beforeSnapshot = currentSnapshot ?? await scanInventory(lastScanOptions);
+      const { result: nextSnapshot } = await getAuditService(lastScanOptions).runOperation(
+        buildRemoveInventoryItemAuditRequest(request, beforeSnapshot, lastScanOptions),
+        () => removeInventoryItemFromInventory(request, lastScanOptions),
+      );
+      commitSnapshot(nextSnapshot);
+      await emitAudit(lastScanOptions);
+      return nextSnapshot;
+    },
     async readAuditLog(optionsOverride = {}, scanOptionsOverride) {
       return getAuditService(scanOptionsOverride ? { ...lastScanOptions, ...scanOptionsOverride } : lastScanOptions)
         .readOperations(optionsOverride);
@@ -607,6 +625,57 @@ function buildResolveIssueAuditRequest(
     affectedPaths,
     undoable: affectedPaths.length > 0,
   };
+}
+
+function buildRemoveInventoryItemAuditRequest(
+  request: RemoveInventoryItemRequest,
+  snapshot: SkillInventorySnapshot,
+  options: ScanSkillInventoryOptions,
+): AuditOperationRequest {
+  const sourceMode = resolveAuditSourceMode(options);
+  const entity = getRemoveInventoryItemEntity(request);
+  const affectedPaths = getRemoveInventoryItemAffectedPaths(request, snapshot);
+  const itemLabel = entity.name ?? 'inventory item';
+
+  return {
+    kind: 'remove-inventory-item',
+    title: `Removed ${itemLabel}`,
+    summary: `${affectedPaths.length} ${affectedPaths.length === 1 ? 'location' : 'locations'} removed.`,
+    sourceMode,
+    entity,
+    affectedPaths,
+    undoable: affectedPaths.length > 0,
+  };
+}
+
+function getRemoveInventoryItemEntity(request: RemoveInventoryItemRequest): NonNullable<AuditOperationRequest['entity']> {
+  if (request.entity === 'skill') {
+    return { type: 'skill', name: request.skillName };
+  }
+
+  if (request.entity === 'mcp') {
+    return { type: 'mcp', name: request.mcpName };
+  }
+
+  return { type: 'subagent', name: request.subagentName };
+}
+
+function getRemoveInventoryItemAffectedPaths(
+  request: RemoveInventoryItemRequest,
+  snapshot: SkillInventorySnapshot,
+): string[] {
+  if (request.entity === 'skill') {
+    const skill = snapshot.skills.find((entry) => entry.name === request.skillName);
+    return dedupePaths(skill?.locations.map((location) => location.path) ?? []);
+  }
+
+  if (request.entity === 'mcp') {
+    const mcp = (snapshot.mcps ?? []).find((entry) => entry.name === request.mcpName);
+    return dedupePaths(mcp?.locations.map((location) => location.configPath) ?? []);
+  }
+
+  const subagent = (snapshot.subagents ?? []).find((entry) => entry.name === request.subagentName);
+  return dedupePaths(subagent?.locations.map((location) => location.path) ?? []);
 }
 
 function buildAddSkillAuditRequest(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,6 +12,7 @@ import {
   type CompleteOnboardingRequest,
   type DismissDriftRequest,
   IPC_CHANNELS,
+  type RemoveInventoryItemRequest,
   type RescanInventoryRequest,
   type ResolveIssueRequest,
   type InventorySourceMode,
@@ -72,6 +73,7 @@ export function registerIpcHandlers(): void {
   ipcMain.removeHandler(IPC_CHANNELS.resolveIssue);
   ipcMain.removeHandler(IPC_CHANNELS.applyCapabilityAction);
   ipcMain.removeHandler(IPC_CHANNELS.dismissDrift);
+  ipcMain.removeHandler(IPC_CHANNELS.removeInventoryItem);
   ipcMain.removeHandler(IPC_CHANNELS.readAuditLog);
   ipcMain.removeHandler(IPC_CHANNELS.undoAuditOperation);
   ipcMain.removeHandler(IPC_CHANNELS.releaseStartupObservation);
@@ -161,6 +163,9 @@ export function registerIpcHandlers(): void {
   );
   ipcMain.handle(IPC_CHANNELS.dismissDrift, (_event, request: DismissDriftRequest) =>
     inventoryRuntime.dismissDrift(request),
+  );
+  ipcMain.handle(IPC_CHANNELS.removeInventoryItem, (_event, request: RemoveInventoryItemRequest) =>
+    inventoryRuntime.removeInventoryItem(request, resolveInventoryScanOptions()),
   );
   ipcMain.handle(IPC_CHANNELS.readAuditLog, (_event, options?: { limit?: number }) =>
     inventoryRuntime.readAuditLog(options, resolveInventoryScanOptions()),

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -51,7 +51,7 @@ export interface ResolveIssueOptions extends ScanSkillInventoryOptions {
   paths?: SkillIndexPaths;
 }
 
-interface McpMutationTarget {
+export interface McpMutationTarget {
   agentId: string;
   configPath: string;
   parserKind:
@@ -1103,7 +1103,7 @@ function buildWritableMcpMutationTarget(
   return buildMcpMutationTarget(snapshot, agentId, configPath);
 }
 
-async function readWritableMcpDefinitions(target: McpMutationTarget): Promise<McpServerDefinitions> {
+export async function readWritableMcpDefinitions(target: McpMutationTarget): Promise<McpServerDefinitions> {
   let raw: string;
   try {
     raw = await readFile(target.configPath, 'utf8');
@@ -1130,7 +1130,7 @@ function isFileNotFoundError(error: unknown): boolean {
     && (error as { code?: unknown }).code === 'ENOENT';
 }
 
-async function writeMcpDefinitions(
+export async function writeMcpDefinitions(
   configPath: string,
   parserKind: McpMutationTarget['parserKind'],
   definitions: McpServerDefinitions,
@@ -1501,7 +1501,7 @@ function resolveSkillMutationScope(
   return derivedScope;
 }
 
-function isSupportedWritableMcpParser(parserKind: string): parserKind is McpMutationTarget['parserKind'] {
+export function isSupportedWritableMcpParser(parserKind: string): parserKind is McpMutationTarget['parserKind'] {
   return parserKind === 'json-servers'
     || parserKind === 'json-mcpServers'
     || parserKind === 'json-mcp'
@@ -1515,7 +1515,7 @@ function isSupportedWritableMcpParser(parserKind: string): parserKind is McpMuta
     || parserKind === 'toml-mcpServers-array';
 }
 
-function getDefaultMcpWriteDialect(parserKind: McpMutationTarget['parserKind']): AgentMcpWriteDialect {
+export function getDefaultMcpWriteDialect(parserKind: McpMutationTarget['parserKind']): AgentMcpWriteDialect {
   switch (parserKind) {
     case 'jsonc-opencode-mcp':
       return 'json-opencode';

--- a/src/main/remove-inventory-item.test.ts
+++ b/src/main/remove-inventory-item.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { removeInventoryItem } from '@main/remove-inventory-item';
+import { resolveSkillIndexPaths } from '@shared/skill-index-paths';
+
+describe('removeInventoryItem', () => {
+  it('moves a skill package from every scanned location to Trash', async () => {
+    const paths = await createPaths('skillindex-remove-skill-');
+    const canonicalSkillPath = path.join(paths.sandboxAgentsSkillsDir, 'remove-me');
+    const claudeSkillPath = path.join(paths.sandboxRoot, '.claude', 'skills', 'remove-me');
+    const trashedPaths: string[] = [];
+
+    await writeSkillPackage(paths.sandboxAgentsSkillsDir, 'remove-me');
+    await mkdir(path.dirname(claudeSkillPath), { recursive: true });
+    await symlink(canonicalSkillPath, claudeSkillPath);
+
+    const snapshot = await removeInventoryItem(
+      { entity: 'skill', skillName: 'remove-me' },
+      {
+        paths,
+        includeSandboxSources: true,
+        includeLiveSources: false,
+        trashItem: async (targetPath) => {
+          trashedPaths.push(targetPath);
+          await rm(targetPath, { recursive: true, force: true });
+        },
+      },
+    );
+
+    expect(snapshot.skills.some((skill) => skill.name === 'remove-me')).toBe(false);
+    expect([...trashedPaths].sort()).toEqual([canonicalSkillPath, claudeSkillPath].sort());
+    await expect(pathExists(canonicalSkillPath)).resolves.toBe(false);
+    await expect(pathExists(claudeSkillPath)).resolves.toBe(false);
+  });
+
+  it('removes an MCP server definition from every config where it appears', async () => {
+    const paths = await createPaths('skillindex-remove-mcp-');
+    const agentsConfigPath = path.join(paths.sandboxRoot, '.agents', 'mcp.json');
+    const claudeConfigPath = path.join(paths.sandboxRoot, '.claude.json');
+
+    await writeJsonFile(agentsConfigPath, {
+      servers: {
+        keepMe: { command: 'node', args: ['keep.js'] },
+        removeMe: { command: 'node', args: ['agents.js'] },
+      },
+    });
+    await writeJsonFile(claudeConfigPath, {
+      mcpServers: {
+        keepMe: { command: 'node', args: ['keep.js'] },
+        removeMe: { command: 'node', args: ['claude.js'] },
+      },
+    });
+    await writeJsonFile(path.join(paths.sandboxRoot, '.claude', 'settings.json'), {});
+
+    const snapshot = await removeInventoryItem(
+      { entity: 'mcp', mcpName: 'removeMe' },
+      {
+        paths,
+        includeSandboxSources: true,
+        includeLiveSources: false,
+        env: { SKILL_INDEX_AGENT_SUBSET: 'claude' },
+      },
+    );
+
+    const agentsConfig = JSON.parse(await readFile(agentsConfigPath, 'utf8')) as { servers?: Record<string, unknown> };
+    const claudeConfig = JSON.parse(await readFile(claudeConfigPath, 'utf8')) as { mcpServers?: Record<string, unknown> };
+    expect(snapshot.mcps?.some((mcp) => mcp.name === 'removeMe')).toBe(false);
+    expect(agentsConfig.servers).toHaveProperty('keepMe');
+    expect(agentsConfig.servers).not.toHaveProperty('removeMe');
+    expect(claudeConfig.mcpServers).toHaveProperty('keepMe');
+    expect(claudeConfig.mcpServers).not.toHaveProperty('removeMe');
+  });
+
+  it('moves a subagent definition from every scanned location to Trash', async () => {
+    const paths = await createPaths('skillindex-remove-subagent-');
+    const canonicalSubagentPath = path.join(paths.sandboxRoot, '.agents', 'agents', 'remove-me.md');
+    const claudeSubagentPath = path.join(paths.sandboxRoot, '.claude', 'agents', 'remove-me.md');
+    const trashedPaths: string[] = [];
+
+    await writeMarkdownSubagent(canonicalSubagentPath, 'remove-me', 'Canonical remove me');
+    await writeMarkdownSubagent(claudeSubagentPath, 'remove-me', 'Claude remove me');
+
+    const snapshot = await removeInventoryItem(
+      { entity: 'subagent', subagentName: 'remove-me' },
+      {
+        paths,
+        includeSandboxSources: true,
+        includeLiveSources: false,
+        env: { SKILL_INDEX_AGENT_SUBSET: 'claude' },
+        trashItem: async (targetPath) => {
+          trashedPaths.push(targetPath);
+          await rm(targetPath, { recursive: true, force: true });
+        },
+      },
+    );
+
+    expect(snapshot.subagents?.some((subagent) => subagent.name === 'remove-me')).toBe(false);
+    expect([...trashedPaths].sort()).toEqual([canonicalSubagentPath, claudeSubagentPath].sort());
+    await expect(pathExists(canonicalSubagentPath)).resolves.toBe(false);
+    await expect(pathExists(claudeSubagentPath)).resolves.toBe(false);
+  });
+});
+
+async function createPaths(prefix: string) {
+  const root = await mkdtemp(path.join(tmpdir(), prefix));
+  return resolveSkillIndexPaths({
+    env: {
+      SKILL_INDEX_DATA_DIR: root,
+    },
+  });
+}
+
+async function writeSkillPackage(rootDir: string, skillName: string): Promise<void> {
+  await writeFileWithParents(path.join(rootDir, skillName, 'SKILL.md'), [
+    '---',
+    `name: ${skillName}`,
+    `description: ${skillName}`,
+    '---',
+    '',
+    `# ${skillName}`,
+    '',
+  ].join('\n'));
+}
+
+async function writeMarkdownSubagent(filePath: string, name: string, description: string): Promise<void> {
+  await writeFileWithParents(filePath, [
+    '---',
+    `name: ${name}`,
+    `description: ${description}`,
+    '---',
+    '',
+    `# ${name}`,
+    '',
+  ].join('\n'));
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await writeFileWithParents(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function writeFileWithParents(filePath: string, content: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, 'utf8');
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await lstat(targetPath);
+    return true;
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
+      return false;
+    }
+
+    throw error;
+  }
+}

--- a/src/main/remove-inventory-item.ts
+++ b/src/main/remove-inventory-item.ts
@@ -1,0 +1,236 @@
+import { lstat } from 'node:fs/promises';
+import path from 'node:path';
+
+import type {
+  McpLocationRecord,
+  RemoveInventoryItemRequest,
+  SkillInventorySnapshot,
+} from '@shared/contracts';
+import {
+  ensureSkillIndexLayout,
+  resolveSkillIndexPaths,
+  type SkillIndexPaths,
+} from '@shared/skill-index-paths';
+
+import {
+  getDefaultMcpWriteDialect,
+  isSupportedWritableMcpParser,
+  readWritableMcpDefinitions,
+  writeMcpDefinitions,
+  type McpMutationTarget,
+} from '@main/issue-resolution';
+import { scanInventory, type ScanSkillInventoryOptions } from '@main/scan-inventory';
+
+export interface RemoveInventoryItemOptions extends ScanSkillInventoryOptions {
+  paths?: SkillIndexPaths;
+  trashItem?: TrashItem;
+}
+
+interface McpRemovalTarget extends McpMutationTarget {
+  definitionNames: Set<string>;
+}
+
+type TrashItem = (targetPath: string) => Promise<void>;
+
+export async function removeInventoryItem(
+  request: RemoveInventoryItemRequest,
+  options: RemoveInventoryItemOptions = {},
+): Promise<SkillInventorySnapshot> {
+  const paths = options.paths ?? resolveSkillIndexPaths(options);
+  await ensureSkillIndexLayout(paths);
+
+  const snapshot = await scanInventory({
+    ...options,
+    paths,
+  });
+
+  if (request.entity === 'skill') {
+    await removeSkillFromAllLocations(snapshot, request.skillName, options.trashItem ?? trashPathWithElectron);
+  } else if (request.entity === 'mcp') {
+    await removeMcpFromAllLocations(snapshot, request.mcpName);
+  } else {
+    await removeSubagentFromAllLocations(snapshot, request.subagentName, options.trashItem ?? trashPathWithElectron);
+  }
+
+  return scanInventory({
+    ...options,
+    paths,
+  });
+}
+
+async function removeSkillFromAllLocations(
+  snapshot: SkillInventorySnapshot,
+  skillName: string,
+  trashItem: TrashItem,
+): Promise<void> {
+  const skill = snapshot.skills.find((entry) => entry.name === skillName);
+  if (!skill) {
+    throw new Error(`Skill "${skillName}" was not found in the current inventory.`);
+  }
+
+  await removePaths(skill.locations.map((location) => location.path), `Skill "${skillName}"`, trashItem);
+}
+
+async function removeSubagentFromAllLocations(
+  snapshot: SkillInventorySnapshot,
+  subagentName: string,
+  trashItem: TrashItem,
+): Promise<void> {
+  const subagent = (snapshot.subagents ?? []).find((entry) => entry.name === subagentName);
+  if (!subagent) {
+    throw new Error(`Subagent "${subagentName}" was not found in the current inventory.`);
+  }
+
+  await removePaths(subagent.locations.map((location) => location.path), `Subagent "${subagentName}"`, trashItem);
+}
+
+async function removePaths(paths: string[], entityLabel: string, trashItem: TrashItem): Promise<void> {
+  const uniquePaths = dedupePaths(paths);
+  if (uniquePaths.length === 0) {
+    throw new Error(`${entityLabel} has no removable locations.`);
+  }
+
+  await Promise.all(uniquePaths.map((targetPath) => trashExistingPath(targetPath, trashItem)));
+}
+
+async function trashExistingPath(targetPath: string, trashItem: TrashItem): Promise<void> {
+  try {
+    await lstat(targetPath);
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
+      return;
+    }
+
+    throw error;
+  }
+
+  await trashItem(targetPath);
+}
+
+async function trashPathWithElectron(targetPath: string): Promise<void> {
+  const { shell } = await import('electron');
+  await shell.trashItem(targetPath);
+}
+
+async function removeMcpFromAllLocations(snapshot: SkillInventorySnapshot, mcpName: string): Promise<void> {
+  const mcp = (snapshot.mcps ?? []).find((entry) => entry.name === mcpName);
+  if (!mcp) {
+    throw new Error(`MCP "${mcpName}" was not found in the current inventory.`);
+  }
+
+  const targets = collectMcpRemovalTargets(snapshot, mcp.locations, mcpName);
+  if (targets.length === 0) {
+    throw new Error(`MCP "${mcpName}" has no removable config locations.`);
+  }
+
+  await Promise.all(targets.map(async (target) => {
+    const definitions = await readWritableMcpDefinitions(target);
+    let changed = false;
+
+    for (const definitionName of target.definitionNames) {
+      if (Object.prototype.hasOwnProperty.call(definitions, definitionName)) {
+        delete definitions[definitionName];
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      await writeMcpDefinitions(target.configPath, target.parserKind, definitions, target.writeDialect);
+    }
+  }));
+}
+
+function collectMcpRemovalTargets(
+  snapshot: SkillInventorySnapshot,
+  locations: McpLocationRecord[],
+  inventoryMcpName: string,
+): McpRemovalTarget[] {
+  const targetsByKey = new Map<string, McpRemovalTarget>();
+
+  for (const location of locations) {
+    const target = buildMcpRemovalTarget(snapshot, location);
+    if (!target) {
+      continue;
+    }
+
+    const key = [
+      path.normalize(target.configPath),
+      target.parserKind,
+      target.writeDialect,
+    ].join('\0');
+    const existing = targetsByKey.get(key) ?? {
+      ...target,
+      definitionNames: new Set<string>(),
+    };
+    existing.definitionNames.add(getMcpDefinitionNameForRemoval(inventoryMcpName, location));
+    targetsByKey.set(key, existing);
+  }
+
+  return [...targetsByKey.values()];
+}
+
+function buildMcpRemovalTarget(
+  snapshot: SkillInventorySnapshot,
+  location: McpLocationRecord,
+): Omit<McpRemovalTarget, 'definitionNames'> | null {
+  if (location.agentId.startsWith('plugin:') || location.provenance?.kind === 'plugin') {
+    return {
+      agentId: location.agentId,
+      configPath: location.configPath,
+      parserKind: 'jsonc-mcpServers',
+      writeDialect: 'json-type-url',
+    };
+  }
+
+  const agent = (snapshot.agents ?? []).find((entry) => entry.id === location.agentId);
+  if (agent) {
+    const parserKind = agent.mcpParserKind ?? 'json-servers';
+    if (!agent.writable || !isSupportedWritableMcpParser(parserKind)) {
+      return null;
+    }
+
+    return {
+      agentId: location.agentId,
+      configPath: location.configPath,
+      parserKind,
+      writeDialect: agent.mcpWriteDialect ?? getDefaultMcpWriteDialect(parserKind),
+    };
+  }
+
+  const source = snapshot.sources.find((entry) => entry.id === location.agentId);
+  if (!source?.writable) {
+    return null;
+  }
+
+  return {
+    agentId: location.agentId,
+    configPath: location.configPath,
+    parserKind: 'json-servers',
+    writeDialect: 'json-type-url',
+  };
+}
+
+function getMcpDefinitionNameForRemoval(inventoryMcpName: string, location: McpLocationRecord): string {
+  if (location.configName) {
+    return location.configName;
+  }
+
+  if (location.agentId.startsWith('plugin:') && inventoryMcpName.includes(':')) {
+    return inventoryMcpName.slice(inventoryMcpName.indexOf(':') + 1);
+  }
+
+  return inventoryMcpName;
+}
+
+function dedupePaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  return paths.filter((targetPath) => {
+    const normalizedPath = path.normalize(targetPath);
+    if (seen.has(normalizedPath)) {
+      return false;
+    }
+
+    seen.add(normalizedPath);
+    return true;
+  });
+}

--- a/src/preload/bridge.test.ts
+++ b/src/preload/bridge.test.ts
@@ -6,6 +6,7 @@ import {
   type AuditOperation,
   type CapabilityActionRequest,
   IPC_CHANNELS,
+  type RemoveInventoryItemRequest,
   createSkillIndexDevApi,
   createSkillIndexDesktopApi,
   type AppShellState,
@@ -197,6 +198,7 @@ describe('createSkillIndexDesktopApi', () => {
       if (channel === IPC_CHANNELS.resolveIssue) return Promise.resolve(inventorySnapshot);
       if (channel === IPC_CHANNELS.applyCapabilityAction) return Promise.resolve(inventorySnapshot);
       if (channel === IPC_CHANNELS.dismissDrift) return Promise.resolve(inventorySnapshot);
+      if (channel === IPC_CHANNELS.removeInventoryItem) return Promise.resolve(inventorySnapshot);
       if (channel === IPC_CHANNELS.readAuditLog) return Promise.resolve(auditOperations);
       if (channel === IPC_CHANNELS.undoAuditOperation) return Promise.resolve({
         auditLog: auditOperations,
@@ -270,6 +272,10 @@ describe('createSkillIndexDesktopApi', () => {
     } satisfies CapabilityActionRequest)).resolves.toEqual(inventorySnapshot);
     await expect(api.dismissDrift({ skillName: 'healthy-skill' })).resolves.toEqual(inventorySnapshot);
     await expect(api.dismissDrift({ mcpName: 'healthy-mcp' })).resolves.toEqual(inventorySnapshot);
+    await expect(api.removeInventoryItem({
+      entity: 'skill',
+      skillName: 'healthy-skill',
+    } satisfies RemoveInventoryItemRequest)).resolves.toEqual(inventorySnapshot);
     await expect(api.readAuditLog()).resolves.toEqual(auditOperations);
     await expect(api.undoAuditOperation('audit-operation-1')).resolves.toEqual({
       auditLog: auditOperations,
@@ -341,6 +347,10 @@ describe('createSkillIndexDesktopApi', () => {
     });
     expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.dismissDrift, {
       mcpName: 'healthy-mcp',
+    });
+    expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.removeInventoryItem, {
+      entity: 'skill',
+      skillName: 'healthy-skill',
     });
     expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.readAuditLog);
     expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.undoAuditOperation, 'audit-operation-1');

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type ReactElement } from 'react';
-import { Check, ChevronDown, ChevronUp, Copy, Undo2 } from 'lucide-react';
+import { Check, ChevronDown, ChevronUp, Copy, Undo2, X } from 'lucide-react';
 
 import {
   type AddSkillRequest,
@@ -13,6 +13,7 @@ import {
   type InventorySourceMode,
   type McpIssueReason,
   type PluginRecord,
+  type RemoveInventoryItemRequest,
   type ResolveIssueRequest,
   type SettingsState,
   type SkillInventorySnapshot,
@@ -86,6 +87,11 @@ function getAutoResolvableRequestsForSnapshot(snapshot: SkillInventorySnapshot):
 interface OnboardingPreferredSourceSelection {
   didChangePreferredSource: boolean;
   preferredSourcePath: string | null;
+}
+
+interface PendingRemoveItem {
+  label: string;
+  request: RemoveInventoryItemRequest;
 }
 
 function getResolveIssueRequestKey(request: ResolveIssueRequest): string {
@@ -200,6 +206,8 @@ export default function App() {
   const [isResolvingIssue, setIsResolvingIssue] = useState(false);
   const [isApplyingCapabilityAction, setIsApplyingCapabilityAction] = useState(false);
   const [isDismissingDrift, setIsDismissingDrift] = useState(false);
+  const [isRemovingInventoryItem, setIsRemovingInventoryItem] = useState(false);
+  const [pendingRemoveItem, setPendingRemoveItem] = useState<PendingRemoveItem | null>(null);
   const [, setLastScanClockTick] = useState(0);
   const [pendingDriftTransitionSkillName, setPendingDriftTransitionSkillName] = useState<string | null>(null);
   const [selectionOverrideSkillName, setSelectionOverrideSkillName] = useState<string | null>(null);
@@ -1037,6 +1045,56 @@ export default function App() {
     [applyInventorySnapshot, desktopApi, showAppToastWithLatestUndo, showErrorToast],
   );
 
+  const handleRequestRemoveInventoryItem = useCallback((request: RemoveInventoryItemRequest, label: string) => {
+    setPendingRemoveItem({
+      label,
+      request,
+    });
+  }, []);
+
+  const handleConfirmRemoveInventoryItem = useCallback(async () => {
+    if (!pendingRemoveItem) {
+      return;
+    }
+
+    const { label, request } = pendingRemoveItem;
+    setIsRemovingInventoryItem(true);
+
+    try {
+      const nextInventorySnapshot = await desktopApi.removeInventoryItem(request);
+      applyInventorySnapshot(nextInventorySnapshot);
+      if (request.entity === 'skill') {
+        setSelectedSkillName(null);
+        setSelectionOverrideSkillName(null);
+        setSelectedSkillProblemKey(null);
+        setSelectedSkillVariantPath(null);
+      } else if (request.entity === 'mcp') {
+        setSelectedMcpName(null);
+        setSelectedMcpProblemKey(null);
+        setSelectedMcpVariantPath(null);
+      } else {
+        setSelectedSubagentName(null);
+        setSelectedSubagentProblemKey(null);
+        setSelectedSubagentVariantPath(null);
+      }
+      setPendingRemoveItem(null);
+      await showAppToastWithLatestUndo(
+        'Item removed',
+        `${label} was removed from all tracked locations.`,
+      );
+    } catch (error) {
+      showErrorToast('Remove failed', error);
+    } finally {
+      setIsRemovingInventoryItem(false);
+    }
+  }, [
+    applyInventorySnapshot,
+    desktopApi,
+    pendingRemoveItem,
+    showAppToastWithLatestUndo,
+    showErrorToast,
+  ]);
+
   const handleAutoResolve = useCallback(async () => {
     const startingSnapshot = latestInventorySnapshotRef.current;
     if (!startingSnapshot) {
@@ -1542,6 +1600,7 @@ export default function App() {
           inventorySnapshot={inventorySnapshot}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
+          isRemovingInventoryItem={isRemovingInventoryItem}
           isApplyingCapabilityAction={isApplyingCapabilityAction}
           isRescanning={isRescanActionBusy}
           onAddSkill={handleAddSkill}
@@ -1550,6 +1609,7 @@ export default function App() {
           onResolveIssue={handleResolveIssue}
           onApplyCapabilityAction={handleCapabilityAction}
           onOpenPluginSource={openPluginFromProvenance}
+          onRequestRemove={handleRequestRemoveInventoryItem}
           onRescan={triggerManualRescan}
           rows={skillRows}
           searchInputRef={skillSearchInputRef}
@@ -1577,6 +1637,7 @@ export default function App() {
           isAddingMcpServer={isAddingMcpServer}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
+          isRemovingInventoryItem={isRemovingInventoryItem}
           isRescanning={isRescanActionBusy}
           mcp={selectedMcp}
           mcpInspectorModel={selectedMcpInspectorModel}
@@ -1585,6 +1646,7 @@ export default function App() {
           onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onClearSelection={resetMcpSelection}
           onDismissDrift={handleDismissDrift}
+          onRequestRemove={handleRequestRemoveInventoryItem}
           onResolveIssue={handleResolveIssue}
           onRescan={triggerManualRescan}
           onSearchQueryChange={setMcpSearchQuery}
@@ -1605,10 +1667,12 @@ export default function App() {
           inventorySnapshot={inventorySnapshot}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
+          isRemovingInventoryItem={isRemovingInventoryItem}
           isRescanning={isRescanActionBusy}
           onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onClearSelection={resetSubagentSelection}
           onDismissDrift={handleDismissDrift}
+          onRequestRemove={handleRequestRemoveInventoryItem}
           onResolveIssue={handleResolveIssue}
           onRescan={triggerManualRescan}
           onSearchQueryChange={setSubagentSearchQuery}
@@ -1804,6 +1868,20 @@ export default function App() {
       </section>
     </div>
   ) : null;
+  const removeItemDialog = pendingRemoveItem ? (
+    <RemoveItemDialog
+      isRemoving={isRemovingInventoryItem}
+      item={pendingRemoveItem}
+      onCancel={() => {
+        if (!isRemovingInventoryItem) {
+          setPendingRemoveItem(null);
+        }
+      }}
+      onConfirm={() => {
+        void handleConfirmRemoveInventoryItem();
+      }}
+    />
+  ) : null;
 
   if (shouldShowOnboarding) {
     return (
@@ -1820,6 +1898,7 @@ export default function App() {
           status={autoUpdateStatus}
         />
         {appToastRegion}
+        {removeItemDialog}
       </>
     );
   }
@@ -1863,6 +1942,7 @@ export default function App() {
       </div>
 
       {appToastRegion}
+      {removeItemDialog}
 
       <AutoUpdateDialog
         appName={shellState?.appName ?? APP_NAME}
@@ -1871,6 +1951,105 @@ export default function App() {
       />
     </div>
   );
+}
+
+function RemoveItemDialog({
+  isRemoving,
+  item,
+  onCancel,
+  onConfirm,
+}: {
+  isRemoving: boolean;
+  item: PendingRemoveItem;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const itemKind = formatRemoveItemKind(item.request);
+  const title = `Remove ${itemKind}`;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || isRemoving) {
+        return;
+      }
+
+      event.preventDefault();
+      onCancel();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isRemoving, onCancel]);
+
+  return (
+    <div className="remove-item-dialog-root" role="presentation">
+      <div className="remove-item-dialog-backdrop" />
+      <section aria-label={title} aria-modal="true" className="remove-item-dialog" role="dialog">
+        <div className="remove-item-dialog__header">
+          <div>
+            <h3>{title}</h3>
+          </div>
+          <button
+            aria-label="Close remove dialog"
+            className="remove-item-dialog__close"
+            disabled={isRemoving}
+            type="button"
+            onClick={onCancel}
+          >
+            <X aria-hidden="true" size={16} />
+          </button>
+        </div>
+        <div className="remove-item-dialog__body">
+          <p>
+            <strong>{item.label}</strong>
+            {' will be removed from every location Skill Index currently tracks.'}
+          </p>
+          <p>
+            {getRemoveItemRecoveryCopy(item.request)}
+          </p>
+        </div>
+        <div className="remove-item-dialog__actions">
+          <button
+            className="remove-item-dialog__button remove-item-dialog__button--secondary"
+            disabled={isRemoving}
+            type="button"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            className="remove-item-dialog__button remove-item-dialog__button--danger"
+            disabled={isRemoving}
+            type="button"
+            onClick={onConfirm}
+          >
+            {isRemoving ? 'Removing...' : 'Yes, remove'}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function formatRemoveItemKind(request: RemoveInventoryItemRequest): string {
+  switch (request.entity) {
+    case 'skill':
+      return 'skill';
+    case 'mcp':
+      return 'MCP';
+    case 'subagent':
+      return 'subagent';
+  }
+}
+
+function getRemoveItemRecoveryCopy(request: RemoveInventoryItemRequest): string {
+  if (request.entity === 'mcp') {
+    return 'MCP config entries are removed from their config files. There are no files to move to Trash.';
+  }
+
+  return 'Files are moved to Trash so you can recover them from Finder. This can affect every agent using it.';
 }
 
 function AutoUpdateDialog({

--- a/src/renderer/src/app-search.test.tsx
+++ b/src/renderer/src/app-search.test.tsx
@@ -245,6 +245,7 @@ function createDesktopApi(inventorySnapshot: SkillInventorySnapshot): SkillIndex
     addMcpServer: vi.fn().mockResolvedValue(inventorySnapshot),
     resolveIssue: vi.fn().mockResolvedValue(inventorySnapshot),
     dismissDrift: vi.fn().mockResolvedValue(inventorySnapshot),
+    removeInventoryItem: vi.fn().mockResolvedValue(inventorySnapshot),
     applyCapabilityAction: vi.fn().mockResolvedValue(inventorySnapshot),
     readAuditLog: vi.fn().mockResolvedValue([]),
     undoAuditOperation: vi.fn().mockResolvedValue({

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -50,6 +50,7 @@ describe('App shell inventory views', () => {
   let addMcpServerMock: Mock<SkillIndexDesktopApi['addMcpServer']>;
   let makeCanonicalMock: Mock<SkillIndexDesktopApi['resolveIssue']>;
   let dismissDriftMock: Mock<SkillIndexDesktopApi['dismissDrift']>;
+  let removeInventoryItemMock: Mock<SkillIndexDesktopApi['removeInventoryItem']>;
   let applyCapabilityActionMock: Mock<SkillIndexDesktopApi['applyCapabilityAction']>;
   let readAuditLogMock: Mock<SkillIndexDesktopApi['readAuditLog']>;
   let undoAuditOperationMock: Mock<SkillIndexDesktopApi['undoAuditOperation']>;
@@ -82,6 +83,7 @@ describe('App shell inventory views', () => {
     addMcpServerMock = vi.fn().mockResolvedValue(createInventorySnapshot());
     makeCanonicalMock = vi.fn().mockResolvedValue(createCanonicalizedDivergedInventorySnapshot());
     dismissDriftMock = vi.fn().mockResolvedValue(createDismissedIdenticalDriftInventorySnapshot());
+    removeInventoryItemMock = vi.fn().mockResolvedValue(createInventorySnapshot());
     applyCapabilityActionMock = vi.fn().mockResolvedValue(createInventorySnapshot());
     readAuditLogMock = vi.fn().mockResolvedValue([]);
     undoAuditOperationMock = vi.fn().mockResolvedValue({
@@ -136,6 +138,7 @@ describe('App shell inventory views', () => {
       addMcpServer: addMcpServerMock,
       resolveIssue: makeCanonicalMock,
       dismissDrift: dismissDriftMock,
+      removeInventoryItem: removeInventoryItemMock,
       applyCapabilityAction: applyCapabilityActionMock,
       readAuditLog: readAuditLogMock,
       undoAuditOperation: undoAuditOperationMock,
@@ -1657,6 +1660,84 @@ describe('App shell inventory views', () => {
     fireEvent.keyDown(window, { key: 'd' });
     await waitFor(() => {
       expect(dismissDriftMock).toHaveBeenCalledWith({ mcpName: 'broken-mcp' });
+    });
+  });
+
+  it('confirms removal in a styled dialog before removing detail items', async () => {
+    render(<App />);
+    await openSkills();
+
+    fireEvent.click(getSkillRow('identical-drift-skill'));
+    expect(await screen.findByRole('heading', { name: 'identical-drift-skill', level: 3 })).toBeInTheDocument();
+    const removeButton = screen.getByRole('button', { name: /^Remove$/i });
+    expect(within(removeButton).getByText('R')).toHaveClass('detail-inspector-panel__footer-shortcut');
+    expect(removeButton).toHaveAttribute('aria-keyshortcuts', 'R');
+
+    fireEvent.keyDown(window, { key: 'r' });
+    const dialog = await screen.findByRole('dialog', { name: /^Remove skill$/i });
+    expect(dialog).toHaveClass('remove-item-dialog');
+    expect(within(dialog).queryByText(/^Remove from inventory$/i)).not.toBeInTheDocument();
+    expect(within(dialog).getByText(/removed from every location Skill Index currently tracks/i)).toBeInTheDocument();
+    expect(within(dialog).getByText(/moved to Trash/i)).toBeInTheDocument();
+    expect(within(dialog).queryByRole('checkbox')).not.toBeInTheDocument();
+
+    const confirmButton = within(dialog).getByRole('button', { name: /^Yes, remove$/i });
+    expect(confirmButton).toBeEnabled();
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(removeInventoryItemMock).toHaveBeenCalledWith({
+        entity: 'skill',
+        skillName: 'identical-drift-skill',
+      });
+    });
+
+    cleanup();
+    render(<App />);
+    await openMcps();
+    fireEvent.click(getMcpRow('broken-mcp'));
+    expect(await screen.findByRole('heading', { name: 'broken-mcp', level: 3 })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+    const mcpDialog = await screen.findByRole('dialog', { name: /^Remove MCP$/i });
+    expect(within(mcpDialog).getByText(/There are no files to move to Trash/i)).toBeInTheDocument();
+    expect(within(mcpDialog).queryByRole('checkbox')).not.toBeInTheDocument();
+    fireEvent.click(within(mcpDialog).getByRole('button', { name: /^Yes, remove$/i }));
+    await waitFor(() => {
+      expect(removeInventoryItemMock).toHaveBeenCalledWith({
+        entity: 'mcp',
+        mcpName: 'broken-mcp',
+      });
+    });
+
+    cleanup();
+    const subagentSnapshot = structuredClone(representativeInventorySnapshot);
+    readCachedInventoryMock.mockResolvedValue(subagentSnapshot);
+    scanInventoryMock.mockResolvedValue(subagentSnapshot);
+    removeInventoryItemMock.mockResolvedValue(subagentSnapshot);
+    api = {
+      ...api,
+      readCachedInventory: readCachedInventoryMock,
+      scanInventory: scanInventoryMock,
+      removeInventoryItem: removeInventoryItemMock,
+    };
+    Object.defineProperty(window, 'skillIndex', {
+      value: api,
+      configurable: true,
+      writable: true,
+    });
+    render(<App />);
+    await openSubagents();
+    fireEvent.click(getSubagentRow('reviewer'));
+    expect(await screen.findByRole('heading', { name: 'reviewer', level: 3 })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+    const subagentDialog = await screen.findByRole('dialog', { name: /^Remove subagent$/i });
+    expect(within(subagentDialog).queryByRole('checkbox')).not.toBeInTheDocument();
+    fireEvent.click(within(subagentDialog).getByRole('button', { name: /^Yes, remove$/i }));
+    await waitFor(() => {
+      expect(removeInventoryItemMock).toHaveBeenCalledWith({
+        entity: 'subagent',
+        subagentName: 'reviewer',
+      });
     });
   });
 

--- a/src/renderer/src/app/browser-preview-adapter.ts
+++ b/src/renderer/src/app/browser-preview-adapter.ts
@@ -4,6 +4,7 @@ import {
   APP_NAME,
   type DismissDriftRequest,
   type McpPresentation,
+  type RemoveInventoryItemRequest,
   type ResolveIssueRequest,
   type SettingsState,
   type SkillDriftPresentation,
@@ -93,6 +94,10 @@ const browserPreviewApi: SkillIndexDesktopApi = {
   },
   dismissDrift: (request) => {
     browserPreviewSnapshot = toggleBrowserPreviewDismissal(browserPreviewSnapshot, request);
+    return Promise.resolve(cloneInventorySnapshot(browserPreviewSnapshot));
+  },
+  removeInventoryItem: (request) => {
+    browserPreviewSnapshot = removeBrowserPreviewItem(browserPreviewSnapshot, request);
     return Promise.resolve(cloneInventorySnapshot(browserPreviewSnapshot));
   },
   readAuditLog: () => Promise.resolve([]),
@@ -280,20 +285,27 @@ function toggleBrowserPreviewDismissal(snapshot: SkillInventorySnapshot, request
     nextSnapshot.subagentCounts = recomputeSubagentCounts(nextSnapshot);
   }
 
-  nextSnapshot.homeSummary = {
-    skills: {
-      total: nextSnapshot.counts.totalSkills,
-      healthy: nextSnapshot.counts.healthySkills,
-      needsAttention: nextSnapshot.counts.driftedSkills,
-    },
-    mcps: {
-      total: nextSnapshot.mcpCounts?.totalMcps ?? 0,
-      healthy: nextSnapshot.mcpCounts?.healthyMcps ?? 0,
-      needsAttention: nextSnapshot.mcpCounts?.attentionMcps ?? 0,
-    },
-    installedAgents: nextSnapshot.homeSummary?.installedAgents ?? 0,
-  };
+  nextSnapshot.homeSummary = recomputeHomeSummary(nextSnapshot);
 
+  return nextSnapshot;
+}
+
+function removeBrowserPreviewItem(snapshot: SkillInventorySnapshot, request: RemoveInventoryItemRequest): SkillInventorySnapshot {
+  const nextSnapshot = cloneInventorySnapshot(snapshot);
+  nextSnapshot.scannedAt = new Date().toISOString();
+
+  if (request.entity === 'skill') {
+    nextSnapshot.skills = nextSnapshot.skills.filter((skill) => skill.name !== request.skillName);
+    nextSnapshot.counts = recomputeSkillCounts(nextSnapshot);
+  } else if (request.entity === 'mcp') {
+    nextSnapshot.mcps = (nextSnapshot.mcps ?? []).filter((mcp) => mcp.name !== request.mcpName);
+    nextSnapshot.mcpCounts = recomputeMcpCounts(nextSnapshot);
+  } else {
+    nextSnapshot.subagents = (nextSnapshot.subagents ?? []).filter((subagent) => subagent.name !== request.subagentName);
+    nextSnapshot.subagentCounts = recomputeSubagentCounts(nextSnapshot);
+  }
+
+  nextSnapshot.homeSummary = recomputeHomeSummary(nextSnapshot);
   return nextSnapshot;
 }
 
@@ -339,5 +351,28 @@ function recomputeSubagentCounts(snapshot: SkillInventorySnapshot): NonNullable<
     attentionSubagents: subagents.filter((subagent) => subagent.status === 'needs-attention' && subagent.presentation === 'active').length,
     healthySubagents: subagents.filter((subagent) => subagent.status === 'healthy').length,
     dismissedAttentionSubagents: subagents.filter((subagent) => subagent.status === 'needs-attention' && subagent.presentation === 'dismissed').length,
+  };
+}
+
+function recomputeHomeSummary(snapshot: SkillInventorySnapshot): NonNullable<SkillInventorySnapshot['homeSummary']> {
+  return {
+    skills: {
+      total: snapshot.counts.totalSkills,
+      healthy: snapshot.counts.healthySkills,
+      needsAttention: snapshot.counts.driftedSkills,
+    },
+    mcps: {
+      total: snapshot.mcpCounts?.totalMcps ?? 0,
+      healthy: snapshot.mcpCounts?.healthyMcps ?? 0,
+      needsAttention: snapshot.mcpCounts?.attentionMcps ?? 0,
+    },
+    subagents: snapshot.subagentCounts
+      ? {
+          total: snapshot.subagentCounts.totalSubagents,
+          healthy: snapshot.subagentCounts.healthySubagents,
+          needsAttention: snapshot.subagentCounts.attentionSubagents,
+        }
+      : undefined,
+    installedAgents: snapshot.homeSummary?.installedAgents ?? 0,
   };
 }

--- a/src/renderer/src/components/DetailInspectorPanel.test.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.test.tsx
@@ -920,6 +920,48 @@ describe('DetailInspectorPanel', () => {
     expect(screen.queryByRole('button', { name: helpText })).not.toBeInTheDocument();
   });
 
+  it('renders dismiss and remove footer actions as a two-third and one-third action row', () => {
+    const skill = representativeInventorySnapshot.skills.find((entry) => entry.name === 'identical-drift-skill');
+    expect(skill).toBeDefined();
+
+    const model = buildSkillInspectorModel(skill!, sourceIndex, {
+      selectedProblemKey: 'identical-copies',
+      selectedVariantPath: null,
+    }, agentIndex);
+    const onDismiss = vi.fn();
+    const onRemove = vi.fn();
+
+    render(
+      <DetailInspectorPanel
+        footerActions={[
+          { label: 'Dismiss issues with this skill', onClick: onDismiss, shortcut: 'D', variant: 'subtle' },
+          { label: 'Remove', onClick: onRemove, shortcut: 'R', variant: 'danger' },
+        ]}
+        model={model}
+        onClose={() => undefined}
+        onProblemSelect={() => undefined}
+      />,
+    );
+
+    const footer = document.querySelector('.detail-inspector-panel__footer-block');
+    const dismissButton = screen.getByRole('button', { name: /^Dismiss issues with this skill$/i });
+    const removeButton = screen.getByRole('button', { name: /^Remove$/i });
+
+    expect(footer).toHaveClass('detail-inspector-panel__footer-block--with-remove');
+    expect(dismissButton.closest('.detail-inspector-panel__footer-action-group')).toHaveClass(
+      'detail-inspector-panel__footer-action-group--secondary',
+    );
+    expect(removeButton.closest('.detail-inspector-panel__footer-action-group')).toHaveClass(
+      'detail-inspector-panel__footer-action-group--danger',
+    );
+    expect(dismissButton).toHaveAttribute('aria-keyshortcuts', 'D');
+    expect(removeButton).toHaveAttribute('aria-keyshortcuts', 'R');
+
+    fireEvent.keyDown(window, { key: 'r' });
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
   it('renders MCP invalid-definition rows as a focused code surface', () => {
     const mcp = representativeInventorySnapshot.mcps?.find((entry) => entry.name === 'broken-mcp');
     expect(mcp).toBeDefined();

--- a/src/renderer/src/components/DetailInspectorPanel.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.tsx
@@ -20,7 +20,7 @@ export interface DetailInspectorFooterAction {
   onClick?: () => void;
   shortcut?: string;
   title?: string;
-  variant?: 'default' | 'strong' | 'subtle' | 'note';
+  variant?: 'danger' | 'default' | 'strong' | 'subtle' | 'note';
 }
 
 export function DetailInspectorPanel({
@@ -107,6 +107,7 @@ export function DetailInspectorPanel({
     : entityKind === 'subagent'
       ? PLUGIN_SUBAGENT_TOOLTIP
       : PLUGIN_SKILL_TOOLTIP;
+  const hasRemoveAction = footerActions?.some((action) => action.variant === 'danger') ?? false;
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -583,7 +584,7 @@ export function DetailInspectorPanel({
       ) : null}
 
       {activeTab === 'problems' && footerActions && footerActions.length > 0 ? (
-        <section className="detail-inspector-panel__footer-block">
+        <section className={`detail-inspector-panel__footer-block${hasRemoveAction ? ' detail-inspector-panel__footer-block--with-remove' : ''}`}>
           {activeProblem.actionSummary ? (
             <p className="detail-inspector-panel__action-summary">{activeProblem.actionSummary}</p>
           ) : null}
@@ -599,7 +600,15 @@ export function DetailInspectorPanel({
             }
 
             return (
-              <div className="detail-inspector-panel__footer-action-group" key={action.label}>
+              <div
+                className={[
+                  'detail-inspector-panel__footer-action-group',
+                  action.variant === 'strong' ? 'detail-inspector-panel__footer-action-group--primary' : '',
+                  action.variant === 'subtle' ? 'detail-inspector-panel__footer-action-group--secondary' : '',
+                  action.variant === 'danger' ? 'detail-inspector-panel__footer-action-group--danger' : '',
+                ].filter(Boolean).join(' ')}
+                key={action.label}
+              >
                 <button
                   aria-keyshortcuts={action.shortcut ? action.shortcut.toUpperCase() : undefined}
                   aria-describedby={visibleDetail ? disabledReasonId : undefined}
@@ -607,6 +616,7 @@ export function DetailInspectorPanel({
                     'detail-inspector-panel__footer-action',
                     action.variant === 'strong' ? 'detail-inspector-panel__footer-action--primary' : '',
                     action.variant === 'subtle' ? 'detail-inspector-panel__footer-action--secondary' : '',
+                    action.variant === 'danger' ? 'detail-inspector-panel__footer-action--danger' : '',
                   ].filter(Boolean).join(' ')}
                   disabled={action.disabled}
                   title={action.title}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -6058,6 +6058,126 @@ body {
   color: rgba(255, 253, 248, 0.9);
 }
 
+.remove-item-dialog-root {
+  position: fixed;
+  inset: 0;
+  z-index: 45;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 68px 24px 24px;
+}
+
+.remove-item-dialog-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(18, 20, 26, 0.28);
+  backdrop-filter: blur(5px);
+}
+
+.remove-item-dialog {
+  position: relative;
+  width: min(460px, calc(100vw - 48px));
+  border: 1px solid color-mix(in srgb, var(--danger) 16%, rgba(28, 31, 39, 0.12));
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 28px 80px rgba(18, 20, 26, 0.22);
+  overflow: hidden;
+}
+
+.remove-item-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 22px 24px 16px;
+  border-bottom: 1px solid rgba(28, 31, 39, 0.1);
+}
+
+.remove-item-dialog__header h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 18px;
+  line-height: 22px;
+  letter-spacing: 0;
+  color: var(--text-strong);
+}
+
+.remove-item-dialog__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.remove-item-dialog__close:disabled {
+  opacity: 0.46;
+  cursor: default;
+}
+
+.remove-item-dialog__body {
+  display: grid;
+  gap: 12px;
+  padding: 18px 24px 20px;
+}
+
+.remove-item-dialog__body p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.remove-item-dialog__body strong {
+  color: var(--text-strong);
+}
+
+.remove-item-dialog__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 0 24px 24px;
+}
+
+.remove-item-dialog__button {
+  min-height: 42px;
+  padding: 0 16px;
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 18px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.remove-item-dialog__button:disabled {
+  cursor: default;
+}
+
+.remove-item-dialog__button--secondary {
+  border: 1px solid rgba(28, 31, 39, 0.14);
+  background: #ffffff;
+  color: var(--text-strong);
+}
+
+.remove-item-dialog__button--danger {
+  min-width: 112px;
+  background: var(--danger);
+  color: #fffdf8;
+}
+
+.remove-item-dialog__button--danger:disabled {
+  background: #c9aaa5;
+  color: rgba(255, 253, 248, 0.88);
+}
+
 @keyframes toolbar-button-spin {
   from {
     transform: rotate(0deg);
@@ -9236,6 +9356,25 @@ body {
   background: var(--detail-inspector-bg);
 }
 
+.detail-inspector-panel__footer-block--with-remove {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.detail-inspector-panel__footer-block--with-remove .detail-inspector-panel__action-summary,
+.detail-inspector-panel__footer-block--with-remove .detail-inspector-panel__footer-note,
+.detail-inspector-panel__footer-block--with-remove .detail-inspector-panel__footer-action-group--primary,
+.detail-inspector-panel__footer-block--with-remove .detail-inspector-panel__footer-action-group:not(.detail-inspector-panel__footer-action-group--secondary):not(.detail-inspector-panel__footer-action-group--danger) {
+  grid-column: 1 / -1;
+}
+
+.detail-inspector-panel__footer-block--with-remove .detail-inspector-panel__footer-action-group--secondary {
+  grid-column: span 2;
+}
+
+.detail-inspector-panel__footer-block--with-remove .detail-inspector-panel__footer-action-group--danger {
+  grid-column: span 1;
+}
+
 .detail-inspector-panel__footer-action {
   width: 100%;
   display: inline-flex;
@@ -9322,6 +9461,11 @@ body {
   color: var(--detail-inspector-text-muted);
 }
 
+.detail-inspector-panel__footer-action--danger .detail-inspector-panel__footer-shortcut {
+  background: color-mix(in srgb, var(--detail-inspector-red-surface) 64%, white);
+  color: var(--detail-inspector-red);
+}
+
 .detail-inspector-panel__footer-action:disabled .detail-inspector-panel__footer-shortcut {
   opacity: 0.72;
 }
@@ -9361,6 +9505,25 @@ body {
   border-color: #c9d2df;
   background: #f1f5f9;
   color: var(--detail-inspector-text);
+}
+
+.detail-inspector-panel__footer-action--danger {
+  min-height: 28px;
+  padding: 0 34px 0 12px;
+  border: 1px solid color-mix(in srgb, var(--detail-inspector-red) 26%, var(--detail-inspector-border));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--detail-inspector-red-surface) 55%, white);
+  font-family: "Inter", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 12px;
+  line-height: 15px;
+  font-weight: 600;
+  color: var(--detail-inspector-red);
+  text-align: center;
+}
+
+.detail-inspector-panel__footer-action--danger:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--detail-inspector-red) 42%, var(--detail-inspector-border));
+  background: color-mix(in srgb, var(--detail-inspector-red-surface) 74%, white);
 }
 
 @media (max-width: 880px) {

--- a/src/renderer/src/views/McpWorkspaceView.tsx
+++ b/src/renderer/src/views/McpWorkspaceView.tsx
@@ -4,6 +4,7 @@ import type {
   McpIssueReason,
   McpRecord,
   RemoteMcpTransportKind,
+  RemoveInventoryItemRequest,
   ResolveIssueRequest,
   SkillInventorySnapshot,
 } from '@shared/contracts';
@@ -37,6 +38,7 @@ export function McpWorkspaceView({
   isAddingMcpServer,
   isDismissingDrift,
   isResolvingIssue,
+  isRemovingInventoryItem = false,
   isRescanning,
   mcp,
   mcpInspectorModel,
@@ -45,6 +47,7 @@ export function McpWorkspaceView({
   onCancelMcpConnectivityTest,
   onClearSelection,
   onDismissDrift,
+  onRequestRemove = () => undefined,
   onResolveIssue,
   onRescan,
   onSearchQueryChange,
@@ -61,6 +64,7 @@ export function McpWorkspaceView({
   isAddingMcpServer: boolean;
   isDismissingDrift: boolean;
   isResolvingIssue: boolean;
+  isRemovingInventoryItem?: boolean;
   isRescanning: boolean;
   mcp: McpRecord | null;
   mcpInspectorModel: InspectorModel | null;
@@ -69,6 +73,7 @@ export function McpWorkspaceView({
   onCancelMcpConnectivityTest?: () => void;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
+  onRequestRemove?: (request: RemoveInventoryItemRequest, label: string) => void;
   onResolveIssue: (request: ResolveIssueRequest) => Promise<void>;
   onRescan: () => Promise<void>;
   onSearchQueryChange: (query: string) => void;
@@ -181,12 +186,14 @@ export function McpWorkspaceView({
               <McpDetailPanel
                 isDismissingDrift={isDismissingDrift}
                 isResolvingIssue={isResolvingIssue}
+                isRemovingInventoryItem={isRemovingInventoryItem}
                 inventorySnapshot={inventorySnapshot}
                 mcp={mcp}
                 mcpInspectorModel={mcpInspectorModel}
                 sandboxRoot={sandboxRoot}
                 onClearSelection={onClearSelection}
                 onDismissDrift={onDismissDrift}
+                onRequestRemove={onRequestRemove}
                 onResolveIssue={onResolveIssue}
                 onSelectProblem={onSelectProblem}
                 onSelectVariant={onSelectVariant}
@@ -511,24 +518,28 @@ function parseKeyValueLines(raw: string): Record<string, string> | undefined {
 function McpDetailPanel({
   isDismissingDrift,
   isResolvingIssue,
+  isRemovingInventoryItem,
   inventorySnapshot,
   mcp,
   mcpInspectorModel,
   sandboxRoot,
   onClearSelection,
   onDismissDrift,
+  onRequestRemove,
   onResolveIssue,
   onSelectProblem,
   onSelectVariant,
 }: {
   isDismissingDrift: boolean;
   isResolvingIssue: boolean;
+  isRemovingInventoryItem: boolean;
   inventorySnapshot: SkillInventorySnapshot | null;
   mcp: McpRecord;
   mcpInspectorModel: InspectorModel | null;
   sandboxRoot: string | null;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
+  onRequestRemove: (request: RemoveInventoryItemRequest, label: string) => void;
   onResolveIssue: (request: ResolveIssueRequest) => Promise<void>;
   onSelectProblem: (problemKey: McpIssueReason | null) => void;
   onSelectVariant: (path: string | null) => void;
@@ -579,6 +590,18 @@ function McpDetailPanel({
             variant: 'subtle' as const,
           }]
           : []),
+        {
+          disabled: isRemovingInventoryItem,
+          label: isRemovingInventoryItem ? 'Removing...' : 'Remove',
+          onClick: () => {
+            onRequestRemove({
+              entity: 'mcp',
+              mcpName: mcp.name,
+            }, mcp.name);
+          },
+          shortcut: 'R',
+          variant: 'danger' as const,
+        },
       ]}
       model={mcpInspectorModel}
       paneClassName="mcp-inspector-panel"

--- a/src/renderer/src/views/SkillsWorkspaceView.tsx
+++ b/src/renderer/src/views/SkillsWorkspaceView.tsx
@@ -3,6 +3,7 @@ import type {
   CapabilityActionRequest,
   DismissDriftRequest,
   ResolveIssueRequest,
+  RemoveInventoryItemRequest,
   SkillIssueReason,
   SkillInventorySnapshot,
   SkillRecord,
@@ -40,6 +41,7 @@ export function SkillsWorkspaceView({
   isDismissingDrift,
   isApplyingCapabilityAction,
   isResolvingIssue,
+  isRemovingInventoryItem = false,
   isRescanning,
   onAddSkill,
   onCancelMcpConnectivityTest,
@@ -47,6 +49,7 @@ export function SkillsWorkspaceView({
   onDismissDrift,
   onApplyCapabilityAction,
   onOpenPluginSource,
+  onRequestRemove = () => undefined,
   onResolveIssue,
   onRescan,
   rows,
@@ -70,6 +73,7 @@ export function SkillsWorkspaceView({
   isDismissingDrift: boolean;
   isApplyingCapabilityAction: boolean;
   isResolvingIssue: boolean;
+  isRemovingInventoryItem?: boolean;
   isRescanning: boolean;
   onAddSkill: (request: AddSkillRequest) => Promise<void>;
   onCancelMcpConnectivityTest?: () => void;
@@ -77,6 +81,7 @@ export function SkillsWorkspaceView({
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
   onApplyCapabilityAction: (request: CapabilityActionRequest) => Promise<void>;
   onOpenPluginSource: (action: NonNullable<InspectorProvenanceSummaryRow['action']>) => void;
+  onRequestRemove?: (request: RemoveInventoryItemRequest, label: string) => void;
   onResolveIssue: (request: ResolveIssueRequest) => Promise<void>;
   onRescan: () => Promise<void>;
   rows: SkillRecord[];
@@ -207,11 +212,13 @@ export function SkillsWorkspaceView({
                 isDismissingDrift={isDismissingDrift}
                 isApplyingCapabilityAction={isApplyingCapabilityAction}
                 isResolvingIssue={isResolvingIssue}
+                isRemovingInventoryItem={isRemovingInventoryItem}
                 onClearSelection={onClearSelection}
                 onDismissDrift={onDismissDrift}
                 onApplyCapabilityAction={onApplyCapabilityAction}
                 onResolveIssue={onResolveIssue}
                 onOpenPluginSource={onOpenPluginSource}
+                onRequestRemove={onRequestRemove}
                 sandboxRoot={sandboxRoot}
                 selectedSkill={selectedSkill}
                 selectedSkillInspectorModel={selectedSkillInspectorModel}
@@ -276,10 +283,12 @@ function SkillDetailPanel({
   isDismissingDrift,
   isApplyingCapabilityAction,
   isResolvingIssue,
+  isRemovingInventoryItem,
   onClearSelection,
   onDismissDrift,
   onApplyCapabilityAction,
   onOpenPluginSource,
+  onRequestRemove,
   onResolveIssue,
   sandboxRoot,
   selectedSkill,
@@ -292,10 +301,12 @@ function SkillDetailPanel({
   isDismissingDrift: boolean;
   isApplyingCapabilityAction: boolean;
   isResolvingIssue: boolean;
+  isRemovingInventoryItem: boolean;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
   onApplyCapabilityAction: (request: CapabilityActionRequest) => Promise<void>;
   onOpenPluginSource: (action: NonNullable<InspectorProvenanceSummaryRow['action']>) => void;
+  onRequestRemove: (request: RemoveInventoryItemRequest, label: string) => void;
   onResolveIssue: (request: ResolveIssueRequest) => Promise<void>;
   sandboxRoot: string | null;
   selectedSkill: SkillRecord;
@@ -353,6 +364,18 @@ function SkillDetailPanel({
             variant: 'subtle' as const,
           }]
           : []),
+        {
+          disabled: isRemovingInventoryItem,
+          label: isRemovingInventoryItem ? 'Removing...' : 'Remove',
+          onClick: () => {
+            onRequestRemove({
+              entity: 'skill',
+              skillName: selectedSkill.name,
+            }, selectedSkill.displayName ?? selectedSkill.name);
+          },
+          shortcut: 'R',
+          variant: 'danger' as const,
+        },
       ]}
       model={inspectorModel}
       ariaLabel="Skill detail"

--- a/src/renderer/src/views/SubagentsWorkspaceView.tsx
+++ b/src/renderer/src/views/SubagentsWorkspaceView.tsx
@@ -1,5 +1,6 @@
 import type {
   DismissDriftRequest,
+  RemoveInventoryItemRequest,
   ResolveIssueRequest,
   SkillInventorySnapshot,
   SubagentIssueReason,
@@ -37,10 +38,12 @@ export function SubagentsWorkspaceView({
   inventorySnapshot,
   isDismissingDrift,
   isResolvingIssue,
+  isRemovingInventoryItem = false,
   isRescanning,
   onCancelMcpConnectivityTest,
   onClearSelection,
   onDismissDrift,
+  onRequestRemove = () => undefined,
   onResolveIssue,
   onRescan,
   onSearchQueryChange,
@@ -60,10 +63,12 @@ export function SubagentsWorkspaceView({
   inventorySnapshot: SkillInventorySnapshot | null;
   isDismissingDrift: boolean;
   isResolvingIssue: boolean;
+  isRemovingInventoryItem?: boolean;
   isRescanning: boolean;
   onCancelMcpConnectivityTest?: () => void;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
+  onRequestRemove?: (request: RemoveInventoryItemRequest, label: string) => void;
   onResolveIssue: (request: ResolveIssueRequest) => Promise<void>;
   onRescan: () => Promise<void>;
   onSearchQueryChange: (query: string) => void;
@@ -169,9 +174,11 @@ export function SubagentsWorkspaceView({
             <SubagentDetailPanel
               isDismissingDrift={isDismissingDrift}
               isResolvingIssue={isResolvingIssue}
+              isRemovingInventoryItem={isRemovingInventoryItem}
               inventorySnapshot={inventorySnapshot}
               onClearSelection={onClearSelection}
               onDismissDrift={onDismissDrift}
+              onRequestRemove={onRequestRemove}
               onSelectProblem={onSelectProblem}
               onSelectVariant={onSelectVariant}
               onResolveIssue={onResolveIssue}
@@ -190,9 +197,11 @@ export function SubagentsWorkspaceView({
 function SubagentDetailPanel({
   isDismissingDrift,
   isResolvingIssue,
+  isRemovingInventoryItem,
   inventorySnapshot,
   onClearSelection,
   onDismissDrift,
+  onRequestRemove,
   onSelectProblem,
   onSelectVariant,
   onResolveIssue,
@@ -203,9 +212,11 @@ function SubagentDetailPanel({
 }: {
   isDismissingDrift: boolean;
   isResolvingIssue: boolean;
+  isRemovingInventoryItem: boolean;
   inventorySnapshot: SkillInventorySnapshot | null;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
+  onRequestRemove: (request: RemoveInventoryItemRequest, label: string) => void;
   onSelectProblem: (problemKey: SubagentIssueReason | null) => void;
   onSelectVariant: (path: string | null) => void;
   onResolveIssue: (request: ResolveIssueRequest) => Promise<void>;
@@ -257,6 +268,18 @@ function SubagentDetailPanel({
             variant: 'note' as const,
           }]
           : []),
+        {
+          disabled: isRemovingInventoryItem,
+          label: isRemovingInventoryItem ? 'Removing...' : 'Remove',
+          onClick: () => {
+            onRequestRemove({
+              entity: 'subagent',
+              subagentName: subagent.name,
+            }, subagent.displayName ?? subagent.name);
+          },
+          shortcut: 'R',
+          variant: 'danger' as const,
+        },
       ]}
       model={selectedSubagentInspectorModel}
       ariaLabel="Subagent detail"

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -20,6 +20,7 @@ export const IPC_CHANNELS = {
   resolveIssue: 'inventory:resolve-issue',
   applyCapabilityAction: 'inventory:apply-capability-action',
   dismissDrift: 'inventory:dismiss-drift',
+  removeInventoryItem: 'inventory:remove-item',
   readAuditLog: 'audit:list',
   undoAuditOperation: 'audit:undo-operation',
   auditUpdated: 'audit:updated',
@@ -758,6 +759,26 @@ export type DismissDriftRequest =
     mcpName?: never;
   };
 
+export type RemoveInventoryItemRequest =
+  | {
+    entity: 'skill';
+    skillName: string;
+    mcpName?: never;
+    subagentName?: never;
+  }
+  | {
+    entity: 'mcp';
+    mcpName: string;
+    skillName?: never;
+    subagentName?: never;
+  }
+  | {
+    entity: 'subagent';
+    subagentName: string;
+    skillName?: never;
+    mcpName?: never;
+  };
+
 export interface SeededFixtureExpectation {
   name: string;
   expectedState: SkillStructuralState;
@@ -814,6 +835,7 @@ export type AuditOperationKind =
   | 'settings-update'
   | 'capability-action'
   | 'dismiss-drift'
+  | 'remove-inventory-item'
   | 'inventory-rescan'
   | 'seed-representative-fixtures'
   | 'undo';
@@ -940,6 +962,7 @@ export interface SkillIndexDesktopApi {
   resolveIssue(request: ResolveIssueRequest): Promise<SkillInventorySnapshot>;
   applyCapabilityAction(request: CapabilityActionRequest): Promise<SkillInventorySnapshot>;
   dismissDrift(request: DismissDriftRequest): Promise<SkillInventorySnapshot>;
+  removeInventoryItem(request: RemoveInventoryItemRequest): Promise<SkillInventorySnapshot>;
   readAuditLog(options?: { limit?: number }): Promise<AuditOperation[]>;
   undoAuditOperation(operationId: string): Promise<UndoAuditOperationResult>;
   releaseStartupObservation(): Promise<void>;
@@ -1022,6 +1045,9 @@ export function createSkillIndexDesktopApi(invoke: InvokeLike, subscribe: Subscr
     },
     async dismissDrift(request) {
       return invoke(IPC_CHANNELS.dismissDrift, request) as Promise<SkillInventorySnapshot>;
+    },
+    async removeInventoryItem(request) {
+      return invoke(IPC_CHANNELS.removeInventoryItem, request) as Promise<SkillInventorySnapshot>;
     },
     async readAuditLog(options) {
       return options === undefined


### PR DESCRIPTION
Changes:

- Added Remove actions to skill, MCP, and subagent detail panes with the R shortcut and a custom confirmation dialog.
- Moves file-backed skill and subagent removals to macOS Trash, removes MCP config entries in place, and records the operation in the audit log with undo support when snapshots are restorable.
- Updated the browser preview adapter and regression coverage for remove flows across item types.

Validation:
pnpm typecheck
pnpm exec vitest run src/main/remove-inventory-item.test.ts src/main/inventory-runtime.test.ts src/preload/bridge.test.ts src/renderer/src/components/DetailInspectorPanel.test.tsx src/renderer/src/app-shell.test.tsx src/renderer/src/app-search.test.tsx
Playwright live renderer check on port 5603 for the remove confirmation dialog.
