### PR TITLE
Use one tone for homepage issue badges

### DIFF
--- a/src/renderer/src/views/HomeDashboard.test.tsx
+++ b/src/renderer/src/views/HomeDashboard.test.tsx
@@ -65,6 +65,19 @@ describe('HomeDashboard', () => {
     expect(brokenMcpRow).toHaveTextContent('Invalid Definition');
   });
 
+  it('uses the same attention tone for every issue badge in the attention table', () => {
+    renderDashboard();
+
+    const table = screen.getByRole('region', { name: /^Needs attention$/i });
+    const pills = table.querySelectorAll('.home-attention-status-pill');
+
+    expect(pills.length).toBeGreaterThan(0);
+    expect(table.querySelector('.home-attention-status-pill--warning')).toBeNull();
+    pills.forEach((pill) => {
+      expect(pill).toHaveClass('home-attention-status-pill--attention');
+    });
+  });
+
   it('renders the healthy repair state without inline error banners', () => {
     renderDashboard({
       inventorySnapshot: createNoAttentionSnapshot(),

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -291,26 +291,10 @@ function formatCleanGroupCopy(labels: string[]): { label: string; verb: 'is' | '
   };
 }
 
-function getHomeAttentionBadgeTone(label: string): AttentionBadge['tone'] {
-  if (label === 'Healthy') {
-    return 'healthy';
-  }
-
-  if (label === 'Dismissed') {
-    return 'muted';
-  }
-
-  if (label.includes('Diverged') || label.includes('Definition Mismatch')) {
-    return 'attention';
-  }
-
-  return 'warning';
-}
-
 function toHomeAttentionBadges(labels: string[]): AttentionBadge[] {
   return labels.map((label) => ({
     label,
-    tone: getHomeAttentionBadgeTone(label),
+    tone: 'attention',
   }));
 }
 


### PR DESCRIPTION
Changes:

Render every Home "Needs attention" issue badge with the attention tone instead of deriving tone from the issue label.
Add a HomeDashboard regression test covering mixed issue badges.

Validation:
pnpm exec vitest run src/renderer/src/views/HomeDashboard.test.tsx
pnpm typecheck
Browser preview: Home attention table showed 12 attention badges and 0 warning badges.
