### PR TITLE
Add scoped auto-resolution controls

### DIFF
--- a/docs/reference/inventory-resolution-model.md
+++ b/docs/reference/inventory-resolution-model.md
@@ -88,5 +88,6 @@ copied into another family.
   writes any writable supported targets and leaves unwritable targets unresolved.
 - Config writers preserve unrelated file fields and unrelated MCP server entries.
 - Auto-resolve stays conservative: skills auto-resolve only issues with an
-  inferable Universal choice; MCPs auto-resolve only safe `missing-from-agents`;
-  subagents auto-resolve simple missing, identical-copy, and broken-symlink cases.
+  inferable Universal choice; MCPs auto-resolve safe `missing-universal` and
+  `missing-from-agents`; subagents auto-resolve simple missing, identical-copy,
+  and broken-symlink cases.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -76,14 +76,19 @@ import { SettingsWorkspaceView } from './views/SettingsWorkspaceView';
 import { AddSkillModal, SkillsWorkspaceView } from './views/SkillsWorkspaceView';
 import { AddSubagentModal, SubagentsWorkspaceView } from './views/SubagentsWorkspaceView';
 
-function getAutoResolvableRequestsForSnapshot(snapshot: SkillInventorySnapshot): ResolveIssueRequest[] {
+function getAutoResolvableRequestsForSnapshot(
+  snapshot: SkillInventorySnapshot,
+  entity?: ResolveIssueRequest['entity'],
+): ResolveIssueRequest[] {
   const sourceIndex = new Map(snapshot.sources.map((source) => [source.id, source]));
 
-  return [
+  const requests = [
     ...getAutoResolvableSkillRequests(snapshot, sourceIndex),
     ...getAutoResolvableMcpRequests(snapshot),
     ...getAutoResolvableSubagentRequests(snapshot),
   ];
+
+  return entity ? requests.filter((request) => request.entity === entity) : requests;
 }
 
 interface OnboardingPreferredSourceSelection {
@@ -838,6 +843,18 @@ export default function App() {
     () => (inventorySnapshot ? getAutoResolvableRequestsForSnapshot(inventorySnapshot) : []),
     [inventorySnapshot],
   );
+  const autoResolvableSkillRequests = useMemo(
+    () => autoResolvableRequests.filter((request) => request.entity === 'skill'),
+    [autoResolvableRequests],
+  );
+  const autoResolvableMcpRequests = useMemo(
+    () => autoResolvableRequests.filter((request) => request.entity === 'mcp'),
+    [autoResolvableRequests],
+  );
+  const autoResolvableSubagentRequests = useMemo(
+    () => autoResolvableRequests.filter((request) => request.entity === 'subagent'),
+    [autoResolvableRequests],
+  );
 
   const homeSummary = useMemo(() => getHomeSummary(inventorySnapshot), [inventorySnapshot]);
   const allSkillRows = useMemo(
@@ -1117,13 +1134,13 @@ export default function App() {
     showErrorToast,
   ]);
 
-  const handleAutoResolve = useCallback(async () => {
+  const handleAutoResolve = useCallback(async (entity?: ResolveIssueRequest['entity']) => {
     const startingSnapshot = latestInventorySnapshotRef.current;
     if (!startingSnapshot) {
       return;
     }
 
-    let remainingRequests = getAutoResolvableRequestsForSnapshot(startingSnapshot);
+    let remainingRequests = getAutoResolvableRequestsForSnapshot(startingSnapshot, entity);
     if (remainingRequests.length === 0) {
       return;
     }
@@ -1142,7 +1159,7 @@ export default function App() {
         attemptedRequestKeys.add(getResolveIssueRequestKey(request));
         const nextInventorySnapshot = await desktopApi.resolveIssue(request);
         applyInventorySnapshot(nextInventorySnapshot);
-        remainingRequests = getAutoResolvableRequestsForSnapshot(nextInventorySnapshot);
+        remainingRequests = getAutoResolvableRequestsForSnapshot(nextInventorySnapshot, entity);
       }
       await showAppToastWithLatestUndo(
         'Repairs applied',
@@ -1641,12 +1658,15 @@ export default function App() {
       mainContent = (
         <SkillsWorkspaceView
           addActionControl={renderAddActionControl('skill')}
+          autoResolvableRequests={autoResolvableSkillRequests}
           inventorySnapshot={inventorySnapshot}
+          isAutoResolving={isAutoResolving}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
           isRemovingInventoryItem={isRemovingInventoryItem}
           isApplyingCapabilityAction={isApplyingCapabilityAction}
           isRescanning={isRescanActionBusy}
+          onAutoResolve={() => { void handleAutoResolve('skill'); }}
           onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onDismissDrift={handleDismissDrift}
           onResolveIssue={handleResolveIssue}
@@ -1677,7 +1697,9 @@ export default function App() {
       mainContent = (
         <McpWorkspaceView
           addActionControl={renderAddActionControl('mcp')}
+          autoResolvableRequests={autoResolvableMcpRequests}
           inventorySnapshot={inventorySnapshot}
+          isAutoResolving={isAutoResolving}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
           isRemovingInventoryItem={isRemovingInventoryItem}
@@ -1685,6 +1707,7 @@ export default function App() {
           mcp={selectedMcp}
           mcpInspectorModel={selectedMcpInspectorModel}
           sandboxRoot={shellState?.devTools?.sandboxRoot ?? null}
+          onAutoResolve={() => { void handleAutoResolve('mcp'); }}
           onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onClearSelection={resetMcpSelection}
           onDismissDrift={handleDismissDrift}
@@ -1708,11 +1731,14 @@ export default function App() {
       mainContent = (
         <SubagentsWorkspaceView
           addActionControl={renderAddActionControl('subagent')}
+          autoResolvableRequests={autoResolvableSubagentRequests}
           inventorySnapshot={inventorySnapshot}
+          isAutoResolving={isAutoResolving}
           isDismissingDrift={isDismissingDrift}
           isResolvingIssue={isResolvingIssue}
           isRemovingInventoryItem={isRemovingInventoryItem}
           isRescanning={isRescanActionBusy}
+          onAutoResolve={() => { void handleAutoResolve('subagent'); }}
           onCancelMcpConnectivityTest={onCancelMcpConnectivityTest}
           onClearSelection={resetSubagentSelection}
           onDismissDrift={handleDismissDrift}

--- a/src/renderer/src/components/AutoRepairReview.tsx
+++ b/src/renderer/src/components/AutoRepairReview.tsx
@@ -1,0 +1,260 @@
+import { Check, ChevronDown, Info, Wrench } from 'lucide-react';
+import { useEffect, useId, useRef, useState } from 'react';
+
+import type { ResolveIssueRequest, SkillInventorySnapshot } from '@shared/contracts';
+
+import { getAutoRepairSummary } from '../lib/auto-repair';
+import { getMcpDisplayName, getSkillDisplayName } from '../inventory-view-model';
+
+const FIX_ACTION_LABELS: Record<string, string> = {
+  'missing-symlinks': 'Create missing symlinks',
+  'identical-copies': 'Convert copies to symlinks',
+  'missing-canonical': 'Promote to universal',
+  'missing-universal': 'Add to Universal',
+  'broken-symlink': 'Relink to canonical',
+  'wrong-symlink-target': 'Relink to canonical',
+  'missing-from-agents': 'Add to missing agents',
+};
+
+const FIX_TYPE_LABELS: Record<string, string> = {
+  'missing-symlinks': 'Missing Symlinks',
+  'identical-copies': 'Identical Copies',
+  'missing-canonical': 'Missing Universal',
+  'missing-universal': 'Missing Universal',
+  'broken-symlink': 'Broken Symlink',
+  'wrong-symlink-target': 'Wrong Symlink Target',
+  'missing-from-agents': 'Missing From Agents',
+};
+
+const FIX_ENTITY_LABELS: Record<ResolveIssueRequest['entity'], string> = {
+  skill: 'Skills',
+  mcp: 'MCPs',
+  subagent: 'Subagents',
+};
+
+interface PlannedFixRow {
+  key: string;
+  name: string;
+}
+
+interface PlannedFixGroup {
+  entity: ResolveIssueRequest['entity'];
+  issue: ResolveIssueRequest['issue'];
+  rows: PlannedFixRow[];
+}
+
+export function AutoRepairReviewPanel({
+  autoResolvableRequests,
+  id,
+  inventorySnapshot,
+  isAutoResolving,
+  onAutoResolve,
+  onCancel,
+}: {
+  autoResolvableRequests: ResolveIssueRequest[];
+  id: string;
+  inventorySnapshot: SkillInventorySnapshot | null;
+  isAutoResolving: boolean;
+  onAutoResolve: () => void;
+  onCancel: () => void;
+}) {
+  const fixesByType = autoResolvableRequests.reduce<Map<string, PlannedFixGroup>>((acc, req) => {
+    const groupKey = getFixGroupKey(req);
+    const group = acc.get(groupKey) ?? {
+      entity: req.entity,
+      issue: req.issue,
+      rows: [],
+    };
+    group.rows.push({
+      key: getResolveRequestKey(req),
+      name: getResolveRequestDisplayName(req, inventorySnapshot),
+    });
+    acc.set(groupKey, group);
+    return acc;
+  }, new Map());
+  const { totalIssues, totalItems } = getAutoRepairSummary(autoResolvableRequests);
+
+  return (
+    <div className="review-panel review-panel--open" id={id}>
+      <div className="review-header">
+        <span className="review-header-title">Review planned fixes</span>
+      </div>
+      <div className="review-body">
+        {[...fixesByType.values()].map((fixGroup) => (
+          <div className="issue-bucket" key={`${fixGroup.entity}:${fixGroup.issue}`}>
+            <div className="issue-bucket-header">
+              <span className="issue-bucket-label">{formatFixGroupLabel(fixGroup)}</span>
+              <span className="issue-bucket-count">{fixGroup.rows.length} {fixGroup.rows.length === 1 ? 'item' : 'items'}</span>
+            </div>
+            <div className="issue-bucket-rows">
+              {fixGroup.rows.map((row) => (
+                <div className="skill-fix-row" key={row.key}>
+                  <span className="skill-fix-name">{row.name}</span>
+                  <span className="skill-fix-action">{FIX_ACTION_LABELS[fixGroup.issue] ?? fixGroup.issue}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="review-footer">
+        <span className="review-footer-summary">{totalIssues} {totalIssues === 1 ? 'repair' : 'repairs'} · {totalItems} {totalItems === 1 ? 'item' : 'items'} affected</span>
+        <button className="review-footer-cancel" type="button" onClick={onCancel}>
+          Cancel
+        </button>
+        <button
+          className={`review-footer-confirm${isAutoResolving ? ' review-footer-confirm--busy' : ''}`}
+          disabled={isAutoResolving}
+          type="button"
+          onClick={onAutoResolve}
+        >
+          {isAutoResolving ? (
+            'Applying…'
+          ) : (
+            <>
+              <Check />
+              Apply {totalIssues} {totalIssues === 1 ? 'repair' : 'repairs'}
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ScopedAutoRepairControl({
+  activeIssueCount,
+  autoResolvableRequests,
+  inventorySnapshot,
+  isAutoResolving,
+  onAutoResolve,
+}: {
+  activeIssueCount: number;
+  autoResolvableRequests: ResolveIssueRequest[];
+  inventorySnapshot: SkillInventorySnapshot | null;
+  isAutoResolving: boolean;
+  onAutoResolve: () => void;
+}) {
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const reviewPanelId = useId();
+  const { totalIssues } = getAutoRepairSummary(autoResolvableRequests);
+
+  useEffect(() => {
+    if (!reviewOpen) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setReviewOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setReviewOpen(false);
+      }
+    };
+
+    window.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [reviewOpen]);
+
+  useEffect(() => {
+    if (autoResolvableRequests.length === 0) {
+      setReviewOpen(false);
+    }
+  }, [autoResolvableRequests.length]);
+
+  if (totalIssues === 0 && activeIssueCount > 0) {
+    return (
+      <div className="scoped-repair-control">
+        <div
+          aria-label={`${activeIssueCount} ${activeIssueCount === 1 ? 'issue needs' : 'issues need'} manual review. No safe auto-resolutions available.`}
+          className="scoped-repair-empty"
+          role="status"
+          title={`${activeIssueCount} ${activeIssueCount === 1 ? 'issue needs' : 'issues need'} manual review.`}
+        >
+          <Info aria-hidden="true" />
+          <span>No safe auto-resolutions</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (totalIssues === 0) {
+    return null;
+  }
+
+  return (
+    <div className="scoped-repair-control" ref={rootRef}>
+      <button
+        aria-controls={reviewPanelId}
+        aria-expanded={reviewOpen}
+        className="scoped-repair-trigger"
+        disabled={isAutoResolving}
+        type="button"
+        onClick={() => setReviewOpen((current) => !current)}
+      >
+        <Wrench aria-hidden="true" />
+        <span>
+          Review {totalIssues} safe{' '}
+          {totalIssues === 1 ? 'auto-resolution' : 'auto-resolutions'}
+        </span>
+        <ChevronDown aria-hidden="true" />
+      </button>
+
+      {reviewOpen ? (
+        <div className="scoped-repair-popover">
+          <AutoRepairReviewPanel
+            autoResolvableRequests={autoResolvableRequests}
+            id={reviewPanelId}
+            inventorySnapshot={inventorySnapshot}
+            isAutoResolving={isAutoResolving}
+            onAutoResolve={onAutoResolve}
+            onCancel={() => setReviewOpen(false)}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function getResolveRequestDisplayName(
+  request: ResolveIssueRequest,
+  inventorySnapshot: SkillInventorySnapshot | null,
+): string {
+  if (request.entity === 'skill') {
+    const skill = inventorySnapshot?.skills.find((entry) => entry.name === request.skillName);
+    return skill ? getSkillDisplayName(skill) : request.skillName;
+  }
+
+  if (request.entity === 'subagent') {
+    const subagent = inventorySnapshot?.subagents?.find((entry) => entry.name === request.subagentName);
+    return subagent?.displayName ?? request.subagentName;
+  }
+
+  const mcp = inventorySnapshot?.mcps?.find((entry) => entry.name === request.mcpName);
+  return mcp ? getMcpDisplayName(mcp) : request.mcpName;
+}
+
+function getResolveRequestKey(request: ResolveIssueRequest): string {
+  return [
+    request.entity,
+    request.skillName ?? request.mcpName ?? request.subagentName,
+    request.issue,
+    request.selectedVariantPath ?? '',
+  ].join(':');
+}
+
+function getFixGroupKey(request: ResolveIssueRequest): string {
+  return `${request.entity}:${request.issue}`;
+}
+
+function formatFixGroupLabel(group: Pick<PlannedFixGroup, 'entity' | 'issue'>): string {
+  return `${FIX_ENTITY_LABELS[group.entity]} • ${FIX_TYPE_LABELS[group.issue] ?? group.issue}`;
+}

--- a/src/renderer/src/components/AutoRepairReview.tsx
+++ b/src/renderer/src/components/AutoRepairReview.tsx
@@ -176,7 +176,6 @@ export function ScopedAutoRepairControl({
         <div
           aria-label={`${activeIssueCount} ${activeIssueCount === 1 ? 'issue needs' : 'issues need'} manual review. No safe auto-resolutions available.`}
           className="scoped-repair-empty"
-          role="status"
           title={`${activeIssueCount} ${activeIssueCount === 1 ? 'issue needs' : 'issues need'} manual review.`}
         >
           <Info aria-hidden="true" />

--- a/src/renderer/src/lib/auto-repair.ts
+++ b/src/renderer/src/lib/auto-repair.ts
@@ -1,0 +1,40 @@
+import type { ResolveIssueRequest, SkillInventorySnapshot } from '@shared/contracts';
+
+import { getDisplaySkillIssueReasons } from './inventory-presentation';
+
+export interface AutoRepairSummary {
+  totalIssues: number;
+  totalItems: number;
+}
+
+export function getAutoRepairSummary(autoResolvableRequests: ResolveIssueRequest[]): AutoRepairSummary {
+  return {
+    totalIssues: autoResolvableRequests.length,
+    totalItems: new Set(autoResolvableRequests.map((request) =>
+      request.skillName ?? request.mcpName ?? request.subagentName)).size,
+  };
+}
+
+export function getActiveIssueCountForAutoRepairScope(
+  inventorySnapshot: SkillInventorySnapshot | null,
+  entity: ResolveIssueRequest['entity'],
+): number {
+  if (!inventorySnapshot) {
+    return 0;
+  }
+
+  switch (entity) {
+    case 'skill':
+      return inventorySnapshot.skills
+        .filter((skill) => skill.driftPresentation === 'active')
+        .reduce((count, skill) => count + getDisplaySkillIssueReasons(skill).length, 0);
+    case 'mcp':
+      return (inventorySnapshot.mcps ?? [])
+        .filter((mcp) => mcp.presentation === 'active' && mcp.status === 'needs-attention')
+        .reduce((count, mcp) => count + mcp.issueReasons.length, 0);
+    case 'subagent':
+      return (inventorySnapshot.subagents ?? [])
+        .filter((subagent) => subagent.presentation === 'active' && subagent.status === 'needs-attention')
+        .reduce((count, subagent) => count + subagent.issueReasons.length, 0);
+  }
+}

--- a/src/renderer/src/lib/issue-resolution.test.ts
+++ b/src/renderer/src/lib/issue-resolution.test.ts
@@ -233,6 +233,130 @@ describe('issue resolution request builder', () => {
     expect(getAutoResolvableMcpRequests(snapshot)).toEqual([]);
   });
 
+  it('includes non-plugin missing-universal MCP repairs when one definition can be inferred', () => {
+    const mcp: McpRecord = {
+      name: 'local-only-mcp',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['missing-universal'],
+      locations: [
+        {
+          agentId: 'sandbox-factory',
+          agentLabel: 'Factory',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/.factory/mcp.json',
+          configName: 'local-only-mcp',
+          transport: 'stdio',
+          command: 'node',
+          args: ['local-only.js'],
+          definitionText: '{\n  "command": "node",\n  "args": ["local-only.js"],\n  "disabled": false\n}',
+          definitionComparisonKey: '{"args":["local-only.js"],"command":"node","transport":"stdio"}',
+          nativeDefinition: {
+            disabled: false,
+          },
+          agentLocalKey: 'factory',
+          mutability: 'writable',
+        },
+      ],
+    };
+    const snapshot: SkillInventorySnapshot = {
+      ...representativeInventorySnapshot,
+      mcps: [mcp],
+    };
+
+    expect(getAutoResolvableMcpRequests(snapshot)).toEqual([
+      {
+        entity: 'mcp',
+        issue: 'missing-universal',
+        mcpName: 'local-only-mcp',
+        selectedVariantPath: '~/.skillindex/sandbox/.factory/mcp.json',
+      },
+    ]);
+  });
+
+  it('keeps ambiguous missing-universal MCP repairs out of Home auto-resolve batches', () => {
+    const mcp: McpRecord = {
+      name: 'ambiguous-local-mcp',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['missing-universal', 'definition-mismatch'],
+      locations: [
+        {
+          agentId: 'sandbox-claude',
+          agentLabel: 'Claude Code',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/.claude.json',
+          configName: 'ambiguous-local-mcp',
+          transport: 'stdio',
+          command: 'node',
+          args: ['claude.js'],
+          definitionText: '{"command":"node","args":["claude.js"]}',
+          definitionComparisonKey: '{"args":["claude.js"],"command":"node","transport":"stdio"}',
+          mutability: 'writable',
+        },
+        {
+          agentId: 'sandbox-factory',
+          agentLabel: 'Factory',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/.factory/mcp.json',
+          configName: 'ambiguous-local-mcp',
+          transport: 'stdio',
+          command: 'node',
+          args: ['factory.js'],
+          definitionText: '{"command":"node","args":["factory.js"]}',
+          definitionComparisonKey: '{"args":["factory.js"],"command":"node","transport":"stdio"}',
+          mutability: 'writable',
+        },
+      ],
+    };
+    const snapshot: SkillInventorySnapshot = {
+      ...representativeInventorySnapshot,
+      mcps: [mcp],
+    };
+
+    expect(getAutoResolvableMcpRequests(snapshot)).toEqual([]);
+  });
+
+  it('keeps plugin-owned missing-universal MCP repairs out of Home auto-resolve batches', () => {
+    const mcp: McpRecord = {
+      name: 'tools:plugin-mcp',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['missing-universal'],
+      locations: [
+        {
+          agentId: 'plugin:sandbox:codex:tools@market:1.0.0',
+          agentLabel: 'Codex Plugin tools',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/.codex/plugins/cache/tools/1.0.0/.mcp.json',
+          configName: 'plugin-mcp',
+          transport: 'stdio',
+          command: 'node',
+          args: ['plugin.js'],
+          definitionText: '{"command":"node","args":["plugin.js"]}',
+          definitionComparisonKey: '{"args":["plugin.js"],"command":"node","transport":"stdio"}',
+          provenance: {
+            kind: 'plugin',
+            plugin: {
+              host: 'codex',
+              pluginId: 'tools@market',
+              version: '1.0.0',
+            },
+            sourcePath: '~/.skillindex/sandbox/.codex/plugins/cache/tools/1.0.0/.mcp.json',
+            discoveredAt: '2026-05-01T00:00:00.000Z',
+          },
+          mutability: 'read-only-managed',
+        },
+      ],
+    };
+    const snapshot: SkillInventorySnapshot = {
+      ...representativeInventorySnapshot,
+      mcps: [mcp],
+    };
+
+    expect(getAutoResolvableMcpRequests(snapshot)).toEqual([]);
+  });
+
   it('builds a missing-symlink skill request without forcing diverged selection when canonical exists', () => {
     const baseSkill = representativeInventorySnapshot.skills.find((entry) => entry.name === 'diagnostic-rich-skill')!;
     const skill: SkillRecord = {

--- a/src/renderer/src/lib/issue-resolution.ts
+++ b/src/renderer/src/lib/issue-resolution.ts
@@ -577,7 +577,7 @@ export function getAutoResolvableMcpRequests(
   const sourceIndex = new Map(snapshot.sources.map((source) => [source.id, source]));
 
   for (const mcp of snapshot.mcps ?? []) {
-    if (mcp.presentation !== 'active' || !mcp.issueReasons.includes('missing-from-agents')) {
+    if (mcp.presentation !== 'active') {
       continue;
     }
 
@@ -586,6 +586,27 @@ export function getAutoResolvableMcpRequests(
     }
 
     if (hasMcpMultipleResolutionScopes(mcp)) {
+      continue;
+    }
+
+    if (mcp.issueReasons.includes('missing-universal')
+      && !mcp.issueReasons.includes('definition-mismatch')
+      && !mcp.issueReasons.includes('invalid-definition')) {
+      const selectedVariantPath = getMcpSelectedVariantPath(mcp, null, 'missing-universal', snapshot);
+      const selectedLocation = selectedVariantPath
+        ? mcp.locations.find((location) => location.configPath === selectedVariantPath)
+        : null;
+      if (selectedVariantPath && selectedLocation && canWriteUniversalMcpTargetForScope(snapshot, selectedLocation.scope)) {
+        requests.push({
+          entity: 'mcp',
+          issue: 'missing-universal',
+          mcpName: mcp.name,
+          selectedVariantPath,
+        });
+      }
+    }
+
+    if (!mcp.issueReasons.includes('missing-from-agents')) {
       continue;
     }
 
@@ -613,6 +634,15 @@ export function getAutoResolvableMcpRequests(
   }
 
   return requests;
+}
+
+function canWriteUniversalMcpTargetForScope(
+  snapshot: SkillInventorySnapshot,
+  scope: McpRecord['locations'][number]['scope'],
+): boolean {
+  return scope === 'live'
+    || scope === 'sandbox'
+    || snapshot.sources.some((source) => source.canonical && source.writable && source.scope === scope);
 }
 
 const AUTO_RESOLVABLE_SUBAGENT_ISSUES: Set<SubagentResolvableIssue> = new Set([

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1245,6 +1245,92 @@ body {
   height: 11px;
 }
 
+.scoped-repair-control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.scoped-repair-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid color-mix(in srgb, var(--action) 28%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--action) 8%, #fff);
+  color: var(--text-strong);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.scoped-repair-trigger:hover:not(:disabled),
+.scoped-repair-trigger[aria-expanded="true"] {
+  border-color: color-mix(in srgb, var(--action) 42%, transparent);
+  background: color-mix(in srgb, var(--action) 13%, #fff);
+}
+
+.scoped-repair-trigger:disabled {
+  opacity: 0.64;
+  cursor: default;
+}
+
+.scoped-repair-trigger svg {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+}
+
+.scoped-repair-empty {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  background: rgba(245, 246, 248, 0.78);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+  white-space: nowrap;
+}
+
+.scoped-repair-empty svg {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+}
+
+.scoped-repair-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 30;
+  width: min(560px, calc(100vw - 68px));
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 18px 44px rgba(36, 38, 43, 0.16);
+  overflow: hidden;
+}
+
+.scoped-repair-popover .review-panel {
+  border-top: none;
+}
+
+.scoped-repair-popover .review-panel--open {
+  max-height: min(520px, 70vh);
+}
+
 /* Canonical source */
 .canonical-source-card {
   display: grid;
@@ -1561,6 +1647,7 @@ body {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
+  gap: 12px;
 }
 
 .inventory-keyboard-hint {

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -20,6 +20,7 @@ import {
   getDisplaySkillIssueReasons,
   formatLastScanLabel,
 } from '../lib/inventory-presentation';
+import { AutoRepairReviewPanel } from '../components/AutoRepairReview';
 import {
   EmptyStatePanel,
   PageTopBar,
@@ -29,43 +30,7 @@ import {
   PluginTooltipIndicator,
   RescanToolbarButton,
 } from '../components/ui';
-
-const FIX_ACTION_LABELS: Record<string, string> = {
-  'missing-symlinks': 'Create missing symlinks',
-  'identical-copies': 'Convert copies to symlinks',
-  'missing-canonical': 'Promote to universal',
-  'missing-universal': 'Promote to universal',
-  'broken-symlink': 'Relink to canonical',
-  'wrong-symlink-target': 'Relink to canonical',
-  'missing-from-agents': 'Add to missing agents',
-};
-
-const FIX_TYPE_LABELS: Record<string, string> = {
-  'missing-symlinks': 'Missing Symlinks',
-  'identical-copies': 'Identical Copies',
-  'missing-canonical': 'Missing Universal',
-  'missing-universal': 'Missing Universal',
-  'broken-symlink': 'Broken Symlink',
-  'wrong-symlink-target': 'Wrong Symlink Target',
-  'missing-from-agents': 'Missing From Agents',
-};
-
-const FIX_ENTITY_LABELS: Record<ResolveIssueRequest['entity'], string> = {
-  skill: 'Skills',
-  mcp: 'MCPs',
-  subagent: 'Subagents',
-};
-
-interface PlannedFixRow {
-  key: string;
-  name: string;
-}
-
-interface PlannedFixGroup {
-  entity: ResolveIssueRequest['entity'];
-  issue: ResolveIssueRequest['issue'];
-  rows: PlannedFixRow[];
-}
+import { getAutoRepairSummary } from '../lib/auto-repair';
 
 interface HomeMetric {
   key: string;
@@ -102,32 +67,6 @@ interface HomeAttentionGroup {
 
 const EMPTY_HOME_METRIC = { total: 0, healthy: 0, needsAttention: 0 };
 
-function getResolveRequestDisplayName(
-  request: ResolveIssueRequest,
-  inventorySnapshot: SkillInventorySnapshot | null,
-): string {
-  if (request.entity === 'skill') {
-    const skill = inventorySnapshot?.skills.find((entry) => entry.name === request.skillName);
-    return skill ? getSkillDisplayName(skill) : request.skillName;
-  }
-
-  if (request.entity === 'subagent') {
-    return request.subagentName;
-  }
-
-  const mcp = inventorySnapshot?.mcps?.find((entry) => entry.name === request.mcpName);
-  return mcp ? getMcpDisplayName(mcp) : request.mcpName;
-}
-
-function getResolveRequestKey(request: ResolveIssueRequest): string {
-  return [
-    request.entity,
-    request.skillName ?? request.mcpName ?? request.subagentName,
-    request.issue,
-    request.selectedVariantPath ?? '',
-  ].join(':');
-}
-
 function getActiveIssueCount(inventorySnapshot: SkillInventorySnapshot | null): number {
   if (!inventorySnapshot) {
     return 0;
@@ -143,14 +82,6 @@ function getActiveIssueCount(inventorySnapshot: SkillInventorySnapshot | null): 
     .filter((subagent) => subagent.presentation === 'active' && subagent.status === 'needs-attention')
     .reduce((count, subagent) => count + subagent.issueReasons.length, 0);
   return skillIssueCount + mcpIssueCount + subagentIssueCount;
-}
-
-function getFixGroupKey(request: ResolveIssueRequest): string {
-  return `${request.entity}:${request.issue}`;
-}
-
-function formatFixGroupLabel(group: Pick<PlannedFixGroup, 'entity' | 'issue'>): string {
-  return `${FIX_ENTITY_LABELS[group.entity]} • ${FIX_TYPE_LABELS[group.issue] ?? group.issue}`;
 }
 
 function HomeInventoryMetrics({ metrics }: { metrics: HomeMetric[] }) {
@@ -317,24 +248,7 @@ function RepairSurface({
 }) {
   const [reviewOpen, setReviewOpen] = useState(false);
   const reviewPanelId = 'home-auto-repair-review-panel';
-
-  const fixesByType = autoResolvableRequests.reduce<Map<string, PlannedFixGroup>>((acc, req) => {
-    const groupKey = getFixGroupKey(req);
-    const group = acc.get(groupKey) ?? {
-      entity: req.entity,
-      issue: req.issue,
-      rows: [],
-    };
-    group.rows.push({
-      key: getResolveRequestKey(req),
-      name: getResolveRequestDisplayName(req, inventorySnapshot),
-    });
-    acc.set(groupKey, group);
-    return acc;
-  }, new Map());
-
-  const totalIssues = autoResolvableRequests.length;
-  const totalItems = new Set(autoResolvableRequests.map((r) => r.skillName ?? r.mcpName ?? r.subagentName)).size;
+  const { totalIssues, totalItems } = getAutoRepairSummary(autoResolvableRequests);
   const manualIssueCount = Math.max(0, getActiveIssueCount(inventorySnapshot) - totalIssues);
 
   if (autoResolvableRequests.length === 0 && !hasAttentionIssues) {
@@ -405,50 +319,14 @@ function RepairSurface({
       </div>
 
       {reviewOpen ? (
-        <div className="review-panel review-panel--open" id={reviewPanelId}>
-          <div className="review-header">
-            <span className="review-header-title">Review planned fixes</span>
-          </div>
-          <div className="review-body">
-            {[...fixesByType.values()].map((fixGroup) => (
-              <div className="issue-bucket" key={`${fixGroup.entity}:${fixGroup.issue}`}>
-                <div className="issue-bucket-header">
-                  <span className="issue-bucket-label">{formatFixGroupLabel(fixGroup)}</span>
-                  <span className="issue-bucket-count">{fixGroup.rows.length} {fixGroup.rows.length === 1 ? 'item' : 'items'}</span>
-                </div>
-                <div className="issue-bucket-rows">
-                  {fixGroup.rows.map((row) => (
-                    <div className="skill-fix-row" key={row.key}>
-                      <span className="skill-fix-name">{row.name}</span>
-                      <span className="skill-fix-action">{FIX_ACTION_LABELS[fixGroup.issue] ?? fixGroup.issue}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="review-footer">
-            <span className="review-footer-summary">{totalIssues} {totalIssues === 1 ? 'repair' : 'repairs'} · {totalItems} {totalItems === 1 ? 'item' : 'items'} affected</span>
-            <button className="review-footer-cancel" type="button" onClick={() => setReviewOpen(false)}>
-              Cancel
-            </button>
-            <button
-              className={`review-footer-confirm${isAutoResolving ? ' review-footer-confirm--busy' : ''}`}
-              disabled={isAutoResolving}
-              type="button"
-              onClick={onAutoResolve}
-            >
-              {isAutoResolving ? (
-                'Applying…'
-              ) : (
-                <>
-                  <Check />
-                  Apply {totalIssues} {totalIssues === 1 ? 'repair' : 'repairs'}
-                </>
-              )}
-            </button>
-          </div>
-        </div>
+        <AutoRepairReviewPanel
+          autoResolvableRequests={autoResolvableRequests}
+          id={reviewPanelId}
+          inventorySnapshot={inventorySnapshot}
+          isAutoResolving={isAutoResolving}
+          onAutoResolve={onAutoResolve}
+          onCancel={() => setReviewOpen(false)}
+        />
       ) : null}
     </div>
   );

--- a/src/renderer/src/views/InventoryViewChrome.test.tsx
+++ b/src/renderer/src/views/InventoryViewChrome.test.tsx
@@ -3,7 +3,7 @@ import { createRef, type ComponentProps } from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { McpRecord } from '@shared/contracts';
+import type { McpRecord, ResolveIssueRequest } from '@shared/contracts';
 
 import { representativeInventorySnapshot } from '../representative-preview-data';
 import { buildMcpInspectorModel, buildSkillInspectorModel, buildSubagentInspectorModel } from '../lib/detail-inspector-model';
@@ -13,14 +13,20 @@ import { SkillsWorkspaceView } from './SkillsWorkspaceView';
 import { SubagentsWorkspaceView } from './SubagentsWorkspaceView';
 
 function renderSkillsWorkspaceView({
+  autoResolvableRequests = [],
   inventorySnapshot = representativeInventorySnapshot,
+  isAutoResolving = false,
   isRescanning = false,
+  onAutoResolve = vi.fn(),
   rows = representativeInventorySnapshot.skills,
   searchQuery = '',
   statusFilter = 'all',
 }: {
+  autoResolvableRequests?: ResolveIssueRequest[];
   inventorySnapshot?: typeof representativeInventorySnapshot;
+  isAutoResolving?: boolean;
   isRescanning?: boolean;
+  onAutoResolve?: () => void;
   rows?: typeof representativeInventorySnapshot.skills;
   searchQuery?: string;
   statusFilter?: 'all' | 'active' | 'dismissed' | 'none';
@@ -28,10 +34,13 @@ function renderSkillsWorkspaceView({
   return render(
     <SkillsWorkspaceView
       inventorySnapshot={inventorySnapshot}
+      autoResolvableRequests={autoResolvableRequests}
+      isAutoResolving={isAutoResolving}
       isDismissingDrift={false}
       isApplyingCapabilityAction={false}
       isResolvingIssue={false}
       isRescanning={isRescanning}
+      onAutoResolve={onAutoResolve}
       onClearSelection={vi.fn()}
       onDismissDrift={vi.fn(() => Promise.resolve())}
       onApplyCapabilityAction={vi.fn(() => Promise.resolve())}
@@ -58,20 +67,26 @@ function renderSkillsWorkspaceView({
 }
 
 function renderMcpWorkspaceView({
+  autoResolvableRequests = [],
   inventorySnapshot = representativeInventorySnapshot,
+  isAutoResolving = false,
   isRescanning = false,
   mcp = null,
   mcpInspectorModel = null,
+  onAutoResolve = vi.fn(),
   onOpenPluginSource = vi.fn(),
   onSelectMcp = vi.fn(),
   rows = representativeInventorySnapshot.mcps ?? [],
   searchQuery = '',
   statusFilter = 'all',
 }: {
+  autoResolvableRequests?: ResolveIssueRequest[];
   inventorySnapshot?: typeof representativeInventorySnapshot;
+  isAutoResolving?: boolean;
   isRescanning?: boolean;
   mcp?: McpRecord | null;
   mcpInspectorModel?: ReturnType<typeof buildMcpInspectorModel> | null;
+  onAutoResolve?: () => void;
   onOpenPluginSource?: (action: Parameters<NonNullable<ComponentProps<typeof McpWorkspaceView>['onOpenPluginSource']>>[0]) => void;
   onSelectMcp?: (name: string | null) => void;
   rows?: NonNullable<typeof representativeInventorySnapshot.mcps>;
@@ -80,13 +95,16 @@ function renderMcpWorkspaceView({
 } = {}) {
   render(
     <McpWorkspaceView
+      autoResolvableRequests={autoResolvableRequests}
       inventorySnapshot={inventorySnapshot}
+      isAutoResolving={isAutoResolving}
       isDismissingDrift={false}
       isResolvingIssue={false}
       isRescanning={isRescanning}
       mcp={mcp}
       mcpInspectorModel={mcpInspectorModel}
       sandboxRoot={null}
+      onAutoResolve={onAutoResolve}
       onClearSelection={vi.fn()}
       onDismissDrift={vi.fn(() => Promise.resolve())}
       onOpenPluginSource={onOpenPluginSource}
@@ -106,8 +124,11 @@ function renderMcpWorkspaceView({
 }
 
 function renderSubagentsWorkspaceView({
+  autoResolvableRequests = [],
   inventorySnapshot = representativeInventorySnapshot,
+  isAutoResolving = false,
   isRescanning = false,
+  onAutoResolve = vi.fn(),
   onOpenPluginSource = vi.fn(),
   rows = representativeInventorySnapshot.subagents ?? [],
   searchQuery = '',
@@ -116,8 +137,11 @@ function renderSubagentsWorkspaceView({
   selectedSubagentProblemKey = null,
   statusFilter = 'all',
 }: {
+  autoResolvableRequests?: ResolveIssueRequest[];
   inventorySnapshot?: typeof representativeInventorySnapshot;
+  isAutoResolving?: boolean;
   isRescanning?: boolean;
+  onAutoResolve?: () => void;
   onOpenPluginSource?: (action: Parameters<NonNullable<ComponentProps<typeof SubagentsWorkspaceView>['onOpenPluginSource']>>[0]) => void;
   rows?: NonNullable<typeof representativeInventorySnapshot.subagents>;
   searchQuery?: string;
@@ -128,10 +152,13 @@ function renderSubagentsWorkspaceView({
 } = {}) {
   render(
     <SubagentsWorkspaceView
+      autoResolvableRequests={autoResolvableRequests}
       inventorySnapshot={inventorySnapshot}
+      isAutoResolving={isAutoResolving}
       isDismissingDrift={false}
       isResolvingIssue={false}
       isRescanning={isRescanning}
+      onAutoResolve={onAutoResolve}
       onClearSelection={vi.fn()}
       onDismissDrift={vi.fn(() => Promise.resolve())}
       onOpenPluginSource={onOpenPluginSource}
@@ -218,6 +245,72 @@ describe('inventory view chrome', () => {
     expect(screen.queryByRole('button', { name: 'Filter' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /broken-mcp/i }).querySelector('p')).toBeNull();
     expect(screen.getByRole('button', { name: /healthy-mcp/i }).querySelector('p')).toBeNull();
+  });
+
+  it('shows a scoped empty state when MCP issues remain but no safe auto-resolutions are available', () => {
+    renderMcpWorkspaceView();
+
+    expect(screen.getByRole('toolbar', { name: 'MCP filters' })).toBeInTheDocument();
+    expect(screen.getByText('No safe auto-resolutions')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Review \d+ safe auto-resolution/i })).not.toBeInTheDocument();
+  });
+
+  it('hides the scoped auto-resolution affordance when the MCP tab is clean', () => {
+    const inventorySnapshot = structuredClone(representativeInventorySnapshot);
+    inventorySnapshot.mcps = inventorySnapshot.mcps?.map((mcp) => ({
+      ...mcp,
+      issueReasons: [],
+      presentation: 'none',
+      status: 'healthy',
+    }));
+    inventorySnapshot.mcpCounts = inventorySnapshot.mcpCounts
+      ? {
+          ...inventorySnapshot.mcpCounts,
+          attentionMcps: 0,
+          dismissedAttentionMcps: 0,
+          healthyMcps: inventorySnapshot.mcpCounts.totalMcps,
+        }
+      : undefined;
+
+    renderMcpWorkspaceView({
+      inventorySnapshot,
+      rows: inventorySnapshot.mcps ?? [],
+    });
+
+    expect(screen.getByRole('toolbar', { name: 'MCP filters' })).toBeInTheDocument();
+    expect(screen.queryByText('No safe auto-resolutions')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Review \d+ safe auto-resolution/i })).not.toBeInTheDocument();
+  });
+
+  it('shows scoped safe repairs in the MCP filter bar without replacing the Home review panel', () => {
+    const onAutoResolve = vi.fn();
+    renderMcpWorkspaceView({
+      autoResolvableRequests: [
+        {
+          entity: 'mcp',
+          issue: 'missing-universal',
+          mcpName: 'local-only-mcp',
+          selectedVariantPath: '~/.skillindex/sandbox/.factory/mcp.json',
+        },
+      ],
+      onAutoResolve,
+    });
+
+    expect(screen.getByRole('toolbar', { name: 'MCP filters' })).toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: /Review 1 safe auto-resolution/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Review planned fixes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Auto-resolve issues with safe resolutions')).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Review planned fixes')).toBeInTheDocument();
+    expect(screen.getByText('MCPs • Missing Universal')).toBeInTheDocument();
+    expect(screen.getByText('Add to Universal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply 1 repair/i }));
+    expect(onAutoResolve).toHaveBeenCalledTimes(1);
   });
 
   it('renders Subagent details with the shared inspector chrome used by Skills', () => {

--- a/src/renderer/src/views/McpWorkspaceView.tsx
+++ b/src/renderer/src/views/McpWorkspaceView.tsx
@@ -17,8 +17,10 @@ import {
   getMcpStatusLabels,
   type McpStatusFilter,
 } from '../lib/inventory-presentation';
+import { getActiveIssueCountForAutoRepairScope } from '../lib/auto-repair';
 import { getMcpResolveActionState } from '../lib/issue-resolution';
 import type { InspectorModel, InspectorProvenanceSummaryRow } from '../lib/detail-inspector-model';
+import { ScopedAutoRepairControl } from '../components/AutoRepairReview';
 import { DetailInspectorPanel } from '../components/DetailInspectorPanel';
 import {
   EmptyStatePanel,
@@ -34,7 +36,9 @@ import {
 
 export function McpWorkspaceView({
   addActionControl,
+  autoResolvableRequests = [],
   inventorySnapshot,
+  isAutoResolving = false,
   isDismissingDrift,
   isResolvingIssue,
   isRemovingInventoryItem = false,
@@ -42,6 +46,7 @@ export function McpWorkspaceView({
   mcp,
   mcpInspectorModel,
   sandboxRoot,
+  onAutoResolve = () => undefined,
   onCancelMcpConnectivityTest,
   onClearSelection,
   onDismissDrift,
@@ -60,7 +65,9 @@ export function McpWorkspaceView({
   statusFilter,
 }: {
   addActionControl?: ReactNode;
+  autoResolvableRequests?: ResolveIssueRequest[];
   inventorySnapshot: SkillInventorySnapshot | null;
+  isAutoResolving?: boolean;
   isDismissingDrift: boolean;
   isResolvingIssue: boolean;
   isRemovingInventoryItem?: boolean;
@@ -68,6 +75,7 @@ export function McpWorkspaceView({
   mcp: McpRecord | null;
   mcpInspectorModel: InspectorModel | null;
   sandboxRoot: string | null;
+  onAutoResolve?: () => void;
   onCancelMcpConnectivityTest?: () => void;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
@@ -137,7 +145,18 @@ export function McpWorkspaceView({
             ariaLabel="MCP filters"
             filters={filters}
             onFilterChange={onStatusFilterChange}
-            trailing={<InventoryKeyboardHint />}
+            trailing={(
+              <>
+                <ScopedAutoRepairControl
+                  activeIssueCount={getActiveIssueCountForAutoRepairScope(inventorySnapshot, 'mcp')}
+                  autoResolvableRequests={autoResolvableRequests}
+                  inventorySnapshot={inventorySnapshot}
+                  isAutoResolving={isAutoResolving}
+                  onAutoResolve={onAutoResolve}
+                />
+                <InventoryKeyboardHint />
+              </>
+            )}
           />
 
           <div className={`split-workspace split-workspace--detail${mcp ? '' : ' split-workspace--detail-collapsed'}`}>

--- a/src/renderer/src/views/SkillsWorkspaceView.tsx
+++ b/src/renderer/src/views/SkillsWorkspaceView.tsx
@@ -19,8 +19,10 @@ import {
   getSkillRowDescription,
   type SkillStatusFilter,
 } from '../lib/inventory-presentation';
+import { getActiveIssueCountForAutoRepairScope } from '../lib/auto-repair';
 import { getSkillResolveActionState } from '../lib/issue-resolution';
 import type { InspectorLocationAction, InspectorModel, InspectorProvenanceSummaryRow } from '../lib/detail-inspector-model';
+import { ScopedAutoRepairControl } from '../components/AutoRepairReview';
 import { DetailInspectorPanel } from '../components/DetailInspectorPanel';
 import {
   EmptyStatePanel,
@@ -35,13 +37,16 @@ import {
 } from '../components/ui';
 
 export function SkillsWorkspaceView({
+  autoResolvableRequests = [],
   inventorySnapshot,
+  isAutoResolving = false,
   isDismissingDrift,
   isApplyingCapabilityAction,
   isResolvingIssue,
   isRemovingInventoryItem = false,
   isRescanning,
   onCancelMcpConnectivityTest,
+  onAutoResolve = () => undefined,
   onClearSelection,
   onDismissDrift,
   onApplyCapabilityAction,
@@ -66,13 +71,16 @@ export function SkillsWorkspaceView({
   statusFilter,
   addActionControl,
 }: {
+  autoResolvableRequests?: ResolveIssueRequest[];
   inventorySnapshot: SkillInventorySnapshot | null;
+  isAutoResolving?: boolean;
   isDismissingDrift: boolean;
   isApplyingCapabilityAction: boolean;
   isResolvingIssue: boolean;
   isRemovingInventoryItem?: boolean;
   isRescanning: boolean;
   onCancelMcpConnectivityTest?: () => void;
+  onAutoResolve?: () => void;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
   onApplyCapabilityAction: (request: CapabilityActionRequest) => Promise<void>;
@@ -156,7 +164,18 @@ export function SkillsWorkspaceView({
               setSelectionOverrideSkillName(null);
               setStatusFilter(value);
             }}
-            trailing={<InventoryKeyboardHint />}
+            trailing={(
+              <>
+                <ScopedAutoRepairControl
+                  activeIssueCount={getActiveIssueCountForAutoRepairScope(inventorySnapshot, 'skill')}
+                  autoResolvableRequests={autoResolvableRequests}
+                  inventorySnapshot={inventorySnapshot}
+                  isAutoResolving={isAutoResolving}
+                  onAutoResolve={onAutoResolve}
+                />
+                <InventoryKeyboardHint />
+              </>
+            )}
           />
 
           <div className={`split-workspace split-workspace--detail${selectedSkill ? '' : ' split-workspace--detail-collapsed'}`}>

--- a/src/renderer/src/views/SubagentsWorkspaceView.tsx
+++ b/src/renderer/src/views/SubagentsWorkspaceView.tsx
@@ -20,8 +20,10 @@ import {
   getSubagentStatusLabels,
   type SubagentStatusFilter,
 } from '../lib/inventory-presentation';
+import { getActiveIssueCountForAutoRepairScope } from '../lib/auto-repair';
 import type { InspectorModel, InspectorProvenanceSummaryRow } from '../lib/detail-inspector-model';
 import { getSubagentResolveActionState } from '../lib/issue-resolution';
+import { ScopedAutoRepairControl } from '../components/AutoRepairReview';
 import { DetailInspectorPanel } from '../components/DetailInspectorPanel';
 import {
   EmptyStatePanel,
@@ -37,11 +39,14 @@ import {
 
 export function SubagentsWorkspaceView({
   addActionControl,
+  autoResolvableRequests = [],
   inventorySnapshot,
+  isAutoResolving = false,
   isDismissingDrift,
   isResolvingIssue,
   isRemovingInventoryItem = false,
   isRescanning,
+  onAutoResolve = () => undefined,
   onCancelMcpConnectivityTest,
   onClearSelection,
   onDismissDrift,
@@ -64,11 +69,14 @@ export function SubagentsWorkspaceView({
   statusFilter,
 }: {
   addActionControl?: ReactNode;
+  autoResolvableRequests?: ResolveIssueRequest[];
   inventorySnapshot: SkillInventorySnapshot | null;
+  isAutoResolving?: boolean;
   isDismissingDrift: boolean;
   isResolvingIssue: boolean;
   isRemovingInventoryItem?: boolean;
   isRescanning: boolean;
+  onAutoResolve?: () => void;
   onCancelMcpConnectivityTest?: () => void;
   onClearSelection: () => void;
   onDismissDrift: (request: DismissDriftRequest) => Promise<void>;
@@ -142,7 +150,18 @@ export function SubagentsWorkspaceView({
           ariaLabel="Subagent filters"
           filters={filters}
           onFilterChange={onStatusFilterChange}
-          trailing={<InventoryKeyboardHint />}
+          trailing={(
+            <>
+              <ScopedAutoRepairControl
+                activeIssueCount={getActiveIssueCountForAutoRepairScope(inventorySnapshot, 'subagent')}
+                autoResolvableRequests={autoResolvableRequests}
+                inventorySnapshot={inventorySnapshot}
+                isAutoResolving={isAutoResolving}
+                onAutoResolve={onAutoResolve}
+              />
+              <InventoryKeyboardHint />
+            </>
+          )}
         />
 
         <div className={`split-workspace split-workspace--detail${selectedSubagent ? '' : ' split-workspace--detail-collapsed'}`}>


### PR DESCRIPTION
Changes:

Adds scoped auto-resolution controls to the Skills, MCPs, and Subagents tabs, reusing the shared review panel from Home. Safe non-plugin MCP Missing Universal cases are now auto-resolvable, and tabs show a quiet No safe auto-resolutions state when issues remain but only manual review is available.

Validation:
pnpm typecheck
pnpm lint
pnpm test src/renderer/src/lib/issue-resolution.test.ts src/renderer/src/views/InventoryViewChrome.test.tsx src/renderer/src/views/HomeDashboard.test.tsx
