### PR TITLE
Allow invalid subagents in structural repairs

### DIFF
--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -312,9 +312,7 @@ async function resolveSkillIssueIfCurrent(
   switch (request.issue) {
     case 'missing-canonical':
     case 'diverged-copies': {
-      const selectedSourcePath = pickSkillRealFileSelectionPath(skill, request.selectedVariantPath, {
-        requireSelectionOnAmbiguous: true,
-      });
+      const selectedSourcePath = pickSkillRealFileSelectionPath(skill, request.selectedVariantPath);
       await makeSkillCanonical(
         {
           skillName: request.skillName,
@@ -473,7 +471,6 @@ async function resolveMcpIssueIfCurrent(
   assertMcpResolutionScopeAllowed(mcp);
 
   const selectedVariant = pickMcpSelection(mcp.locations, request.selectedVariantPath, {
-    requireSelectionOnAmbiguous: request.issue === 'definition-mismatch' || request.issue === 'missing-universal',
     preferUniversal: request.issue === 'missing-from-agents',
   });
   const selectedDefinition = parseSelectedMcpDefinition(selectedVariant);
@@ -725,13 +722,11 @@ async function resolveSubagentIssueIfCurrent(
     case 'missing-universal': {
       const selectedLocation = pickSubagentSelection(subagent, request.selectedVariantPath, {
         allowInvalid: true,
-        requireSelectionOnAmbiguous: true,
       });
       const canonicalPath = isInvalidSubagentLocation(selectedLocation)
         ? await copySubagentLocationToCanonicalPath(subagent, selectedLocation, options.paths)
         : (await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
             preferExisting: false,
-            requireSelectionOnAmbiguous: true,
           })).path;
       const duplicateTargets = collectIdenticalMarkdownSubagentCopyTargets(subagent, snapshot, selectedLocation.definitionComparisonKey);
       await Promise.all(dedupeSubagentTargets(duplicateTargets).map((target) =>
@@ -742,7 +737,6 @@ async function resolveSubagentIssueIfCurrent(
       const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
         allowInvalid: true,
         preferExisting: true,
-        requireSelectionOnAmbiguous: true,
       });
       const targets = collectWritableMissingSubagentTargets(snapshot, subagent.missingLocations ?? []);
       await Promise.all(dedupeSubagentTargets(targets).map((target) =>
@@ -754,7 +748,6 @@ async function resolveSubagentIssueIfCurrent(
       const canonicalPath = canonicalLocation?.path
         ?? (await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
           preferExisting: true,
-          requireSelectionOnAmbiguous: false,
         })).path;
       const duplicateTargets = collectIdenticalMarkdownSubagentCopyTargets(
         subagent,
@@ -770,7 +763,6 @@ async function resolveSubagentIssueIfCurrent(
       const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
         allowInvalid: true,
         preferExisting: true,
-        requireSelectionOnAmbiguous: false,
       });
       const targets = subagent.locations
         .filter((location) =>
@@ -786,9 +778,7 @@ async function resolveSubagentIssueIfCurrent(
       return;
     }
     case 'definition-mismatch': {
-      const selectedLocation = pickSubagentSelection(subagent, request.selectedVariantPath, {
-        requireSelectionOnAmbiguous: true,
-      });
+      const selectedLocation = pickSubagentSelection(subagent, request.selectedVariantPath);
       const selectedDefinition = readPortableDefinitionForSubagentLocation(snapshot, subagent.name, selectedLocation);
       const canonicalPath = resolveCanonicalSubagentPath(subagent, selectedLocation, options.paths);
       const canonicalPackage: CanonicalSubagentPackage = {
@@ -837,7 +827,6 @@ async function ensureCanonicalSubagentPackage(
   behavior: {
     allowInvalid?: boolean;
     preferExisting: boolean;
-    requireSelectionOnAmbiguous: boolean;
   },
 ): Promise<CanonicalSubagentPackage> {
   const canonicalLocation = behavior.preferExisting
@@ -858,7 +847,6 @@ async function ensureCanonicalSubagentPackage(
 
   const selectedLocation = pickSubagentSelection(subagent, selectedVariantPath, {
     allowInvalid: behavior.allowInvalid,
-    requireSelectionOnAmbiguous: behavior.requireSelectionOnAmbiguous,
   });
   const definition = stripSubagentLocalExtras(
     readPortableDefinitionForSubagentLocation(snapshot, subagent.name, selectedLocation, {
@@ -909,7 +897,7 @@ function isInvalidSubagentLocation(location: SubagentLocationRecord): boolean {
 function pickSubagentSelection(
   subagent: SubagentRecord,
   selectedVariantPath: string | undefined,
-  options: { allowInvalid?: boolean; requireSelectionOnAmbiguous: boolean },
+  options: { allowInvalid?: boolean } = {},
 ): SubagentLocationRecord {
   const selectableLocations = subagent.locations.filter((location) =>
     location.fileType === 'real-file'
@@ -937,10 +925,6 @@ function pickSubagentSelection(
 
   if (groups.size === 1) {
     return [...groups.values()][0][0];
-  }
-
-  if (options.requireSelectionOnAmbiguous) {
-    return pickPreferredSubagentSelection(selectableLocations);
   }
 
   return pickPreferredSubagentSelection(selectableLocations);
@@ -1206,9 +1190,7 @@ async function ensureCanonicalSkillPackage(
     };
   }
 
-  const selectedSourcePath = pickSkillRealFileSelectionPath(skill, selectedVariantPath, {
-    requireSelectionOnAmbiguous: true,
-  });
+  const selectedSourcePath = pickSkillRealFileSelectionPath(skill, selectedVariantPath);
   const selectedLocation = skill.locations.find((location) => location.path === selectedSourcePath && location.fileType === 'real-file');
   if (!selectedLocation) {
     throw new Error('The selected skill version must be a real file before repairing links.');
@@ -1233,7 +1215,6 @@ async function ensureCanonicalSkillPackage(
 function pickSkillRealFileSelectionPath(
   skill: SkillRecord,
   selectedVariantPath: string | undefined,
-  options: { requireSelectionOnAmbiguous: boolean },
 ): string {
   const realFileLocations = skill.locations.filter((location) => location.fileType === 'real-file');
   if (realFileLocations.length === 0) {
@@ -1252,10 +1233,6 @@ function pickSkillRealFileSelectionPath(
   const groups = groupSkillRealFiles(realFileLocations);
   if (groups.length === 1) {
     return groups[0][0].path;
-  }
-
-  if (options.requireSelectionOnAmbiguous) {
-    return pickPreferredSkillRealFileSelection(realFileLocations).path;
   }
 
   return pickPreferredSkillRealFileSelection(realFileLocations).path;
@@ -1331,7 +1308,7 @@ function resolveMissingSkillInstallPath(
 function pickMcpSelection(
   locations: McpLocationRecord[],
   selectedVariantPath: string | undefined,
-  options: { preferUniversal?: boolean; requireSelectionOnAmbiguous: boolean },
+  options: { preferUniversal?: boolean } = {},
 ): McpLocationRecord {
   if (locations.length === 0) {
     throw new Error('No MCP definition is available for resolution.');
@@ -1363,10 +1340,6 @@ function pickMcpSelection(
 
   if (groups.size === 1) {
     return [...groups.values()][0][0];
-  }
-
-  if (options.requireSelectionOnAmbiguous) {
-    return pickPreferredMcpSelection(locations);
   }
 
   return pickPreferredMcpSelection(locations);

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -83,6 +83,7 @@ interface CanonicalSkillPackage {
 }
 
 interface CanonicalSubagentPackage {
+  allowInvalid?: boolean;
   path: string;
   definition: PortableSubagentDefinition;
 }
@@ -722,20 +723,24 @@ async function resolveSubagentIssueIfCurrent(
 
   switch (request.issue) {
     case 'missing-universal': {
-      const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
-        preferExisting: false,
-        requireSelectionOnAmbiguous: true,
-      });
       const selectedLocation = pickSubagentSelection(subagent, request.selectedVariantPath, {
+        allowInvalid: true,
         requireSelectionOnAmbiguous: true,
       });
+      const canonicalPath = isInvalidSubagentLocation(selectedLocation)
+        ? await copySubagentLocationToCanonicalPath(subagent, selectedLocation, options.paths)
+        : (await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
+            preferExisting: false,
+            requireSelectionOnAmbiguous: true,
+          })).path;
       const duplicateTargets = collectIdenticalMarkdownSubagentCopyTargets(subagent, snapshot, selectedLocation.definitionComparisonKey);
       await Promise.all(dedupeSubagentTargets(duplicateTargets).map((target) =>
-        replaceWithCanonicalSymlink(target.path, canonicalPackage.path)));
+        replaceWithCanonicalSymlink(target.path, canonicalPath)));
       return;
     }
     case 'missing-from-agents': {
       const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
+        allowInvalid: true,
         preferExisting: true,
         requireSelectionOnAmbiguous: true,
       });
@@ -745,22 +750,25 @@ async function resolveSubagentIssueIfCurrent(
       return;
     }
     case 'identical-copies': {
-      const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
-        preferExisting: true,
-        requireSelectionOnAmbiguous: false,
-      });
+      const canonicalLocation = findCanonicalSubagentLocation(subagent, { allowInvalid: true });
+      const canonicalPath = canonicalLocation?.path
+        ?? (await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
+          preferExisting: true,
+          requireSelectionOnAmbiguous: false,
+        })).path;
       const duplicateTargets = collectIdenticalMarkdownSubagentCopyTargets(
         subagent,
         snapshot,
-        findCanonicalSubagentLocation(subagent)?.definitionComparisonKey,
+        canonicalLocation?.definitionComparisonKey,
       );
       await Promise.all(dedupeSubagentTargets(duplicateTargets).map((target) =>
-        replaceWithCanonicalSymlink(target.path, canonicalPackage.path)));
+        replaceWithCanonicalSymlink(target.path, canonicalPath)));
       return;
     }
     case 'broken-symlink':
     case 'wrong-symlink-target': {
       const canonicalPackage = await ensureCanonicalSubagentPackage(subagent, snapshot, request.selectedVariantPath, options, {
+        allowInvalid: true,
         preferExisting: true,
         requireSelectionOnAmbiguous: false,
       });
@@ -827,50 +835,85 @@ async function ensureCanonicalSubagentPackage(
   selectedVariantPath: string | undefined,
   options: ResolveIssueOptions & { paths: SkillIndexPaths },
   behavior: {
+    allowInvalid?: boolean;
     preferExisting: boolean;
     requireSelectionOnAmbiguous: boolean;
   },
 ): Promise<CanonicalSubagentPackage> {
-  const canonicalLocation = behavior.preferExisting ? findCanonicalSubagentLocation(subagent) : null;
+  const canonicalLocation = behavior.preferExisting
+    ? findCanonicalSubagentLocation(subagent, { allowInvalid: behavior.allowInvalid })
+    : null;
   if (canonicalLocation) {
     const definition = stripSubagentLocalExtras(
-      readPortableDefinitionForSubagentLocation(snapshot, subagent.name, canonicalLocation),
+      readPortableDefinitionForSubagentLocation(snapshot, subagent.name, canonicalLocation, {
+        allowInvalid: behavior.allowInvalid,
+      }),
     );
     return {
+      allowInvalid: isInvalidSubagentLocation(canonicalLocation),
       path: canonicalLocation.path,
       definition,
     };
   }
 
   const selectedLocation = pickSubagentSelection(subagent, selectedVariantPath, {
+    allowInvalid: behavior.allowInvalid,
     requireSelectionOnAmbiguous: behavior.requireSelectionOnAmbiguous,
   });
   const definition = stripSubagentLocalExtras(
-    readPortableDefinitionForSubagentLocation(snapshot, subagent.name, selectedLocation),
+    readPortableDefinitionForSubagentLocation(snapshot, subagent.name, selectedLocation, {
+      allowInvalid: behavior.allowInvalid,
+    }),
   );
   const canonicalPath = resolveCanonicalSubagentPath(subagent, selectedLocation, options.paths);
-  await writeSubagentDefinitionFile(canonicalPath, 'markdown-frontmatter', definition);
+  await writeSubagentDefinitionFile(canonicalPath, 'markdown-frontmatter', definition, {
+    allowInvalid: behavior.allowInvalid && isInvalidSubagentLocation(selectedLocation),
+  });
   return {
+    allowInvalid: isInvalidSubagentLocation(selectedLocation),
     path: canonicalPath,
     definition,
   };
 }
 
-function findCanonicalSubagentLocation(subagent: SubagentRecord): SubagentLocationRecord | null {
+function findCanonicalSubagentLocation(
+  subagent: SubagentRecord,
+  options: { allowInvalid?: boolean } = {},
+): SubagentLocationRecord | null {
   return subagent.locations.find((location) =>
     location.canonical
     && location.fileType === 'real-file'
-    && (location.invalidDetails?.length ?? 0) === 0) ?? null;
+    && (options.allowInvalid || (location.invalidDetails?.length ?? 0) === 0)) ?? null;
+}
+
+async function copySubagentLocationToCanonicalPath(
+  subagent: SubagentRecord,
+  selectedLocation: SubagentLocationRecord,
+  paths: SkillIndexPaths,
+): Promise<string> {
+  const canonicalPath = resolveCanonicalSubagentPath(subagent, selectedLocation, paths);
+  if (path.normalize(canonicalPath) === path.normalize(selectedLocation.path)) {
+    return canonicalPath;
+  }
+
+  await mkdir(path.dirname(canonicalPath), { recursive: true });
+  await rm(canonicalPath, { recursive: true, force: true });
+  await cp(selectedLocation.path, canonicalPath);
+  return canonicalPath;
+}
+
+function isInvalidSubagentLocation(location: SubagentLocationRecord): boolean {
+  return (location.invalidDetails?.length ?? 0) > 0;
 }
 
 function pickSubagentSelection(
   subagent: SubagentRecord,
   selectedVariantPath: string | undefined,
-  options: { requireSelectionOnAmbiguous: boolean },
+  options: { allowInvalid?: boolean; requireSelectionOnAmbiguous: boolean },
 ): SubagentLocationRecord {
   const selectableLocations = subagent.locations.filter((location) =>
     location.fileType === 'real-file'
-    && (location.invalidDetails?.length ?? 0) === 0);
+    && (options.allowInvalid || (location.invalidDetails?.length ?? 0) === 0));
   if (selectableLocations.length === 0) {
     throw new Error(`Subagent "${subagent.name}" has no valid definition to use for resolution.`);
   }
@@ -878,7 +921,7 @@ function pickSubagentSelection(
   if (selectedVariantPath) {
     const selectedLocation = selectableLocations.find((location) => location.path === selectedVariantPath);
     if (!selectedLocation) {
-      throw new Error('Choose one of the available subagent definitions before resolving this issue.');
+      throw new Error('The selected subagent definition is no longer available for resolution.');
     }
 
     return selectedLocation;
@@ -897,23 +940,44 @@ function pickSubagentSelection(
   }
 
   if (options.requireSelectionOnAmbiguous) {
-    throw new Error('Choose a subagent definition before resolving this issue.');
+    return pickPreferredSubagentSelection(selectableLocations);
   }
 
-  const canonicalLocation = selectableLocations.find((location) => location.canonical);
-  if (canonicalLocation) {
-    return canonicalLocation;
+  return pickPreferredSubagentSelection(selectableLocations);
+}
+
+function pickPreferredSubagentSelection(locations: SubagentLocationRecord[]): SubagentLocationRecord {
+  const selectedLocation = locations.slice().sort(compareSubagentSelectionLocations)[0];
+  if (!selectedLocation) {
+    throw new Error('No valid subagent definition is available for resolution.');
   }
 
-  return selectableLocations[0];
+  return selectedLocation;
+}
+
+function compareSubagentSelectionLocations(left: SubagentLocationRecord, right: SubagentLocationRecord): number {
+  if (left.canonical !== right.canonical) {
+    return left.canonical ? -1 : 1;
+  }
+
+  const leftIsAgentsPath = isAgentsPath(left.path);
+  const rightIsAgentsPath = isAgentsPath(right.path);
+  if (leftIsAgentsPath !== rightIsAgentsPath) {
+    return leftIsAgentsPath ? -1 : 1;
+  }
+
+  const modifiedDifference = new Date(right.modifiedAt).getTime() - new Date(left.modifiedAt).getTime();
+  return modifiedDifference || left.path.localeCompare(right.path);
 }
 
 function readPortableDefinitionForSubagentLocation(
   snapshot: SkillInventorySnapshot,
   fallbackName: string,
   location: SubagentLocationRecord,
+  options: { allowInvalid?: boolean } = {},
 ): PortableSubagentDefinition {
   return readPortableSubagentDefinitionFromFile({
+    allowInvalid: options.allowInvalid,
     family: findSubagentLocationFamily(snapshot, location.agentId),
     filePath: location.path,
     format: location.format,
@@ -1030,7 +1094,9 @@ async function writeSubagentTarget(
   snapshot: SkillInventorySnapshot,
 ): Promise<void> {
   if (path.normalize(target.path) === path.normalize(canonicalPackage.path)) {
-    await writeSubagentDefinitionFile(target.path, 'markdown-frontmatter', stripSubagentLocalExtras(definition));
+    await writeSubagentDefinitionFile(target.path, 'markdown-frontmatter', stripSubagentLocalExtras(definition), {
+      allowInvalid: canonicalPackage.allowInvalid,
+    });
     return;
   }
 
@@ -1048,7 +1114,7 @@ async function writeSubagentTarget(
     target.path,
     target.format,
     mergeExistingSubagentTargetExtras(target, stripSubagentLocalExtras(definition)),
-    { family },
+    { allowInvalid: canonicalPackage.allowInvalid, family },
   );
 }
 
@@ -1056,7 +1122,7 @@ async function writeSubagentDefinitionFile(
   filePath: string,
   format: AgentSubagentParserKind,
   definition: PortableSubagentDefinition,
-  options: { family?: string } = {},
+  options: { allowInvalid?: boolean; family?: string } = {},
 ): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
   await rm(filePath, { recursive: true, force: true });
@@ -1145,7 +1211,7 @@ async function ensureCanonicalSkillPackage(
   });
   const selectedLocation = skill.locations.find((location) => location.path === selectedSourcePath && location.fileType === 'real-file');
   if (!selectedLocation) {
-    throw new Error('Choose a real-file skill version before repairing links.');
+    throw new Error('The selected skill version must be a real file before repairing links.');
   }
 
   await mkdir(path.dirname(canonicalPath), { recursive: true });
@@ -1177,7 +1243,7 @@ function pickSkillRealFileSelectionPath(
   if (selectedVariantPath) {
     const selectedLocation = realFileLocations.find((location) => location.path === selectedVariantPath);
     if (!selectedLocation) {
-      throw new Error('Choose one of the available real-file skill versions before resolving this issue.');
+      throw new Error('The selected skill version is no longer available for resolution.');
     }
 
     return selectedLocation.path;
@@ -1189,10 +1255,34 @@ function pickSkillRealFileSelectionPath(
   }
 
   if (options.requireSelectionOnAmbiguous) {
-    throw new Error('Choose a skill version before resolving this issue.');
+    return pickPreferredSkillRealFileSelection(realFileLocations).path;
   }
 
-  return realFileLocations[0].path;
+  return pickPreferredSkillRealFileSelection(realFileLocations).path;
+}
+
+function pickPreferredSkillRealFileSelection(locations: SkillLocationRecord[]): SkillLocationRecord {
+  const selectedLocation = locations.slice().sort(compareSkillSelectionLocations)[0];
+  if (!selectedLocation) {
+    throw new Error('No valid skill version is available for resolution.');
+  }
+
+  return selectedLocation;
+}
+
+function compareSkillSelectionLocations(left: SkillLocationRecord, right: SkillLocationRecord): number {
+  if (left.canonical !== right.canonical) {
+    return left.canonical ? -1 : 1;
+  }
+
+  const leftIsAgentsPath = isAgentsPath(left.path);
+  const rightIsAgentsPath = isAgentsPath(right.path);
+  if (leftIsAgentsPath !== rightIsAgentsPath) {
+    return leftIsAgentsPath ? -1 : 1;
+  }
+
+  const modifiedDifference = new Date(right.modifiedAt).getTime() - new Date(left.modifiedAt).getTime();
+  return modifiedDifference || left.path.localeCompare(right.path);
 }
 
 function groupSkillRealFiles(locations: SkillLocationRecord[]): SkillLocationRecord[][] {
@@ -1244,7 +1334,7 @@ function pickMcpSelection(
   options: { preferUniversal?: boolean; requireSelectionOnAmbiguous: boolean },
 ): McpLocationRecord {
   if (locations.length === 0) {
-    throw new Error('Choose an MCP definition before resolving this issue.');
+    throw new Error('No MCP definition is available for resolution.');
   }
 
   if (options.preferUniversal) {
@@ -1257,7 +1347,7 @@ function pickMcpSelection(
   if (selectedVariantPath) {
     const selectedLocation = locations.find((location) => location.configPath === selectedVariantPath);
     if (!selectedLocation) {
-      throw new Error('Choose one of the available MCP definitions before resolving this issue.');
+      throw new Error('The selected MCP definition is no longer available for resolution.');
     }
 
     return selectedLocation;
@@ -1276,15 +1366,42 @@ function pickMcpSelection(
   }
 
   if (options.requireSelectionOnAmbiguous) {
-    throw new Error('Choose an MCP definition before resolving this issue.');
+    return pickPreferredMcpSelection(locations);
   }
 
-  return locations[0];
+  return pickPreferredMcpSelection(locations);
+}
+
+function pickPreferredMcpSelection(locations: McpLocationRecord[]): McpLocationRecord {
+  const selectedLocation = locations.slice().sort(compareMcpSelectionLocations)[0];
+  if (!selectedLocation) {
+    throw new Error('No MCP definition is available for resolution.');
+  }
+
+  return selectedLocation;
+}
+
+function compareMcpSelectionLocations(left: McpLocationRecord, right: McpLocationRecord): number {
+  const leftIsUniversal = isUniversalMcpSelectionLocation(left);
+  const rightIsUniversal = isUniversalMcpSelectionLocation(right);
+  if (leftIsUniversal !== rightIsUniversal) {
+    return leftIsUniversal ? -1 : 1;
+  }
+
+  return left.configPath.localeCompare(right.configPath);
 }
 
 function isUniversalMcpSelectionLocation(location: McpLocationRecord): boolean {
   return location.provenance?.kind === 'universal'
     || isAgentsMcpConfigPath(location.configPath);
+}
+
+function isAgentsPath(value: string | undefined | null): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  return value.replace(/\\/g, '/').includes('/.agents/');
 }
 
 function isAgentsMcpConfigPath(value: string): boolean {
@@ -1309,7 +1426,7 @@ function parseSelectedMcpDefinition(location: McpLocationRecord): SelectedMcpDef
 
   const parsed = JSON.parse(location.definitionText) as unknown;
   if (!isMcpDefinitionObject(parsed)) {
-    throw new Error('Choose an MCP definition with a supported object structure before resolving this issue.');
+    throw new Error('The selected MCP definition must use a supported object structure.');
   }
 
   const splitDefinition = splitMcpDefinitionForComparison(parsed, location);

--- a/src/main/subagent-inventory.test.ts
+++ b/src/main/subagent-inventory.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { lstat, mkdir, mkdtemp, readFile, realpath, symlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -264,7 +264,7 @@ describe('subagent inventory', () => {
       issue: 'definition-mismatch',
       selectedVariantPath: claudePath,
       subagentName: 'reviewer',
-    }, scanOptions)).rejects.toThrow('Choose one of the available subagent definitions before resolving this issue.');
+    }, scanOptions)).rejects.toThrow('The selected subagent definition is no longer available for resolution.');
   });
 
   it('renders markdown subagents with incompatible required fields as materialized copies', async () => {
@@ -484,7 +484,7 @@ describe('subagent inventory', () => {
     expect(universalDefinition).not.toContain('github-tools:reviewer');
   });
 
-  it('requires an explicit definition choice for ambiguous subagent mismatch repair', async () => {
+  it('auto-selects the Universal definition for ambiguous subagent mismatch repair', async () => {
     const { homeDir, scanOptions } = await createSubagentTestPaths();
     const canonicalPath = path.join(homeDir, '.agents', 'agents', 'ambiguous.md');
     const claudePath = path.join(homeDir, '.claude', 'agents', 'ambiguous.md');
@@ -492,16 +492,9 @@ describe('subagent inventory', () => {
     await writeMarkdownSubagent(canonicalPath, 'ambiguous', 'Canonical description.', 'Use canonical behavior.');
     await writeMarkdownSubagent(claudePath, 'ambiguous', 'Claude description.', 'Use Claude behavior.');
 
-    await expect(resolveInventoryIssue({
-      entity: 'subagent',
-      issue: 'definition-mismatch',
-      subagentName: 'ambiguous',
-    }, scanOptions)).rejects.toThrow('Choose a subagent definition before resolving this issue.');
-
     const repaired = await resolveInventoryIssue({
       entity: 'subagent',
       issue: 'definition-mismatch',
-      selectedVariantPath: canonicalPath,
       subagentName: 'ambiguous',
     }, scanOptions);
     const ambiguous = repaired.subagents?.find((subagent) => subagent.name === 'ambiguous');
@@ -643,6 +636,83 @@ describe('subagent inventory', () => {
     expect(resolvedSubagent?.issueReasons).not.toContain('definition-mismatch');
     expect(resolvedSubagent?.issueReasons).toContain('missing-from-agents');
     expect(resolvedSubagent?.missingLocations ?? []).not.toHaveLength(0);
+  });
+
+  it('promotes an invalid but readable subagent definition into Universal', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-invalid-subagent-resolution-'));
+    const homeDir = path.join(root, 'home');
+    const rootPaths = resolveSkillIndexPaths({
+      env: { SKILL_INDEX_DATA_DIR: path.join(root, 'data') },
+      homeDir,
+    });
+    const sandboxPaths = resolveSandboxSkillIndexPaths({ paths: rootPaths });
+    const scanOptions = {
+      paths: sandboxPaths,
+      homeDir,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    };
+    const subagentName = 'invalid-definition-subagent';
+    const claudePath = path.join(rootPaths.sandboxRoot, '.claude', 'agents', `${subagentName}.md`);
+    const canonicalPath = path.join(rootPaths.sandboxRoot, '.agents', 'agents', `${subagentName}.md`);
+
+    await seedRepresentativeFixtures({ paths: rootPaths, homeDir });
+
+    const before = await scanInventory(scanOptions);
+    const beforeSubagent = before.subagents?.find((subagent) => subagent.name === subagentName);
+    expect(beforeSubagent?.issueReasons).toEqual(expect.arrayContaining(['missing-universal', 'invalid-definition']));
+    await expect(readFile(canonicalPath, 'utf8')).rejects.toThrow();
+
+    const resolved = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'missing-universal',
+      selectedVariantPath: claudePath,
+      subagentName,
+    }, scanOptions);
+    const resolvedSubagent = resolved.subagents?.find((subagent) => subagent.name === subagentName);
+
+    expect(await readFile(canonicalPath, 'utf8')).toBe(await readFile(claudePath, 'utf8'));
+    expect((await lstat(claudePath)).isSymbolicLink()).toBe(true);
+    expect(await realpath(claudePath)).toBe(await realpath(canonicalPath));
+    expect(resolvedSubagent?.issueReasons).not.toContain('missing-universal');
+    expect(resolvedSubagent?.issueReasons).not.toContain('identical-copies');
+    expect(resolvedSubagent?.issueReasons).toContain('invalid-definition');
+
+    await rm(claudePath, { force: true });
+    await writeRawFile(claudePath, await readFile(canonicalPath, 'utf8'));
+    const duplicated = await scanInventory(scanOptions);
+    expect(duplicated.subagents?.find((subagent) => subagent.name === subagentName)?.issueReasons)
+      .toContain('identical-copies');
+
+    const symlinked = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'identical-copies',
+      selectedVariantPath: canonicalPath,
+      subagentName,
+    }, scanOptions);
+    const symlinkedSubagent = symlinked.subagents?.find((subagent) => subagent.name === subagentName);
+
+    expect((await lstat(claudePath)).isSymbolicLink()).toBe(true);
+    expect(await realpath(claudePath)).toBe(await realpath(canonicalPath));
+    expect(symlinkedSubagent?.issueReasons).not.toContain('identical-copies');
+    expect(symlinkedSubagent?.issueReasons).toContain('invalid-definition');
+
+    const codexPath = path.join(rootPaths.sandboxRoot, '.codex', 'agents', `${subagentName}.toml`);
+    const factoryPath = path.join(rootPaths.sandboxRoot, '.factory', 'droids', `${subagentName}.md`);
+    const installed = await resolveInventoryIssue({
+      entity: 'subagent',
+      issue: 'missing-from-agents',
+      selectedVariantPath: canonicalPath,
+      subagentName,
+    }, scanOptions);
+    const installedSubagent = installed.subagents?.find((subagent) => subagent.name === subagentName);
+
+    expect(await readFile(codexPath, 'utf8')).toContain('name = "invalid-definition-subagent"');
+    expect(await readFile(codexPath, 'utf8')).toContain('developer_instructions = "This intentionally omits Claude Code\'s required description field."');
+    expect((await lstat(factoryPath)).isSymbolicLink()).toBe(true);
+    expect(await realpath(factoryPath)).toBe(await realpath(canonicalPath));
+    expect(installedSubagent?.issueReasons).not.toContain('missing-from-agents');
+    expect(installedSubagent?.issueReasons).toContain('invalid-definition');
   });
 
   it('preserves local-only Markdown fields when resolving subagent mismatches', async () => {

--- a/src/main/subagent-inventory.ts
+++ b/src/main/subagent-inventory.ts
@@ -304,8 +304,8 @@ function buildSubagentLocation(
   const fileType: SkillLocationType = stats.isSymbolicLink() ? 'symlink' : 'real-file';
   const resolvedPath = safeRealpathSync(filePath);
   const modifiedAt = new Date(stats.mtimeMs).toISOString();
-  const definitionComparisonKey = parsed.invalidDetails.length === 0 && fileType === 'real-file'
-    ? stableStringify(normalizeSubagentDefinition(parsed.definition))
+  const definitionComparisonKey = fileType === 'real-file'
+    ? getSubagentDefinitionComparisonKey(parsed)
     : undefined;
   const localExtrasKeys = parsed.invalidDetails.length === 0 && fileType === 'real-file'
     ? Object.keys(omitSubagentAliasFields(parsed.definition)).sort()
@@ -332,6 +332,17 @@ function buildSubagentLocation(
     canonicalRole: owner.canonical ? 'canonical' : 'materialized-copy',
     mutability: owner.writable ? 'writable' : owner.plugin ? 'read-only-managed' : 'unknown',
   };
+}
+
+function getSubagentDefinitionComparisonKey(parsed: ParsedSubagentDefinition): string {
+  if (parsed.invalidDetails.length === 0) {
+    return stableStringify(normalizeSubagentDefinition(parsed.definition));
+  }
+
+  return stableStringify({
+    invalidDefinitionText: parsed.definitionText ?? null,
+    normalizedDefinition: parsed.definitionText ? undefined : normalizeSubagentDefinition(parsed.definition),
+  });
 }
 
 function classifySubagentLocations(
@@ -462,11 +473,13 @@ function getSubagentFileNameForOwner(
 }
 
 export function readPortableSubagentDefinitionFromFile({
+  allowInvalid = false,
   family,
   filePath,
   format,
   fallbackName,
 }: {
+  allowInvalid?: boolean;
   family?: string;
   filePath: string;
   format: AgentSubagentParserKind;
@@ -482,7 +495,7 @@ export function readPortableSubagentDefinitionFromFile({
     writable: false,
     canonical: false,
   }, fallbackName);
-  if (parsed.invalidDetails.length > 0) {
+  if (parsed.invalidDetails.length > 0 && !allowInvalid) {
     throw new Error(parsed.invalidDetails.join(' '));
   }
 
@@ -520,11 +533,13 @@ export function readPortableSubagentDefinitionFromText({
 export function renderPortableSubagentDefinition(
   definition: PortableSubagentDefinition,
   format: AgentSubagentParserKind,
-  options: { family?: string } = {},
+  options: { allowInvalid?: boolean; family?: string } = {},
 ): string {
   switch (format) {
     case 'codex-toml':
-      assertPortableSubagentCanRender(definition, format);
+      if (!options.allowInvalid) {
+        assertPortableSubagentCanRender(definition, format);
+      }
       return renderTomlFields({
         name: definition.name,
         description: definition.description,
@@ -533,7 +548,9 @@ export function renderPortableSubagentDefinition(
       });
     case 'json':
     case 'jsonc':
-      assertPortableSubagentCanRender(definition, format);
+      if (!options.allowInvalid) {
+        assertPortableSubagentCanRender(definition, format);
+      }
       return `${JSON.stringify({
         name: definition.name,
         description: definition.description,
@@ -541,7 +558,9 @@ export function renderPortableSubagentDefinition(
         ...definition.extras,
       }, null, 2)}\n`;
     case 'toml':
-      assertPortableSubagentCanRender(definition, format);
+      if (!options.allowInvalid) {
+        assertPortableSubagentCanRender(definition, format);
+      }
       return renderTomlFields({
         agent_type: 'subagent',
         name: definition.name,
@@ -550,10 +569,14 @@ export function renderPortableSubagentDefinition(
         ...definition.extras,
       });
     case 'markdown-frontmatter':
-      assertPortableSubagentCanRender(definition, format);
+      if (!options.allowInvalid) {
+        assertPortableSubagentCanRender(definition, format);
+      }
       return renderMarkdownSubagentDefinition(definition, options.family);
     case 'yaml':
-      assertPortableSubagentCanRender(definition, format);
+      if (!options.allowInvalid) {
+        assertPortableSubagentCanRender(definition, format);
+      }
       return renderYamlFields({
         name: definition.name,
         description: definition.description,

--- a/src/main/subagent-inventory.ts
+++ b/src/main/subagent-inventory.ts
@@ -339,6 +339,8 @@ function getSubagentDefinitionComparisonKey(parsed: ParsedSubagentDefinition): s
     return stableStringify(normalizeSubagentDefinition(parsed.definition));
   }
 
+  // Invalid definitions are compared by source text so matching broken copies can be repaired
+  // without treating a failed parse as equivalent to a valid portable definition.
   return stableStringify({
     invalidDefinitionText: parsed.definitionText ?? null,
     normalizedDefinition: parsed.definitionText ? undefined : normalizeSubagentDefinition(parsed.definition),

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -2244,11 +2244,8 @@ describe('App shell inventory views', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'diverged-drift-skill', level: 3 })).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /\/Users\/arjitjaiswal\/\.skillindex\/sandbox\/\.claude/i })).not.toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /^Use as Universal$/i })).toBeDisabled();
-      expect(screen.getByRole('button', { name: /^Use as Universal$/i })).toHaveAttribute(
-        'title',
-        'Choose a skill version before resolving this issue.',
-      );
+      expect(screen.getByRole('button', { name: /^Use as Universal$/i })).toBeEnabled();
+      expect(screen.getByRole('button', { name: /^Use as Universal$/i })).not.toHaveAttribute('title');
     });
   });
 
@@ -2316,7 +2313,7 @@ describe('App shell inventory views', () => {
       { title: 'Variant resolution', problemKeys: ['definition-mismatch'] },
       { title: 'Structural repair', problemKeys: ['invalid-definition'] },
     ]);
-    expect(mcpModel.selectedVariantPath).toBe('/Users/arjitjaiswal/.skillindex/sandbox/.claude.json');
+    expect(mcpModel.selectedVariantPath).toBe('~/.skillindex/sandbox/.agents/mcp.json');
     expect(mcpModel.activeProblem.kind).toBe('variant-resolution');
     if (mcpModel.activeProblem.kind === 'variant-resolution') {
       expect(mcpModel.activeProblem.diffTitle).toBe(MCP_DETAIL_DIFF_TITLE);

--- a/src/renderer/src/lib/detail-inspector-model.ts
+++ b/src/renderer/src/lib/detail-inspector-model.ts
@@ -296,9 +296,15 @@ export function buildSkillInspectorModel(
   agentIndex: Map<string, AgentRecord> = new Map(),
 ): InspectorModel {
   const problemKeys = getSkillProblemKeys(skill);
-  const activeProblem = problemKeys.length > 0
+  let activeProblem = problemKeys.length > 0
     ? buildSkillProblemModel(skill, selectProblemKey(problemKeys, selection.selectedProblemKey), selection.selectedVariantPath, sourceIndex, agentIndex)
     : buildHealthySkillProblem(skill);
+  if (!selection.selectedProblemKey && shouldPreferInspectionProblem(activeProblem)) {
+    const inspectionProblemKey = getInspectionRequiredProblemKey(problemKeys);
+    if (inspectionProblemKey) {
+      activeProblem = buildSkillProblemModel(skill, inspectionProblemKey, selection.selectedVariantPath, sourceIndex, agentIndex);
+    }
+  }
   const selectedVariantPath = getPreferredSelectedVariantPath(selection.selectedVariantPath, activeProblem);
   const provenanceRows = buildSkillProvenanceRows(skill, selectedVariantPath);
   const provenanceSummary = buildSkillProvenanceSummary(skill, selectedVariantPath, sourceIndex);
@@ -340,9 +346,15 @@ export function buildMcpInspectorModel(
   sourceIndex: Map<string, SkillScanSource> = new Map(),
 ): InspectorModel {
   const problemKeys: McpIssueReason[] = mcp.issueReasons.length > 0 ? mcp.issueReasons : [];
-  const activeProblem = problemKeys.length > 0
+  let activeProblem = problemKeys.length > 0
     ? buildMcpProblemModel(mcp, selectProblemKey(problemKeys, selection.selectedProblemKey), selection.selectedVariantPath, agentIndex)
     : buildHealthyMcpProblem();
+  if (!selection.selectedProblemKey && shouldPreferInspectionProblem(activeProblem)) {
+    const inspectionProblemKey = getInspectionRequiredProblemKey(problemKeys);
+    if (inspectionProblemKey) {
+      activeProblem = buildMcpProblemModel(mcp, inspectionProblemKey, selection.selectedVariantPath, agentIndex);
+    }
+  }
   const selectedVariantPath = getPreferredSelectedVariantPath(selection.selectedVariantPath, activeProblem);
   const referencePath = activeProblem.key === 'missing-universal'
     ? null
@@ -386,9 +398,15 @@ export function buildSubagentInspectorModel(
   agentIndex: Map<string, AgentRecord> = new Map(),
 ): InspectorModel {
   const problemKeys: SubagentIssueReason[] = subagent.issueReasons.length > 0 ? subagent.issueReasons : [];
-  const activeProblem = problemKeys.length > 0
+  let activeProblem = problemKeys.length > 0
     ? buildSubagentProblemModel(subagent, selectProblemKey(problemKeys, selection.selectedProblemKey), selection.selectedVariantPath, agentIndex)
     : buildHealthySubagentProblem(subagent);
+  if (!selection.selectedProblemKey && shouldPreferInspectionProblem(activeProblem)) {
+    const inspectionProblemKey = getInspectionRequiredProblemKey(problemKeys);
+    if (inspectionProblemKey) {
+      activeProblem = buildSubagentProblemModel(subagent, inspectionProblemKey, selection.selectedVariantPath, agentIndex);
+    }
+  }
   const selectedVariantPath = getPreferredSelectedVariantPath(selection.selectedVariantPath, activeProblem);
   const referencePath = getActiveProblemBaselineVariantPath(activeProblem) ?? getCanonicalSubagentPath(subagent);
   const provenanceRows = buildSubagentProvenanceRows(subagent, selectedVariantPath, referencePath, agentIndex);
@@ -683,7 +701,7 @@ function buildSkillVariantProblem(
     diffPath: primaryDiffFile
       ? resolveSkillPackageDiffPath(primaryDiffFile.relativePath, primaryDiffFile, selectedVariant, baselineVariant)
       : null,
-    primaryActionLabel: SKILL_ACTION_LABELS.useAsUniversal,
+    primaryActionLabel: selectedVariant ? SKILL_ACTION_LABELS.useAsUniversal : null,
     actionSummary: buildSkillUseAsUniversalSummary(skill, problemKey, selectedVariant, sourceIndex),
   };
 }
@@ -796,9 +814,11 @@ function buildMcpVariantProblem(
     definitionBreakdown: selectedVariant
       ? buildMcpDefinitionBreakdown(mcp.name, selectedVariant, baselineVariant ?? selectedVariant)
       : undefined,
-    primaryActionLabel: problemKey === 'missing-universal'
-      ? MCP_ACTION_LABELS.promoteToUniversal
-      : MCP_ACTION_LABELS.applySelectedDefinition,
+    primaryActionLabel: selectedVariant
+      ? problemKey === 'missing-universal'
+        ? MCP_ACTION_LABELS.promoteToUniversal
+        : MCP_ACTION_LABELS.applySelectedDefinition
+      : null,
   };
 }
 
@@ -874,7 +894,9 @@ function buildSubagentVariantProblem(
   agentIndex: Map<string, AgentRecord>,
 ): VariantResolutionProblemModel {
   const groupedVariants = groupSubagentVariants(subagent.locations);
-  const baselineVariant = getSubagentBaselineVariant(groupedVariants, getCanonicalSubagentPath(subagent));
+  const baselineVariant = problemKey === 'missing-universal'
+    ? null
+    : getSubagentBaselineVariant(groupedVariants, getCanonicalSubagentPath(subagent));
   const orderedVariants = orderSubagentVariantsForInspector(groupedVariants, baselineVariant);
   const selectedVariant = selectSubagentVariant(orderedVariants, selectedVariantPath, baselineVariant);
   const selectedModel = selectedVariant ? mapSubagentVariant(selectedVariant, baselineVariant, selectedVariant, agentIndex) : null;
@@ -897,9 +919,11 @@ function buildSubagentVariantProblem(
     diffTitle: baselineVariant ? 'Diff: Selected Definition vs Universal' : 'Selected Definition Preview',
     diffLines,
     diffPath: selectedVariant?.representative.path ?? null,
-    primaryActionLabel: problemKey === 'missing-universal'
-      ? SUBAGENT_ACTION_LABELS.addToUniversal
-      : SUBAGENT_ACTION_LABELS.applySelectedDefinition,
+    primaryActionLabel: selectedVariant
+      ? problemKey === 'missing-universal'
+        ? SUBAGENT_ACTION_LABELS.addToUniversal
+        : SUBAGENT_ACTION_LABELS.applySelectedDefinition
+      : null,
   };
 }
 
@@ -2977,8 +3001,15 @@ function groupSubagentVariants(locations: SubagentLocationRecord[]): SubagentVar
 }
 
 function isReadableSubagentVariantLocation(location: SubagentLocationRecord): boolean {
-  return (location.invalidDetails?.length ?? 0) === 0
-    && (location.fileType === 'real-file' || Boolean(normalizeDefinitionText(location.definitionText)));
+  if (location.fileType !== 'real-file') {
+    return false;
+  }
+
+  if ((location.invalidDetails?.length ?? 0) === 0) {
+    return true;
+  }
+
+  return Boolean(normalizeDefinitionText(location.definitionText));
 }
 
 const MCP_BREAKDOWN_FIELD_ORDER = [
@@ -3507,7 +3538,7 @@ function getPreferredSelectedVariantPath(
   selectedVariantPath: string | null | undefined,
   problem: InspectorActiveProblemModel,
 ): string | null {
-  return selectedVariantPath ?? getActiveProblemSelectedVariantPath(problem);
+  return getActiveProblemSelectedVariantPath(problem) ?? selectedVariantPath ?? null;
 }
 
 function buildMetadataRows(
@@ -4078,6 +4109,18 @@ function selectProblemKey<T extends InspectorProblemKey>(problemKeys: T[], selec
   }
 
   return defaultProblemKey;
+}
+
+function shouldPreferInspectionProblem(problem: InspectorActiveProblemModel): boolean {
+  return !problem.primaryActionLabel;
+}
+
+function getInspectionRequiredProblemKey<T extends InspectorProblemKey>(problemKeys: T[]): T | null {
+  return problemKeys.find(isInspectionRequiredProblemKey) ?? null;
+}
+
+function isInspectionRequiredProblemKey(problemKey: InspectorProblemKey): boolean {
+  return problemKey === 'invalid-definition' || problemKey === 'connection-failed';
 }
 
 function formatProblemCount(count: number): string {

--- a/src/renderer/src/lib/issue-resolution.test.ts
+++ b/src/renderer/src/lib/issue-resolution.test.ts
@@ -269,7 +269,7 @@ describe('issue resolution request builder', () => {
     });
   });
 
-  it('requires a selected variant before repairing links when canonical is missing and multiple variants exist', () => {
+  it('uses the inspector-selected fallback when canonical is missing and multiple variants exist', () => {
     const skill: SkillRecord = {
       ...representativeInventorySnapshot.skills.find((entry) => entry.name === 'diagnostic-rich-skill')!,
       name: 'double-missing-canonical-skill',
@@ -378,6 +378,61 @@ describe('issue resolution request builder', () => {
         issue: 'missing-canonical',
         skillName: 'double-missing-canonical-skill',
         selectedVariantPath: '~/.skillindex/sandbox/.factory/skills/double-missing-canonical-skill.md',
+      },
+    });
+  });
+
+  it('ignores stale selected skill variants and resolves with the current inspector fallback', () => {
+    const skill: SkillRecord = {
+      ...representativeInventorySnapshot.skills.find((entry) => entry.name === 'diagnostic-rich-skill')!,
+      name: 'stale-selection-missing-canonical-skill',
+      structuralState: 'diverged-drift',
+      issueReasons: ['missing-canonical'],
+      locations: [
+        {
+          path: '~/.skillindex/sandbox/.claude/skills/stale-selection-missing-canonical-skill.md',
+          sourceId: 'sandbox-claude',
+          sourceLabel: 'Sandbox Claude',
+          sourceScope: 'sandbox',
+          fileType: 'real-file',
+          modifiedAt: '2026-01-04T12:15:00.000Z',
+          canonical: false,
+          resolvedPath: '~/.skillindex/sandbox/.claude/skills/stale-selection-missing-canonical-skill.md',
+          contentHash: 'claude',
+          definitionText: 'claude body',
+        },
+        {
+          path: '~/.skillindex/sandbox/.factory/skills/stale-selection-missing-canonical-skill.md',
+          sourceId: 'sandbox-factory',
+          sourceLabel: 'Sandbox Factory',
+          sourceScope: 'sandbox',
+          fileType: 'real-file',
+          modifiedAt: '2026-01-04T12:15:01.000Z',
+          canonical: false,
+          resolvedPath: '~/.skillindex/sandbox/.factory/skills/stale-selection-missing-canonical-skill.md',
+          contentHash: 'factory',
+          definitionText: 'factory body',
+        },
+      ],
+      detailDiagnostics: {
+        duplicateCandidates: [],
+        installSources: [],
+        missingInstallSources: [],
+        definitionIssues: [],
+      },
+    };
+    const model = buildSkillInspectorModel(skill, sourceIndex, {
+      selectedProblemKey: 'missing-canonical',
+      selectedVariantPath: '~/.skillindex/sandbox/.deleted/skills/stale-selection-missing-canonical-skill.md',
+    }, agentIndex);
+
+    expect(getSkillResolveActionState(skill, model, sourceIndex)).toEqual({
+      disabledReason: null,
+      request: {
+        entity: 'skill',
+        issue: 'missing-canonical',
+        skillName: 'stale-selection-missing-canonical-skill',
+        selectedVariantPath: '~/.skillindex/sandbox/.factory/skills/stale-selection-missing-canonical-skill.md',
       },
     });
   });
@@ -1135,6 +1190,207 @@ describe('issue resolution request builder', () => {
         issue: 'missing-from-agents',
         subagentName: 'reviewer',
         selectedVariantPath: '~/.skillindex/sandbox/.agents/agents/reviewer.md',
+      },
+    });
+  });
+
+  it('uses invalid-but-readable subagent definitions as Missing Universal candidates', () => {
+    const subagent: SubagentRecord = {
+      name: 'invalid-definition-subagent',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['missing-universal', 'invalid-definition'],
+      locations: [
+        {
+          agentId: 'sandbox-claude',
+          agentLabel: 'Claude Code',
+          scope: 'sandbox',
+          path: '~/.skillindex/sandbox/.claude/agents/invalid-definition-subagent.md',
+          directoryPath: '~/.skillindex/sandbox/.claude/agents',
+          fileType: 'real-file',
+          modifiedAt: '2026-05-28T12:00:00.000Z',
+          canonical: false,
+          format: 'markdown-frontmatter',
+          definitionText: '---\nname: invalid-definition-subagent\n---\nThis intentionally omits description.\n',
+          invalidDetails: ['Missing required field: description'],
+          mutability: 'writable',
+        },
+      ],
+    };
+
+    const defaultModel = buildSubagentInspectorModel(subagent, {}, agentIndex);
+    expect(defaultModel.activeProblem.key).toBe('missing-universal');
+    if (defaultModel.activeProblem.kind !== 'variant-resolution') {
+      throw new Error('Expected Missing Universal to render as a variant-resolution problem.');
+    }
+
+    expect(defaultModel.activeProblem.variants).toEqual([
+      expect.objectContaining({
+        path: '~/.skillindex/sandbox/.claude/agents/invalid-definition-subagent.md',
+        definitionText: '---\nname: invalid-definition-subagent\n---\nThis intentionally omits description.\n',
+      }),
+    ]);
+    expect(defaultModel.activeProblem.selectedVariant?.path)
+      .toBe('~/.skillindex/sandbox/.claude/agents/invalid-definition-subagent.md');
+    expect(defaultModel.definition.selectedVariantPath)
+      .toBe('~/.skillindex/sandbox/.claude/agents/invalid-definition-subagent.md');
+    expect(defaultModel.definition.files).toEqual([
+      expect.objectContaining({
+        absolutePath: '~/.skillindex/sandbox/.claude/agents/invalid-definition-subagent.md',
+        text: '---\nname: invalid-definition-subagent\n---\nThis intentionally omits description.\n',
+      }),
+    ]);
+    expect(defaultModel.activeProblem.baselineVariant).toBeNull();
+    expect(defaultModel.activeProblem.diffTitle).toBe('Selected Definition Preview');
+    expect(defaultModel.activeProblem.primaryActionLabel).toBe('Add to Universal');
+    expect(getSubagentResolveActionState(subagent, defaultModel, representativeInventorySnapshot)).toEqual({
+      disabledReason: null,
+      request: {
+        entity: 'subagent',
+        issue: 'missing-universal',
+        subagentName: 'invalid-definition-subagent',
+        selectedVariantPath: '~/.skillindex/sandbox/.claude/agents/invalid-definition-subagent.md',
+      },
+    });
+
+    const missingUniversalModel = buildSubagentInspectorModel(subagent, {
+      selectedProblemKey: 'missing-universal',
+      selectedVariantPath: null,
+    }, agentIndex);
+    expect(missingUniversalModel.activeProblem.primaryActionLabel).toBe('Add to Universal');
+    expect(getSubagentResolveActionState(subagent, missingUniversalModel, representativeInventorySnapshot)).toEqual({
+      disabledReason: null,
+      request: {
+        entity: 'subagent',
+        issue: 'missing-universal',
+        subagentName: 'invalid-definition-subagent',
+        selectedVariantPath: '~/.skillindex/sandbox/.claude/agents/invalid-definition-subagent.md',
+      },
+    });
+  });
+
+  it('keeps identical-copy repairs available after an invalid definition becomes Universal', () => {
+    const canonicalPath = '~/.skillindex/sandbox/.agents/agents/invalid-definition-subagent.md';
+    const claudePath = '~/.skillindex/sandbox/.claude/agents/invalid-definition-subagent.md';
+    const invalidDefinitionText = '---\nname: invalid-definition-subagent\n---\nThis intentionally omits description.\n';
+    const invalidComparisonKey = `invalid:${invalidDefinitionText}`;
+    const subagent: SubagentRecord = {
+      name: 'invalid-definition-subagent',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['identical-copies', 'missing-from-agents', 'invalid-definition'],
+      locations: [
+        {
+          agentId: 'universal-subagents',
+          agentLabel: 'Universal',
+          scope: 'sandbox',
+          path: canonicalPath,
+          directoryPath: '~/.skillindex/sandbox/.agents/agents',
+          fileType: 'real-file',
+          modifiedAt: '2026-05-31T12:00:00.000Z',
+          canonical: true,
+          format: 'markdown-frontmatter',
+          definitionText: invalidDefinitionText,
+          definitionComparisonKey: invalidComparisonKey,
+          invalidDetails: ['Missing required field: description'],
+          mutability: 'writable',
+        },
+        {
+          agentId: 'sandbox-claude',
+          agentLabel: 'Claude Code',
+          scope: 'sandbox',
+          path: claudePath,
+          directoryPath: '~/.skillindex/sandbox/.claude/agents',
+          fileType: 'real-file',
+          modifiedAt: '2026-05-31T12:00:00.000Z',
+          canonical: false,
+          format: 'markdown-frontmatter',
+          definitionText: invalidDefinitionText,
+          definitionComparisonKey: invalidComparisonKey,
+          invalidDetails: ['Missing required field: description'],
+          mutability: 'writable',
+        },
+      ],
+      missingLocations: [{
+        agentId: 'sandbox-codex',
+        agentLabel: 'Codex',
+        scope: 'sandbox',
+        directoryPath: '~/.skillindex/sandbox/.codex/agents',
+        path: '~/.skillindex/sandbox/.codex/agents/invalid-definition-subagent.toml',
+        format: 'codex-toml',
+        supportStatus: 'supported',
+      }],
+    };
+    const model = buildSubagentInspectorModel(subagent, {
+      selectedProblemKey: 'identical-copies',
+      selectedVariantPath: null,
+    }, agentIndex);
+
+    expect(model.activeProblem.primaryActionLabel).toBe('Convert Copies to Symlinks');
+    expect(getSubagentResolveActionState(subagent, model, representativeInventorySnapshot)).toEqual({
+      disabledReason: null,
+      request: {
+        entity: 'subagent',
+        issue: 'identical-copies',
+        subagentName: 'invalid-definition-subagent',
+        selectedVariantPath: canonicalPath,
+      },
+    });
+  });
+
+  it('keeps missing-agent repairs available when Universal is invalid but readable', () => {
+    const canonicalPath = '~/.skillindex/sandbox/.agents/agents/invalid-definition-subagent.md';
+    const invalidDefinitionText = '---\nname: invalid-definition-subagent\n---\nThis intentionally omits description.\n';
+    const subagent: SubagentRecord = {
+      name: 'invalid-definition-subagent',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['missing-from-agents', 'invalid-definition'],
+      locations: [
+        {
+          agentId: 'universal-subagents',
+          agentLabel: 'Universal',
+          scope: 'sandbox',
+          path: canonicalPath,
+          directoryPath: '~/.skillindex/sandbox/.agents/agents',
+          fileType: 'real-file',
+          modifiedAt: '2026-05-31T12:00:00.000Z',
+          canonical: true,
+          format: 'markdown-frontmatter',
+          definitionText: invalidDefinitionText,
+          definitionComparisonKey: 'same-invalid-definition',
+          invalidDetails: ['Missing required field: description'],
+          mutability: 'writable',
+        },
+      ],
+      missingLocations: [{
+        agentId: 'sandbox-codex',
+        agentLabel: 'Codex',
+        scope: 'sandbox',
+        directoryPath: '~/.skillindex/sandbox/.codex/agents',
+        path: '~/.skillindex/sandbox/.codex/agents/invalid-definition-subagent.toml',
+        format: 'codex-toml',
+        supportStatus: 'supported',
+      }],
+    };
+
+    const defaultModel = buildSubagentInspectorModel(subagent, {}, agentIndex);
+    expect(defaultModel.activeProblem.key).toBe('missing-from-agents');
+    expect(defaultModel.activeProblem.primaryActionLabel).toBe('Add to Agents');
+
+    const missingAgentsModel = buildSubagentInspectorModel(subagent, {
+      selectedProblemKey: 'missing-from-agents',
+      selectedVariantPath: null,
+    }, agentIndex);
+    expect(missingAgentsModel.activeProblem.key).toBe('missing-from-agents');
+    expect(missingAgentsModel.activeProblem.primaryActionLabel).toBe('Add to Agents');
+    expect(getSubagentResolveActionState(subagent, missingAgentsModel, representativeInventorySnapshot)).toEqual({
+      disabledReason: null,
+      request: {
+        entity: 'subagent',
+        issue: 'missing-from-agents',
+        subagentName: 'invalid-definition-subagent',
+        selectedVariantPath: canonicalPath,
       },
     });
   });

--- a/src/renderer/src/lib/issue-resolution.ts
+++ b/src/renderer/src/lib/issue-resolution.ts
@@ -81,7 +81,7 @@ export function getSkillResolveActionState(
 
   if (requiresVariantSelection && !selectedVariantPath) {
     return {
-      disabledReason: 'Choose a skill version before resolving this issue.',
+      disabledReason: null,
       request: null,
     };
   }
@@ -142,7 +142,7 @@ export function getMcpResolveActionState(
 
   if (requiresVariantSelection && !selectedVariantPath) {
     return {
-      disabledReason: 'Choose an MCP definition before resolving this issue.',
+      disabledReason: null,
       request: null,
     };
   }
@@ -181,10 +181,11 @@ export function getSubagentResolveActionState(
   const selectedVariantPath = getSubagentSelectedVariantPath(
     subagent,
     inspectorModel?.selectedVariantPath ?? null,
+    activeProblem.key,
   );
   if (!selectedVariantPath) {
     return {
-      disabledReason: 'Choose a subagent definition before resolving this issue.',
+      disabledReason: null,
       request: null,
     };
   }
@@ -275,7 +276,7 @@ function getSubagentResolutionTargets(
   const canonicalLocation = subagent.locations.find((location) =>
     location.canonical
     && location.fileType === 'real-file'
-    && (location.invalidDetails?.length ?? 0) === 0);
+    && (canUseInvalidSubagentResolutionSource(issue) || (location.invalidDetails?.length ?? 0) === 0));
   const selectedLocation = subagent.locations.find((location) => location.path === selectedVariantPath);
 
   switch (issue) {
@@ -454,17 +455,23 @@ function isAgentsMcpConfigPath(value: string): boolean {
   return parts.at(-1) === 'mcp.json' && parts.at(-2) === '.agents';
 }
 
-function getSubagentSelectedVariantPath(subagent: SubagentRecord, selectedVariantPath: string | null): string | null {
+function getSubagentSelectedVariantPath(
+  subagent: SubagentRecord,
+  selectedVariantPath: string | null,
+  issue: SubagentResolvableIssue,
+): string | null {
+  const allowInvalidSource = canUseInvalidSubagentResolutionSource(issue);
+
   if (selectedVariantPath && subagent.locations.some((location) =>
     location.path === selectedVariantPath
     && location.fileType === 'real-file'
-    && (location.invalidDetails?.length ?? 0) === 0)) {
+    && (allowInvalidSource || (location.invalidDetails?.length ?? 0) === 0))) {
     return selectedVariantPath;
   }
 
   const selectableLocations = subagent.locations.filter((location) =>
     location.fileType === 'real-file'
-    && (location.invalidDetails?.length ?? 0) === 0);
+    && (allowInvalidSource || (location.invalidDetails?.length ?? 0) === 0));
   const canonicalLocation = selectableLocations.find((location) => location.canonical && location.fileType === 'real-file');
   if (canonicalLocation) {
     return canonicalLocation.path;
@@ -479,6 +486,14 @@ function getSubagentSelectedVariantPath(subagent: SubagentRecord, selectedVarian
   }
 
   return groups.size === 1 ? selectableLocations[0]?.path ?? null : null;
+}
+
+function canUseInvalidSubagentResolutionSource(issue: SubagentResolvableIssue): boolean {
+  return issue === 'missing-universal'
+    || issue === 'missing-from-agents'
+    || issue === 'identical-copies'
+    || issue === 'broken-symlink'
+    || issue === 'wrong-symlink-target';
 }
 
 function getDistinctMcpVariantCount(mcp: McpRecord): number {
@@ -637,7 +652,7 @@ export function getAutoResolvableSubagentRequests(
         continue;
       }
 
-      const selectedVariantPath = getSubagentSelectedVariantPath(subagent, null);
+      const selectedVariantPath = getSubagentSelectedVariantPath(subagent, null, reason as SubagentResolvableIssue);
       if (!selectedVariantPath) {
         continue;
       }

--- a/src/renderer/src/views/SubagentsWorkspaceView.tsx
+++ b/src/renderer/src/views/SubagentsWorkspaceView.tsx
@@ -264,6 +264,12 @@ function SubagentDetailPanel({
             variant: 'strong' as const,
           }]
           : []),
+        ...(selectedSubagentInspectorModel.activeProblem.key === 'invalid-definition'
+          ? [{
+            label: 'Click a file name above to open it, then fix the definition.',
+            variant: 'note' as const,
+          }]
+          : []),
         ...(subagent.status === 'needs-attention'
           ? [{
             disabled: isDismissingDrift,
@@ -273,12 +279,6 @@ function SubagentDetailPanel({
             },
             shortcut: 'D',
             variant: 'subtle' as const,
-          }]
-          : []),
-        ...(selectedSubagentInspectorModel.activeProblem.key === 'invalid-definition'
-          ? [{
-            label: 'Click a file name above to open it, then fix the definition.',
-            variant: 'note' as const,
           }]
           : []),
         {


### PR DESCRIPTION
Changes:

Invalid-but-readable subagent definitions can now be used for structural repairs: Missing Universal promotes them, Identical Copies can symlink matching invalid Markdown copies, and Missing From Agents can materialize supported targets while leaving Invalid Definition for manual repair. Inspector and backend selection now choose deterministic repair sources instead of dead choose-a-definition states for skills, MCPs, and subagents.

Validation:
pnpm typecheck
pnpm test -- src/renderer/src/lib/issue-resolution.test.ts src/main/subagent-inventory.test.ts src/renderer/src/app-shell.test.tsx
rg -n "before resolving this issue|Choose a subagent definition before resolving|Choose an MCP definition before resolving|Choose a skill version before resolving" src --glob '!**/*.test.*'
git diff --check
