### PR TITLE
Make agents symlink rows promotable

### DIFF
--- a/src/main/capability-actions.ts
+++ b/src/main/capability-actions.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { cp, mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 import type {
@@ -84,12 +85,13 @@ async function persistSkillUniversalDecision(
 ): Promise<void> {
   const skill = findSkill(snapshot, request.skillName);
   const selectedLocation = selectRepresentativeLocation(skill, request.selectedVariantPath);
-  if (selectedLocation.fileType !== 'real-file') {
-    throw new Error('Choose a real-file skill version before making it Universal.');
+  if (!isSelectableUniversalVersion(selectedLocation)) {
+    throw new Error('Choose a readable skill version before making it Universal.');
   }
 
   const capabilityName = getCapabilityName(skill, selectedLocation);
   const acceptedAlternates = findUniversalDecisionAlternates(snapshot, skill, selectedLocation, capabilityName);
+  await materializeSelectedSymlinkUniversal(selectedLocation, snapshot);
   const decision: SkillUniversalDecision = {
     id: createSkillUniversalDecisionId(skill.name, selectedLocation),
     skillName: skill.name,
@@ -116,6 +118,45 @@ async function persistSkillUniversalDecision(
   });
 }
 
+function isSelectableUniversalVersion(location: SkillLocationRecord): boolean {
+  return location.fileType === 'real-file'
+    || (location.fileType === 'symlink' && Boolean(location.resolvedPath));
+}
+
+async function materializeSelectedSymlinkUniversal(
+  selectedLocation: SkillLocationRecord,
+  snapshot: SkillInventorySnapshot,
+): Promise<void> {
+  if (selectedLocation.fileType !== 'symlink') {
+    return;
+  }
+
+  if (!selectedLocation.resolvedPath) {
+    throw new Error('Choose a readable skill version before making it Universal.');
+  }
+
+  assertWritableUniversalMaterializationTarget(selectedLocation, snapshot);
+  await mkdir(path.dirname(selectedLocation.path), { recursive: true });
+  await rm(selectedLocation.path, { recursive: true, force: true });
+  await cp(selectedLocation.resolvedPath, selectedLocation.path, {
+    recursive: true,
+    dereference: true,
+    force: true,
+  });
+}
+
+function assertWritableUniversalMaterializationTarget(
+  selectedLocation: SkillLocationRecord,
+  snapshot: SkillInventorySnapshot,
+): void {
+  const selectedSource = snapshot.sources.find((source) => source.id === selectedLocation.sourceId);
+  if (selectedSource?.writable && selectedSource.kind !== 'plugin') {
+    return;
+  }
+
+  throw new Error('Make Universal can only replace symlinks in writable skill locations.');
+}
+
 function findUniversalDecisionAlternates(
   snapshot: SkillInventorySnapshot,
   selectedSkill: SkillRecord,
@@ -123,10 +164,11 @@ function findUniversalDecisionAlternates(
   capabilityName: string,
 ): SkillUniversalAlternate[] {
   const selectedPath = normalizePath(selectedLocation.path);
+  const selectedCapabilityNames = getSelectedCapabilityNames(selectedSkill, selectedLocation, capabilityName);
   const equivalentLocations = snapshot.skills
     .filter((skill) =>
       skill.name === selectedSkill.name
-      || getCapabilityName(skill, selectRepresentativeLocation(skill)) === capabilityName)
+      || isPotentialSplitPluginAlternate(skill, selectedCapabilityNames))
     .flatMap((skill) => skill.locations)
     .filter((location) =>
       location.fileType === 'real-file'
@@ -147,6 +189,56 @@ function findUniversalDecisionAlternates(
       seen.add(key);
       return true;
     });
+}
+
+function getSelectedCapabilityNames(
+  skill: SkillRecord,
+  selectedLocation: SkillLocationRecord,
+  capabilityName: string,
+): Set<string> {
+  return new Set([
+    capabilityName,
+    skill.displayName ?? undefined,
+    getUnqualifiedSkillName(skill.name),
+    path.basename(selectedLocation.path),
+    selectedLocation.resolvedPath ? path.basename(selectedLocation.resolvedPath) : undefined,
+  ].filter(isNonEmptyString));
+}
+
+function isPotentialSplitPluginAlternate(
+  skill: SkillRecord,
+  selectedCapabilityNames: Set<string>,
+): boolean {
+  const candidateNames = getPluginCapabilityCandidateNames(skill);
+  return candidateNames.some((name) => selectedCapabilityNames.has(name));
+}
+
+function getPluginCapabilityCandidateNames(skill: SkillRecord): string[] {
+  const pluginLocations = skill.locations.filter((location) =>
+    location.fileType === 'real-file'
+    && location.provenance?.kind === 'plugin');
+
+  if (pluginLocations.length === 0) {
+    return [];
+  }
+
+  return [
+    skill.displayName ?? undefined,
+    getUnqualifiedSkillName(skill.name),
+    ...pluginLocations.flatMap((location) => [
+      getCapabilityName(skill, location),
+      path.basename(location.path),
+      location.resolvedPath ? path.basename(location.resolvedPath) : undefined,
+    ]),
+  ].filter(isNonEmptyString);
+}
+
+function getUnqualifiedSkillName(skillName: string): string {
+  return skillName.split(':').pop() ?? skillName;
+}
+
+function isNonEmptyString(value: string | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
 }
 
 function buildSkillUniversalOrigin(location: SkillLocationRecord): SkillUniversalOrigin {

--- a/src/main/issue-resolution.test.ts
+++ b/src/main/issue-resolution.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -1724,6 +1724,87 @@ describe('resolveInventoryIssue', () => {
       pluginSkillName: 'foo',
     });
     expect(resolvedSkill?.detailDiagnostics.universalDecision?.acceptedAlternates).toEqual([]);
+  });
+
+  it('materializes an .agents symlink as Universal when it points at the preferred canonical source', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-preferred-agents-choice-'));
+    const homeDir = await mkdtemp(path.join(tmpdir(), 'skillindex-live-home-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+      homeDir,
+    });
+    const skillName = 'repo-backed-skill';
+    const preferredSkillsDir = path.join(homeDir, 'repos', 'arjit-skills', 'skills');
+    const preferredPath = path.join(preferredSkillsDir, skillName);
+    const agentsPath = path.join(homeDir, '.agents', 'skills', skillName);
+    const factoryPath = path.join(homeDir, '.factory', 'skills', skillName);
+    const symlinkOnlySkillPath = path.join(homeDir, '.agents', 'skills', 'browser');
+    const symlinkOnlyTargetPath = path.join(homeDir, 'external-skills', 'browser');
+
+    await writeSkillFile(path.join(preferredPath, 'SKILL.md'), [
+      '---',
+      `name: ${skillName}`,
+      'description: Preferred canonical repo skill.',
+      '---',
+      '',
+      '# Repo backed skill',
+      '',
+    ].join('\n'));
+    await mkdir(path.dirname(agentsPath), { recursive: true });
+    await symlink(preferredPath, agentsPath);
+    await mkdir(path.dirname(factoryPath), { recursive: true });
+    await symlink(preferredPath, factoryPath);
+    await writeSkillFile(path.join(homeDir, '.factory', 'settings.json'), '{}\n');
+    await writeSkillFile(path.join(symlinkOnlyTargetPath, 'SKILL.md'), [
+      '---',
+      'name: browser',
+      'description: Browser helper exposed only through a symlink.',
+      '---',
+      '',
+      '# Browser',
+      '',
+    ].join('\n'));
+    await symlink(symlinkOnlyTargetPath, symlinkOnlySkillPath);
+    await writeSkillIndexConfig(paths.configFile, {
+      customScanPaths: [],
+      preferredCanonicalSourcePath: preferredSkillsDir,
+      dismissedDriftSignatures: [],
+      dismissedMcpSignatures: [],
+    });
+
+    const resolvedSnapshot = await applyCapabilityAction({
+      entity: 'skill',
+      action: 'choose-universal-version',
+      skillName,
+      selectedVariantPath: agentsPath,
+    }, {
+      paths,
+      homeDir,
+      includeSandboxSources: false,
+      includeLiveSources: true,
+    });
+
+    await expect(lstat(agentsPath).then((stats) => stats.isSymbolicLink())).resolves.toBe(false);
+    await expect(readFile(path.join(agentsPath, 'SKILL.md'), 'utf8')).resolves.toContain('Preferred canonical repo skill.');
+    expect(await readlink(preferredPath)).toBe(agentsPath);
+    expect(await readlink(factoryPath)).toBe(agentsPath);
+    expect(resolvedSnapshot.skills.find((skill) => skill.name === skillName)).toMatchObject({
+      structuralState: 'healthy',
+      isDrifted: false,
+      driftPresentation: 'none',
+      detailDiagnostics: {
+        universalDecision: {
+          state: 'user-confirmed',
+          universal: {
+            kind: 'path',
+            sourceId: 'live-agents',
+            path: agentsPath,
+          },
+        },
+      },
+    });
   });
 
   it('rejects stale skill issue resolution requests after the issue is already resolved', async () => {

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -1850,6 +1850,11 @@ function resolveCanonicalSkillPath(
   selectedVariantPath: string | undefined,
 ): string {
   const canonicalScope = resolveSkillMutationScope(skill, selectedVariantPath);
+  const decisionCanonicalPath = resolveUserConfirmedPathDecisionSkillPath(skill);
+  if (decisionCanonicalPath) {
+    return decisionCanonicalPath;
+  }
+
   const preferredCanonicalPath = resolvePreferredCanonicalSkillPath(skill, snapshot, canonicalScope);
   if (preferredCanonicalPath) {
     return preferredCanonicalPath;
@@ -1862,6 +1867,19 @@ function resolveCanonicalSkillPath(
   }
 
   throw new Error(`Unable to locate the canonical ${canonicalScope} skills directory for "${skill.name}".`);
+}
+
+function resolveUserConfirmedPathDecisionSkillPath(skill: SkillRecord): string | null {
+  const decision = skill.detailDiagnostics.universalDecision;
+  if (
+    decision?.state !== 'user-confirmed'
+    || decision.skillName !== skill.name
+    || decision.universal.kind !== 'path'
+  ) {
+    return null;
+  }
+
+  return decision.universal.path;
 }
 
 function resolvePreferredCanonicalSkillPath(

--- a/src/main/plugin-inventory.test.ts
+++ b/src/main/plugin-inventory.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -744,6 +744,8 @@ describe('plugin inventory', () => {
     });
     const pluginRoot = path.join(homeDir, '.codex', 'plugins', 'cache', 'openai-curated', 'github-tools', 'abc123');
     const localSkillPath = path.join(homeDir, '.agents', 'skills', 'github');
+    const symlinkOnlySkillPath = path.join(homeDir, '.agents', 'skills', 'browser');
+    const symlinkOnlyTargetPath = path.join(homeDir, 'external-skills', 'browser');
 
     await writeJson(path.join(pluginRoot, '.codex-plugin', 'plugin.json'), {
       name: 'github-tools',
@@ -751,6 +753,8 @@ describe('plugin inventory', () => {
     });
     await writeSkill(path.join(pluginRoot, 'skills', 'github'), 'github', 'GitHub workflow helpers from plugin');
     await writeSkill(localSkillPath, 'github', 'Local GitHub workflow helpers');
+    await writeSkill(symlinkOnlyTargetPath, 'browser', 'Browser helper exposed only through a symlink');
+    await symlink(symlinkOnlyTargetPath, symlinkOnlySkillPath);
 
     const inventory = await applyCapabilityAction({
       entity: 'skill',

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -1535,6 +1535,15 @@ function resolveUniversalDecisionCanonicalPaths(
     const pathLocation = locations.find((location) =>
       location.sourceId === universal.sourceId
       && normalizePath(location.path) === normalizePath(universal.path));
+    if (pathLocation?.fileType === 'symlink' && pathLocation.resolvedPath) {
+      const resolvedPath = normalizePath(pathLocation.resolvedPath);
+      const resolvedLocation = locations.find((location) =>
+        location.fileType === 'real-file'
+        && (normalizePath(location.path) === resolvedPath
+          || (location.resolvedPath !== undefined && normalizePath(location.resolvedPath) === resolvedPath)));
+      return [resolvedLocation?.path ?? pathLocation.resolvedPath];
+    }
+
     return [pathLocation?.path ?? universal.path];
   }
 

--- a/src/renderer/src/lib/detail-inspector-model.test.ts
+++ b/src/renderer/src/lib/detail-inspector-model.test.ts
@@ -651,6 +651,127 @@ describe('buildSkillInspectorModel', () => {
     ]);
   });
 
+  it('lets an .agents symlink to the preferred canonical source become Universal', () => {
+    const preferredPath = '/tmp/skillindex/sandbox/repos/arjit-skills/skills/repo-backed-skill';
+    const agentsPath = '/tmp/skillindex/sandbox/.agents/skills/repo-backed-skill';
+    const preferredSource: SkillScanSource = {
+      id: 'preferred-canonical:/tmp/skillindex/sandbox/repos/arjit-skills/skills',
+      label: 'Preferred canonical /tmp/skillindex/sandbox/repos/arjit-skills/skills',
+      canonical: false,
+      kind: 'custom',
+      writable: true,
+      scope: 'sandbox',
+      skillsDir: '/tmp/skillindex/sandbox/repos/arjit-skills/skills',
+      preferredCanonical: true,
+    };
+    const agentsSource: SkillScanSource = {
+      id: 'sandbox-agents',
+      label: 'Sandbox .agents',
+      canonical: true,
+      kind: 'canonical',
+      writable: true,
+      scope: 'sandbox',
+      skillsDir: '/tmp/skillindex/sandbox/.agents/skills',
+    };
+    const skill: SkillRecord = {
+      name: 'repo-backed-skill',
+      description: 'Repo-backed skill exposed through the shared universal directory.',
+      structuralState: 'healthy',
+      isDrifted: false,
+      driftPresentation: 'none',
+      issueReasons: [],
+      locations: [
+        {
+          path: preferredPath,
+          entrypointPath: `${preferredPath}/SKILL.md`,
+          sourceId: preferredSource.id,
+          sourceLabel: preferredSource.label,
+          sourceScope: 'sandbox',
+          installKind: 'directory',
+          fileType: 'real-file',
+          modifiedAt: '2026-05-15T04:00:00.000Z',
+          canonical: true,
+          resolvedPath: preferredPath,
+          contentHash: 'preferred-repo-backed-skill',
+        },
+        {
+          path: agentsPath,
+          entrypointPath: `${preferredPath}/SKILL.md`,
+          sourceId: agentsSource.id,
+          sourceLabel: agentsSource.label,
+          sourceScope: 'sandbox',
+          installKind: 'directory',
+          fileType: 'symlink',
+          modifiedAt: '2026-05-15T04:00:00.000Z',
+          canonical: false,
+          resolvedPath: preferredPath,
+          symlinkTarget: preferredPath,
+          contentHash: 'preferred-repo-backed-skill',
+        },
+      ],
+      detailDiagnostics: {
+        duplicateCandidates: [],
+        installSources: [
+          {
+            sourceId: preferredSource.id,
+            label: preferredSource.label,
+            kind: preferredSource.kind,
+            scope: preferredSource.scope,
+            writable: preferredSource.writable,
+            canonical: true,
+          },
+          {
+            sourceId: agentsSource.id,
+            label: agentsSource.label,
+            kind: agentsSource.kind,
+            scope: agentsSource.scope,
+            writable: agentsSource.writable,
+            canonical: false,
+          },
+        ],
+        missingInstallSources: [],
+        definitionIssues: [],
+        universalDecision: {
+          id: 'skill:repo-backed-stale-agents',
+          skillName: 'repo-backed-skill',
+          state: 'user-confirmed',
+          universal: {
+            kind: 'path',
+            sourceId: agentsSource.id,
+            path: agentsPath,
+          },
+          acceptedAlternates: [],
+          updatedAt: '2026-05-15T04:10:00.000Z',
+        },
+      },
+    };
+
+    const model = buildSkillInspectorModel(skill, new Map([
+      [preferredSource.id, preferredSource],
+      [agentsSource.id, agentsSource],
+    ]), {
+      selectedProblemKey: null,
+      selectedVariantPath: null,
+    }, agentIndex);
+
+    expect(model.locations.find((section) => section.id === 'universal')?.rows).toEqual([
+      expect.objectContaining({
+        path: preferredPath,
+        label: 'Preferred canonical',
+      }),
+      expect.objectContaining({
+        path: agentsPath,
+        statusLabel: 'symlink',
+        tone: 'healthy',
+        action: {
+          kind: 'choose-skill-universal-version',
+          label: 'Make Universal',
+          path: agentsPath,
+        },
+      }),
+    ]);
+  });
+
   it('pluralizes read-only plugin copies in action summaries', () => {
     const pluginSources: SkillScanSource[] = [
       buildPluginSource('codex', 'workflow-kit@sandbox-curated', 'Codex Plugin workflow-kit', '/tmp/skillindex/codex/workflow-kit'),

--- a/src/renderer/src/lib/detail-inspector-model.ts
+++ b/src/renderer/src/lib/detail-inspector-model.ts
@@ -1658,23 +1658,66 @@ function mapSkillLocationRow(
     pathText: location.path,
     statusLabel: issue.statusLabel,
     tone: issue.tone,
-    action: getSkillLocationAction(skill, location),
+    action: getSkillLocationAction(skill, location, sourceIndex),
   };
 }
 
 function getSkillLocationAction(
   skill: SkillRecord,
   location: SkillLocationRecord,
+  sourceIndex: Map<string, SkillScanSource>,
 ): InspectorLocationAction | undefined {
-  if (location.fileType !== 'real-file' || !isAcceptedSkillAlternate(skill, location)) {
+  const actionPath = getSkillLocationActionPath(skill, location, sourceIndex);
+  if (!actionPath) {
     return undefined;
   }
 
   return {
     kind: 'choose-skill-universal-version',
     label: 'Make Universal',
-    path: location.path,
+    path: actionPath,
   };
+}
+
+function getSkillLocationActionPath(
+  skill: SkillRecord,
+  location: SkillLocationRecord,
+  sourceIndex: Map<string, SkillScanSource>,
+): string | null {
+  if (location.fileType === 'real-file') {
+    return isAcceptedSkillAlternate(skill, location) ? location.path : null;
+  }
+
+  return isAgentsSymlinkToPreferredCanonicalSource(skill, location, sourceIndex)
+    ? location.path
+    : null;
+}
+
+function isAgentsSymlinkToPreferredCanonicalSource(
+  skill: SkillRecord,
+  location: SkillLocationRecord,
+  sourceIndex: Map<string, SkillScanSource>,
+): boolean {
+  if (
+    location.fileType !== 'symlink'
+    || !isAgentsPath(location.path)
+    || !location.resolvedPath
+  ) {
+    return false;
+  }
+
+  const resolvedPath = normalizeLocationPath(location.resolvedPath);
+  return skill.locations.some((candidate) => {
+    if (
+      candidate.fileType !== 'real-file'
+      || sourceIndex.get(candidate.sourceId)?.preferredCanonical !== true
+    ) {
+      return false;
+    }
+
+    return [candidate.path, candidate.resolvedPath].some((candidatePath) =>
+      candidatePath !== undefined && normalizeLocationPath(candidatePath) === resolvedPath);
+  });
 }
 
 function getSkillInstallSourceForLocation(


### PR DESCRIPTION
Changes:

Show Make Universal on .agents symlink rows that still point at a preferred canonical source, including stale saved decisions.
Materialize selected .agents symlinks as real Universal packages and repair writable symlinks to point at them.
Limit plugin alternate discovery to matching real-file plugin rows so unrelated symlink-only skills are ignored.

Validation:
pnpm typecheck
pnpm exec vitest run src/main/issue-resolution.test.ts
pnpm exec vitest run src/main/plugin-inventory.test.ts
pnpm exec vitest run src/main/skill-canonicalization.test.ts
pnpm exec vitest run src/renderer/src/lib/detail-inspector-model.test.ts
