### PR TITLE
Right align detail remove action

### DIFF
--- a/src/renderer/src/components/DetailInspectorPanel.test.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.test.tsx
@@ -922,6 +922,32 @@ describe('DetailInspectorPanel', () => {
     expect(screen.queryByRole('button', { name: helpText })).not.toBeInTheDocument();
   });
 
+  it('marks a remove-only healthy detail footer action as end aligned', () => {
+    const skill = representativeInventorySnapshot.skills.find((entry) => entry.name === 'healthy-skill');
+    expect(skill).toBeDefined();
+
+    const model = buildSkillInspectorModel(skill!, sourceIndex, {}, agentIndex);
+
+    render(
+      <DetailInspectorPanel
+        footerActions={[{ label: 'Remove', shortcut: 'R', variant: 'danger' }]}
+        model={model}
+        onClose={() => undefined}
+      />,
+    );
+
+    const footer = document.querySelector('.detail-inspector-panel__footer-block');
+    const removeGroup = screen.getByRole('button', { name: /^Remove$/i })
+      .closest('.detail-inspector-panel__footer-action-group');
+
+    expect(screen.getByText('No problems')).toBeInTheDocument();
+    expect(footer).toHaveClass('detail-inspector-panel__footer-block--with-remove');
+    expect(removeGroup).toHaveClass(
+      'detail-inspector-panel__footer-action-group--danger',
+      'detail-inspector-panel__footer-action-group--end',
+    );
+  });
+
   it('renders dismiss and remove footer actions as a two-third and one-third action row', () => {
     const skill = representativeInventorySnapshot.skills.find((entry) => entry.name === 'identical-drift-skill');
     expect(skill).toBeDefined();

--- a/src/renderer/src/components/DetailInspectorPanel.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.tsx
@@ -606,6 +606,7 @@ export function DetailInspectorPanel({
                   action.variant === 'strong' ? 'detail-inspector-panel__footer-action-group--primary' : '',
                   action.variant === 'subtle' ? 'detail-inspector-panel__footer-action-group--secondary' : '',
                   action.variant === 'danger' ? 'detail-inspector-panel__footer-action-group--danger' : '',
+                  action.variant === 'danger' ? 'detail-inspector-panel__footer-action-group--end' : '',
                 ].filter(Boolean).join(' ')}
                 key={action.label}
               >

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -9528,7 +9528,7 @@ body {
 }
 
 .detail-inspector-panel__footer-block--with-remove .detail-inspector-panel__footer-action-group--danger {
-  grid-column: span 1;
+  grid-column: 3 / 4;
 }
 
 .detail-inspector-panel__footer-action {


### PR DESCRIPTION
Changes:

Right-align danger/remove actions in the shared detail footer so remove-only healthy skill, MCP, and subagent detail panes place Remove in the footer right column.
Add a regression test for the healthy remove-only footer state.

Validation:
pnpm typecheck
pnpm test -- src/renderer/src/components/DetailInspectorPanel.test.tsx
