### PR TITLE
Clarify disabled skill repairs

### DIFF
--- a/src/renderer/src/components/DetailInspectorPanel.test.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.test.tsx
@@ -515,7 +515,7 @@ describe('DetailInspectorPanel', () => {
     );
 
     expect(screen.getByText('Matching Copies')).toBeInTheDocument();
-    expect(screen.getByText('This will replace 1 writable copy with a symlink to the Universal version.')).toBeInTheDocument();
+    expect(screen.queryByText('This will replace 1 writable copy with a symlink to the Universal version.')).not.toBeInTheDocument();
     const list = screen.getByRole('list', { name: 'Matching Copies' });
     expect(within(list).getByText('Factory')).toBeInTheDocument();
     expect(within(list).getByTitle(packagePath('~/.skillindex/sandbox/.factory/skills/identical-drift-skill.md'))).toBeInTheDocument();
@@ -892,6 +892,37 @@ describe('DetailInspectorPanel', () => {
     const action = screen.getByRole('button', { name: /^Add MCP to Agents$/i });
     expect(action).toBeDisabled();
     expect(screen.getByText(reason)).toBeInTheDocument();
+    expect(action).toHaveAccessibleDescription(reason);
+  });
+
+  it('uses the summary slot only for disabled primary action reasons', () => {
+    const skill = representativeInventorySnapshot.skills.find((entry) => entry.name === 'identical-drift-skill');
+    expect(skill).toBeDefined();
+
+    const model = buildSkillInspectorModel(skill!, sourceIndex, {
+      selectedProblemKey: 'identical-copies',
+      selectedVariantPath: null,
+    }, agentIndex);
+    const reason = 'Choose a Universal version first. Symlink repairs need a Universal target.';
+
+    render(
+      <DetailInspectorPanel
+        footerActions={[{
+          disabled: true,
+          label: 'Convert Copies to Symlinks',
+          title: reason,
+          variant: 'strong',
+        }]}
+        model={model}
+        onClose={() => undefined}
+      />,
+    );
+
+    const action = screen.getByRole('button', { name: /^Convert Copies to Symlinks$/i });
+    const summary = document.querySelector('.detail-inspector-panel__action-summary');
+
+    expect(summary).toHaveTextContent(reason);
+    expect(screen.queryByText('This will replace 1 writable copy with a symlink to the Universal version.')).not.toBeInTheDocument();
     expect(action).toHaveAccessibleDescription(reason);
   });
 

--- a/src/renderer/src/components/DetailInspectorPanel.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.tsx
@@ -108,6 +108,13 @@ export function DetailInspectorPanel({
       ? PLUGIN_SUBAGENT_TOOLTIP
       : PLUGIN_SKILL_TOOLTIP;
   const hasRemoveAction = footerActions?.some((action) => action.variant === 'danger') ?? false;
+  const primaryDisabledAction = footerActions
+    ?.map((action, index) => ({ action, index }))
+    .find(({ action }) => action.variant === 'strong' && action.disabled && Boolean(action.title ?? action.detail));
+  const primaryDisabledReason = primaryDisabledAction?.action.title ?? primaryDisabledAction?.action.detail ?? null;
+  const primaryDisabledReasonId = primaryDisabledReason && primaryDisabledAction
+    ? `detail-inspector-footer-action-${primaryDisabledAction.index}-disabled-reason`
+    : undefined;
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -585,12 +592,17 @@ export function DetailInspectorPanel({
 
       {activeTab === 'problems' && footerActions && footerActions.length > 0 ? (
         <section className={`detail-inspector-panel__footer-block${hasRemoveAction ? ' detail-inspector-panel__footer-block--with-remove' : ''}`}>
-          {activeProblem.actionSummary ? (
-            <p className="detail-inspector-panel__action-summary">{activeProblem.actionSummary}</p>
+          {primaryDisabledReason ? (
+            <p className="detail-inspector-panel__action-summary" id={primaryDisabledReasonId}>{primaryDisabledReason}</p>
           ) : null}
           {footerActions.map((action, actionIndex) => {
             const disabledReasonId = `detail-inspector-footer-action-${actionIndex}-disabled-reason`;
-            const visibleDetail = action.variant === 'note' ? null : action.disabled && action.title ? action.title : action.detail;
+            const usesPrimaryDisabledReason = actionIndex === primaryDisabledAction?.index && Boolean(primaryDisabledReasonId);
+            const actionReasonId = actionIndex === primaryDisabledAction?.index
+              ? primaryDisabledReasonId
+              : disabledReasonId;
+            const visibleDetail = action.variant === 'note' || !action.disabled ? null : action.title ?? action.detail ?? null;
+            const shouldRenderVisibleDetail = visibleDetail && !usesPrimaryDisabledReason;
             if (action.variant === 'note') {
               return (
                 <p className="detail-inspector-panel__footer-note" key={action.label} role="note">
@@ -611,7 +623,7 @@ export function DetailInspectorPanel({
               >
                 <button
                   aria-keyshortcuts={action.shortcut ? action.shortcut.toUpperCase() : undefined}
-                  aria-describedby={visibleDetail ? disabledReasonId : undefined}
+                  aria-describedby={visibleDetail ? actionReasonId : undefined}
                   className={[
                     'detail-inspector-panel__footer-action',
                     action.variant === 'strong' ? 'detail-inspector-panel__footer-action--primary' : '',
@@ -630,7 +642,7 @@ export function DetailInspectorPanel({
                     </kbd>
                   ) : null}
                 </button>
-                {visibleDetail ? (
+                {shouldRenderVisibleDetail ? (
                   <p className="detail-inspector-panel__footer-action-reason" id={disabledReasonId}>
                     {visibleDetail}
                   </p>

--- a/src/renderer/src/lib/detail-inspector-model.test.ts
+++ b/src/renderer/src/lib/detail-inspector-model.test.ts
@@ -1676,6 +1676,80 @@ describe('buildSkillInspectorModel', () => {
     expect(activeProblem.primaryActionLabel).toBe('Repair Symlinks');
   });
 
+  it('puts Missing Universal first when it appears with symlink repair problems', () => {
+    const skill: SkillRecord = {
+      name: 'needs-universal-before-links-skill',
+      structuralState: 'diverged-drift',
+      isDrifted: true,
+      driftPresentation: 'active',
+      issueReasons: ['wrong-symlink-target', 'broken-symlink', 'missing-canonical'],
+      locations: [
+        {
+          path: packagePath('~/.skillindex/sandbox/.claude/skills/needs-universal-before-links-skill.md'),
+          sourceId: 'sandbox-claude',
+          sourceLabel: 'Sandbox Claude',
+          sourceScope: 'sandbox',
+          fileType: 'real-file',
+          modifiedAt: '2026-01-04T12:15:00.000Z',
+          canonical: false,
+          resolvedPath: packagePath('~/.skillindex/sandbox/.claude/skills/needs-universal-before-links-skill.md'),
+          contentHash: 'claude-copy',
+          definitionText: 'claude body',
+        },
+        {
+          path: packagePath('~/.skillindex/sandbox/.factory/skills/needs-universal-before-links-skill.md'),
+          sourceId: 'sandbox-factory',
+          sourceLabel: 'Sandbox Factory',
+          sourceScope: 'sandbox',
+          fileType: 'real-file',
+          modifiedAt: '2026-01-04T12:15:01.000Z',
+          canonical: false,
+          resolvedPath: packagePath('~/.skillindex/sandbox/.factory/skills/needs-universal-before-links-skill.md'),
+          contentHash: 'factory-copy',
+          definitionText: 'factory body',
+        },
+        {
+          path: packagePath('~/.skillindex/sandbox/.codex/skills/needs-universal-before-links-skill.md'),
+          sourceId: 'sandbox-codex',
+          sourceLabel: 'Sandbox Codex',
+          sourceScope: 'sandbox',
+          fileType: 'symlink',
+          modifiedAt: '2026-01-04T12:15:02.000Z',
+          canonical: false,
+          resolvedPath: packagePath('~/.skillindex/sandbox/.agents/skills/other-skill.md'),
+          symlinkTarget: packagePath('~/.skillindex/sandbox/.agents/skills/other-skill.md'),
+        },
+        {
+          path: packagePath('~/.skillindex/sandbox/.amp/skills/needs-universal-before-links-skill.md'),
+          sourceId: 'sandbox-amp',
+          sourceLabel: 'Sandbox Amp',
+          sourceScope: 'sandbox',
+          fileType: 'symlink',
+          modifiedAt: '2026-01-04T12:15:03.000Z',
+          canonical: false,
+        },
+      ],
+      detailDiagnostics: {
+        duplicateCandidates: [],
+        installSources: [],
+        missingInstallSources: [],
+        definitionIssues: [],
+      },
+    };
+
+    const model = buildSkillInspectorModel(skill, sourceIndex, {
+      selectedProblemKey: null,
+      selectedVariantPath: null,
+    }, agentIndex);
+
+    expect(model.problems.map((problem) => problem.key)).toEqual([
+      'missing-canonical',
+      'wrong-symlink-target',
+      'broken-symlink',
+    ]);
+    expect(model.activeProblem.key).toBe('missing-canonical');
+  });
+
   it('does not mark any detected version as universal when a skill is missing the universal copy', () => {
     const skill = representativeInventorySnapshot.skills.find((entry) => entry.name === 'single-source-skill')!;
 

--- a/src/renderer/src/lib/inventory-presentation.ts
+++ b/src/renderer/src/lib/inventory-presentation.ts
@@ -327,15 +327,15 @@ function compareSkillIssueReasons(left: SkillIssueReason, right: SkillIssueReaso
 
 function getSkillIssueRank(reason: SkillIssueReason): number {
   switch (reason) {
-    case 'diverged-copies':
-      return 0;
-    case 'wrong-symlink-target':
-      return 1;
-    case 'broken-symlink':
-      return 2;
-    case 'identical-copies':
-      return 3;
     case 'missing-canonical':
+      return 0;
+    case 'diverged-copies':
+      return 1;
+    case 'wrong-symlink-target':
+      return 2;
+    case 'broken-symlink':
+      return 3;
+    case 'identical-copies':
       return 4;
     case 'missing-symlinks':
       return 5;

--- a/src/renderer/src/lib/issue-resolution.test.ts
+++ b/src/renderer/src/lib/issue-resolution.test.ts
@@ -685,6 +685,68 @@ describe('issue resolution request builder', () => {
     });
   });
 
+  it('explains symlink repairs that are disabled until a Universal version is chosen', () => {
+    const skill: SkillRecord = {
+      name: 'needs-universal-before-link-repair',
+      structuralState: 'diverged-drift',
+      isDrifted: true,
+      driftPresentation: 'active',
+      issueReasons: ['missing-canonical', 'wrong-symlink-target'],
+      locations: [
+        {
+          path: '~/.skillindex/sandbox/.claude/skills/needs-universal-before-link-repair.md',
+          sourceId: 'sandbox-claude',
+          sourceLabel: 'Sandbox Claude',
+          sourceScope: 'sandbox',
+          fileType: 'real-file',
+          modifiedAt: '2026-01-04T12:15:00.000Z',
+          canonical: false,
+          resolvedPath: '~/.skillindex/sandbox/.claude/skills/needs-universal-before-link-repair.md',
+          contentHash: 'claude-copy',
+          definitionText: 'claude body',
+        },
+        {
+          path: '~/.skillindex/sandbox/.factory/skills/needs-universal-before-link-repair.md',
+          sourceId: 'sandbox-factory',
+          sourceLabel: 'Sandbox Factory',
+          sourceScope: 'sandbox',
+          fileType: 'real-file',
+          modifiedAt: '2026-01-04T12:15:01.000Z',
+          canonical: false,
+          resolvedPath: '~/.skillindex/sandbox/.factory/skills/needs-universal-before-link-repair.md',
+          contentHash: 'factory-copy',
+          definitionText: 'factory body',
+        },
+        {
+          path: '~/.skillindex/sandbox/.codex/skills/needs-universal-before-link-repair.md',
+          sourceId: 'sandbox-codex',
+          sourceLabel: 'Sandbox Codex',
+          sourceScope: 'sandbox',
+          fileType: 'symlink',
+          modifiedAt: '2026-01-04T12:15:02.000Z',
+          canonical: false,
+          resolvedPath: '~/.skillindex/sandbox/.agents/skills/other-skill.md',
+          symlinkTarget: '~/.skillindex/sandbox/.agents/skills/other-skill.md',
+        },
+      ],
+      detailDiagnostics: {
+        duplicateCandidates: [],
+        installSources: [],
+        missingInstallSources: [],
+        definitionIssues: [],
+      },
+    };
+    const model = buildSkillInspectorModel(skill, sourceIndex, {
+      selectedProblemKey: 'wrong-symlink-target',
+      selectedVariantPath: null,
+    }, agentIndex);
+
+    expect(getSkillResolveActionState(skill, model, sourceIndex)).toEqual({
+      disabledReason: 'Choose a Universal version first. Symlink repairs need a Universal target.',
+      request: null,
+    });
+  });
+
   it('allows repairing Universal links to a read-only plugin skill', () => {
     const skill: SkillRecord = {
       ...representativeInventorySnapshot.skills.find((entry) => entry.name === 'plugin-readonly-skill')!,

--- a/src/renderer/src/lib/issue-resolution.ts
+++ b/src/renderer/src/lib/issue-resolution.ts
@@ -48,6 +48,7 @@ const SUBAGENT_RESOLVABLE_ISSUES = new Set([
   'broken-symlink',
   'wrong-symlink-target',
 ] as const);
+const SKILL_UNIVERSAL_TARGET_REQUIRED_REASON = 'Choose a Universal version first. Symlink repairs need a Universal target.';
 
 export function getSkillResolveActionState(
   skill: SkillRecord,
@@ -72,16 +73,17 @@ export function getSkillResolveActionState(
   }
 
   const selectedVariantPath = getSkillSelectedVariantPath(skill, inspectorModel?.selectedVariantPath ?? null, activeProblem.key);
+  const hasUniversalRealFile = hasCanonicalRealFile(skill);
   const requiresVariantSelection = activeProblem.key === 'diverged-copies'
     || activeProblem.key === 'missing-canonical'
     || ((activeProblem.key === 'missing-symlinks'
       || activeProblem.key === 'broken-symlink'
       || activeProblem.key === 'wrong-symlink-target')
-      && !hasCanonicalRealFile(skill));
+      && !hasUniversalRealFile);
 
   if (requiresVariantSelection && !selectedVariantPath) {
     return {
-      disabledReason: null,
+      disabledReason: getSkillMissingUniversalTargetReason(activeProblem.key, hasUniversalRealFile),
       request: null,
     };
   }
@@ -352,6 +354,21 @@ function hasSubagentLocalExtras(location: { localExtrasKeys?: string[] }): boole
 
 function hasCanonicalRealFile(skill: SkillRecord): boolean {
   return skill.locations.some((location) => location.canonical && location.fileType === 'real-file');
+}
+
+function getSkillMissingUniversalTargetReason(
+  issue: SkillIssueReason,
+  hasUniversalRealFile: boolean,
+): string | null {
+  if (hasUniversalRealFile) {
+    return null;
+  }
+
+  return issue === 'missing-symlinks'
+    || issue === 'broken-symlink'
+    || issue === 'wrong-symlink-target'
+    ? SKILL_UNIVERSAL_TARGET_REQUIRED_REASON
+    : null;
 }
 
 function getReadOnlyNonPluginSource(


### PR DESCRIPTION
Changes:

- Removed redundant enabled skill-detail action hints.
- Show disabled primary action reasons in the footer summary slot, including the Universal target requirement for symlink repairs.
- Put Missing Universal first in skill problem ordering.

Validation:
pnpm typecheck
pnpm exec vitest run src/renderer/src/components/DetailInspectorPanel.test.tsx src/renderer/src/lib/detail-inspector-model.test.ts src/renderer/src/lib/issue-resolution.test.ts src/renderer/src/lib/inventory-presentation.test.ts src/renderer/src/views/InventoryViewChrome.test.tsx
