### PR TITLE
Read plugin interface subagent YAML

### DIFF
--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -917,8 +917,19 @@ function readPortableDefinitionForSubagentLocation(
     family: findSubagentLocationFamily(snapshot, location.agentId),
     filePath: location.path,
     format: location.format,
-    fallbackName,
+    fallbackName: getSubagentDefinitionFallbackName(fallbackName, location),
   });
+}
+
+function getSubagentDefinitionFallbackName(
+  fallbackName: string,
+  location: Pick<SubagentLocationRecord, 'agentId'>,
+): string {
+  if (location.agentId.startsWith('plugin:') && fallbackName.includes(':')) {
+    return fallbackName.slice(fallbackName.indexOf(':') + 1);
+  }
+
+  return fallbackName;
 }
 
 function findSubagentLocationFamily(snapshot: SkillInventorySnapshot, agentId: string): string | undefined {

--- a/src/main/subagent-inventory.test.ts
+++ b/src/main/subagent-inventory.test.ts
@@ -435,6 +435,69 @@ describe('subagent inventory', () => {
     expect(await readFile(localPath, 'utf8')).toContain('Local review helper.');
   });
 
+  it('promotes plugin interface YAML subagents into Universal', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const pluginPath = path.join(
+      homeDir,
+      '.codex',
+      'plugins',
+      'cache',
+      'openai-curated',
+      'build-ios-apps',
+      'fef63ecf',
+      'agents',
+      'openai.yaml',
+    );
+    const manifestPath = path.join(
+      homeDir,
+      '.codex',
+      'plugins',
+      'cache',
+      'openai-curated',
+      'build-ios-apps',
+      'fef63ecf',
+      '.codex-plugin',
+      'plugin.json',
+    );
+
+    await writeRawFile(pluginPath, [
+      'interface:',
+      '  display_name: "Build iOS Apps"',
+      '  short_description: "Build, profile, debug, and refine iOS apps with SwiftUI and Xcode workflows"',
+      '  icon_small: "./assets/build-ios-apps-small.svg"',
+      '  icon_large: "./assets/app-icon.png"',
+      '  default_prompt: "Build or debug an iOS app with SwiftUI, App Intents, and Simulator."',
+      '',
+    ].join('\n'));
+    await writeRawFile(manifestPath, `${JSON.stringify({ name: 'build-ios-apps', version: 'fef63ecf' }, null, 2)}\n`);
+
+    const inventory = await scanInventory(scanOptions);
+    const pluginSubagent = inventory.subagents?.find((subagent) => subagent.name === 'build-ios-apps:openai');
+
+    expect(pluginSubagent?.issueReasons).toEqual(['missing-universal']);
+    expect(pluginSubagent?.locations[0]).toMatchObject({
+      path: pluginPath,
+      invalidDetails: undefined,
+      description: 'Build, profile, debug, and refine iOS apps with SwiftUI and Xcode workflows',
+    });
+    expect(pluginSubagent?.locations[0]?.definitionComparisonKey).toBeDefined();
+
+    const repaired = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'missing-universal',
+      selectedVariantPath: pluginPath,
+      subagentName: 'build-ios-apps:openai',
+    }, scanOptions);
+    const repairedPlugin = repaired.subagents?.find((subagent) => subagent.name === 'build-ios-apps:openai');
+    const universalDefinition = await readFile(path.join(homeDir, '.agents', 'agents', 'build-ios-apps-openai.md'), 'utf8');
+
+    expect(repairedPlugin?.issueReasons).not.toContain('missing-universal');
+    expect(repairedPlugin?.issueReasons).not.toContain('invalid-definition');
+    expect(universalDefinition).toContain('name: "openai"');
+    expect(universalDefinition).toContain('Build or debug an iOS app with SwiftUI, App Intents, and Simulator.');
+    expect(universalDefinition).not.toContain('build-ios-apps:openai');
+  });
+
   it('repairs legacy plugin subagent Universal files without keeping the scoped name in frontmatter', async () => {
     const { homeDir, scanOptions } = await createSubagentTestPaths();
     const universalPath = path.join(homeDir, '.agents', 'agents', 'github-tools-reviewer.md');

--- a/src/main/subagent-inventory.ts
+++ b/src/main/subagent-inventory.ts
@@ -758,10 +758,14 @@ function readJsonSubagent(raw: string, fallbackName: string, jsonc: boolean): Pa
 function readYamlSubagent(raw: string, fallbackName: string): ParsedSubagentDefinition {
   const values = parseFlatYaml(raw);
   const name = getStringField(values, 'name') ?? getStringField(values, 'agentType') ?? fallbackName;
-  const description = getStringField(values, 'description') ?? getStringField(values, 'whenToUse') ?? null;
+  const description = getStringField(values, 'description')
+    ?? getStringField(values, 'whenToUse')
+    ?? getStringField(values, 'short_description')
+    ?? null;
   const prompt = getStringField(values, 'prompt')
     ?? getStringField(values, 'systemPrompt')
-    ?? getStringField(values, 'instructions');
+    ?? getStringField(values, 'instructions')
+    ?? getStringField(values, 'default_prompt');
   const invalidDetails: string[] = [];
   if (!description) {
     invalidDetails.push('Missing required field: description');
@@ -772,7 +776,7 @@ function readYamlSubagent(raw: string, fallbackName: string): ParsedSubagentDefi
 
   return {
     name,
-    displayName: name,
+    displayName: getStringField(values, 'display_name') ?? name,
     description,
     prompt: prompt ?? undefined,
     invalidDetails,
@@ -1058,11 +1062,13 @@ function normalizeSubagentDefinition(definition: Record<string, unknown>): Recor
     ?? '';
   const description = getStringField(definition, 'description')
     ?? getStringField(definition, 'whenToUse')
+    ?? getStringField(definition, 'short_description')
     ?? null;
   const prompt = getStringField(definition, 'prompt')
     ?? getStringField(definition, 'systemPrompt')
     ?? getStringField(definition, 'developer_instructions')
     ?? getStringField(definition, 'instructions')
+    ?? getStringField(definition, 'default_prompt')
     ?? '';
   return {
     name,
@@ -1087,11 +1093,13 @@ function omitSubagentAliasFields(definition: Record<string, unknown>): Record<st
     'agentType',
     'description',
     'developer_instructions',
+    'default_prompt',
     'displayName',
     'display_name',
     'instructions',
     'name',
     'prompt',
+    'short_description',
     'systemPrompt',
     'whenToUse',
   ]);


### PR DESCRIPTION
Changes:

- Accept plugin interface YAML aliases (`short_description`, `default_prompt`, `display_name`) when reading subagent definitions.
- Preserve unscoped plugin definition names when promoting plugin subagents into Universal.

Validation:
pnpm typecheck
pnpm exec vitest run src/main/subagent-inventory.test.ts src/main/issue-resolution.test.ts
