### PR TITLE
Clean up code quality issues

### DIFF
--- a/src/main/add-skill.test.ts
+++ b/src/main/add-skill.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, lstat, mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -119,6 +119,27 @@ describe('addSkill', () => {
 
     expect(calls).toEqual([{ source: 'https://github.com/example/live-repo', home: liveHome }]);
     await expect(readFile(path.join(liveHome, '.agents', 'skills', 'live-skill', 'SKILL.md'), 'utf8')).resolves.toContain('name: live-skill');
+  });
+
+  it('fails instead of treating an uninspectable install path as available', async () => {
+    const paths = await createSandboxPaths();
+    await mkdir(paths.sandboxAgentsSkillsDir, { recursive: true });
+    await chmod(paths.sandboxAgentsSkillsDir, 0o600);
+
+    try {
+      await expect(addSkill({
+        sourceType: 'markdown',
+        skillName: 'blocked-skill',
+        markdown: '# blocked-skill\n\nUse this skill.\n',
+      }, {
+        includeSandboxSources: true,
+        includeLiveSources: false,
+        paths,
+        homeDir: path.dirname(paths.dataDir),
+      })).rejects.toThrow(`Failed to inspect skill install path ${path.join(paths.sandboxAgentsSkillsDir, 'blocked-skill')}`);
+    } finally {
+      await chmod(paths.sandboxAgentsSkillsDir, 0o700);
+    }
   });
 });
 

--- a/src/main/add-skill.test.ts
+++ b/src/main/add-skill.test.ts
@@ -1,4 +1,4 @@
-import { chmod, lstat, mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -123,23 +123,26 @@ describe('addSkill', () => {
 
   it('fails instead of treating an uninspectable install path as available', async () => {
     const paths = await createSandboxPaths();
-    await mkdir(paths.sandboxAgentsSkillsDir, { recursive: true });
-    await chmod(paths.sandboxAgentsSkillsDir, 0o600);
+    const blockedSkillPath = path.join(paths.sandboxAgentsSkillsDir, 'blocked-skill');
+    const permissionError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
 
-    try {
-      await expect(addSkill({
-        sourceType: 'markdown',
-        skillName: 'blocked-skill',
-        markdown: '# blocked-skill\n\nUse this skill.\n',
-      }, {
-        includeSandboxSources: true,
-        includeLiveSources: false,
-        paths,
-        homeDir: path.dirname(paths.dataDir),
-      })).rejects.toThrow(`Failed to inspect skill install path ${path.join(paths.sandboxAgentsSkillsDir, 'blocked-skill')}`);
-    } finally {
-      await chmod(paths.sandboxAgentsSkillsDir, 0o700);
-    }
+    await expect(addSkill({
+      sourceType: 'markdown',
+      skillName: 'blocked-skill',
+      markdown: '# blocked-skill\n\nUse this skill.\n',
+    }, {
+      includeSandboxSources: true,
+      includeLiveSources: false,
+      paths,
+      homeDir: path.dirname(paths.dataDir),
+      inspectInstallPath: async (targetPath) => {
+        if (targetPath === blockedSkillPath) {
+          throw permissionError;
+        }
+
+        return lstat(targetPath);
+      },
+    })).rejects.toThrow(`Failed to inspect skill install path ${blockedSkillPath}: permission denied`);
   });
 });
 

--- a/src/main/add-skill.ts
+++ b/src/main/add-skill.ts
@@ -193,7 +193,31 @@ async function pathExists(targetPath: string): Promise<boolean> {
   try {
     await lstat(targetPath);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false;
+    }
+
+    throw new Error(`Failed to inspect skill install path ${targetPath}: ${formatUnknownError(error)}`, { cause: error });
   }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return isErrnoException(error) && (error.code === 'ENOENT' || error.code === 'ENOTDIR');
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === 'object' && error !== null && 'code' in error;
+}
+
+function formatUnknownError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return 'Unknown error';
 }

--- a/src/main/add-skill.ts
+++ b/src/main/add-skill.ts
@@ -17,7 +17,10 @@ import {
   type SkillsCliAddEnvironment,
 } from '@main/skills-cli-add-adapter';
 
+type InspectInstallPath = (targetPath: string) => Promise<unknown>;
+
 export interface AddSkillOptions extends ScanSkillInventoryOptions {
+  inspectInstallPath?: InspectInstallPath;
   paths?: SkillIndexPaths;
   runSkillsAdd?: (source: string, environment: SkillsCliAddEnvironment) => Promise<void>;
 }
@@ -45,6 +48,7 @@ export async function addSkill(
     await installPackagesFromDefinitions(
       [{ relativeDir: relativeSkillDir, sourceDir: null, skillMarkdown: normalizeSkillMarkdown(request.markdown) }],
       installTargets,
+      options.inspectInstallPath,
     );
   } else {
     const source = request.source.trim();
@@ -70,8 +74,9 @@ async function installPackagesFromDefinitions(
     skillMarkdown: string | null;
   }>,
   targets: InstallTargetContext,
+  inspectInstallPath: InspectInstallPath = inspectPath,
 ): Promise<void> {
-  await assertInstallPathsAreAvailable(packages, targets);
+  await assertInstallPathsAreAvailable(packages, targets, inspectInstallPath);
 
   for (const pkg of packages) {
     const canonicalPackageDir = path.join(targets.canonicalSkillsDir, pkg.relativeDir);
@@ -102,6 +107,7 @@ async function installPackagesFromDefinitions(
 async function assertInstallPathsAreAvailable(
   packages: Array<{ relativeDir: string }>,
   targets: InstallTargetContext,
+  inspectInstallPath: InspectInstallPath,
 ): Promise<void> {
   const plannedPaths = new Set<string>();
   for (const pkg of packages) {
@@ -112,7 +118,7 @@ async function assertInstallPathsAreAvailable(
   }
 
   for (const filePath of plannedPaths) {
-    if (await pathExists(filePath)) {
+    if (await pathExists(filePath, inspectInstallPath)) {
       throw new Error(`A skill already exists at ${filePath}. Remove or rename it before adding this skill.`);
     }
   }
@@ -189,9 +195,12 @@ function normalizeSkillMarkdown(markdown: string): string {
   return `${trimmed}\n`;
 }
 
-async function pathExists(targetPath: string): Promise<boolean> {
+async function pathExists(
+  targetPath: string,
+  inspectInstallPath: InspectInstallPath,
+): Promise<boolean> {
   try {
-    await lstat(targetPath);
+    await inspectInstallPath(targetPath);
     return true;
   } catch (error) {
     if (isMissingPathError(error)) {
@@ -200,6 +209,10 @@ async function pathExists(targetPath: string): Promise<boolean> {
 
     throw new Error(`Failed to inspect skill install path ${targetPath}: ${formatUnknownError(error)}`, { cause: error });
   }
+}
+
+async function inspectPath(targetPath: string): Promise<unknown> {
+  return lstat(targetPath);
 }
 
 function isMissingPathError(error: unknown): boolean {

--- a/src/main/add-subagent.test.ts
+++ b/src/main/add-subagent.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, readFile, readlink, rm } from 'node:fs/promises';
+import { chmod, lstat, mkdir, mkdtemp, readFile, readlink, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -72,6 +72,29 @@ describe('addSubagent', () => {
     const canonicalPath = path.join(paths.sandboxRoot, '.agents', 'agents', 'codex-reviewer.md');
     await expect(readFile(canonicalPath, 'utf8')).resolves.toContain('Use Codex-specific review guidance.');
     expect(snapshot.subagents?.some((subagent) => subagent.name === 'codex-reviewer')).toBe(true);
+  });
+
+  it('fails instead of treating an uninspectable install path as available', async () => {
+    const paths = await createSandboxPaths();
+    const canonicalSubagentsDir = path.join(path.dirname(paths.sandboxCanonicalUserSkillsDir), 'agents');
+    await mkdir(canonicalSubagentsDir, { recursive: true });
+    await chmod(canonicalSubagentsDir, 0o600);
+
+    try {
+      await expect(addSubagent({
+        sourceType: 'fields',
+        name: 'blocked-reviewer',
+        description: 'Reviews blocked paths.',
+        prompt: 'Review blocked paths.',
+      }, {
+        includeSandboxSources: true,
+        includeLiveSources: false,
+        paths,
+        homeDir: path.dirname(paths.dataDir),
+      })).rejects.toThrow(`Failed to inspect subagent install path ${path.join(canonicalSubagentsDir, 'blocked-reviewer.md')}`);
+    } finally {
+      await chmod(canonicalSubagentsDir, 0o700);
+    }
   });
 });
 

--- a/src/main/add-subagent.test.ts
+++ b/src/main/add-subagent.test.ts
@@ -1,4 +1,4 @@
-import { chmod, lstat, mkdir, mkdtemp, readFile, readlink, rm } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readFile, readlink, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -77,24 +77,27 @@ describe('addSubagent', () => {
   it('fails instead of treating an uninspectable install path as available', async () => {
     const paths = await createSandboxPaths();
     const canonicalSubagentsDir = path.join(path.dirname(paths.sandboxCanonicalUserSkillsDir), 'agents');
-    await mkdir(canonicalSubagentsDir, { recursive: true });
-    await chmod(canonicalSubagentsDir, 0o600);
+    const blockedSubagentPath = path.join(canonicalSubagentsDir, 'blocked-reviewer.md');
+    const permissionError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
 
-    try {
-      await expect(addSubagent({
-        sourceType: 'fields',
-        name: 'blocked-reviewer',
-        description: 'Reviews blocked paths.',
-        prompt: 'Review blocked paths.',
-      }, {
-        includeSandboxSources: true,
-        includeLiveSources: false,
-        paths,
-        homeDir: path.dirname(paths.dataDir),
-      })).rejects.toThrow(`Failed to inspect subagent install path ${path.join(canonicalSubagentsDir, 'blocked-reviewer.md')}`);
-    } finally {
-      await chmod(canonicalSubagentsDir, 0o700);
-    }
+    await expect(addSubagent({
+      sourceType: 'fields',
+      name: 'blocked-reviewer',
+      description: 'Reviews blocked paths.',
+      prompt: 'Review blocked paths.',
+    }, {
+      includeSandboxSources: true,
+      includeLiveSources: false,
+      paths,
+      homeDir: path.dirname(paths.dataDir),
+      inspectInstallPath: async (targetPath) => {
+        if (targetPath === blockedSubagentPath) {
+          throw permissionError;
+        }
+
+        return lstat(targetPath);
+      },
+    })).rejects.toThrow(`Failed to inspect subagent install path ${blockedSubagentPath}: permission denied`);
   });
 });
 

--- a/src/main/add-subagent.ts
+++ b/src/main/add-subagent.ts
@@ -29,7 +29,10 @@ import {
   type PortableSubagentDefinition,
 } from '@main/subagent-inventory';
 
+type InspectInstallPath = (targetPath: string) => Promise<unknown>;
+
 export interface AddSubagentOptions extends ScanSkillInventoryOptions {
+  inspectInstallPath?: InspectInstallPath;
   paths?: SkillIndexPaths;
 }
 
@@ -64,7 +67,10 @@ export async function addSubagent(
   );
   const targetPaths = buildSubagentInstallTargets(definition, canonicalPath, installTargets);
 
-  await assertInstallPathsAreAvailable([canonicalPath, ...targetPaths.map((target) => target.path)]);
+  await assertInstallPathsAreAvailable(
+    [canonicalPath, ...targetPaths.map((target) => target.path)],
+    options.inspectInstallPath ?? inspectPath,
+  );
   await mkdir(path.dirname(canonicalPath), { recursive: true });
   await writeFile(canonicalPath, renderPortableSubagentDefinition(definition, 'markdown-frontmatter'), 'utf8');
 
@@ -241,18 +247,24 @@ function resolveInstallScope(options: ScanSkillInventoryOptions): 'sandbox' | 'l
   return includeSandboxSources ? 'sandbox' : 'live';
 }
 
-async function assertInstallPathsAreAvailable(filePaths: string[]): Promise<void> {
+async function assertInstallPathsAreAvailable(
+  filePaths: string[],
+  inspectInstallPath: InspectInstallPath,
+): Promise<void> {
   const plannedPaths = [...new Set(filePaths.map((filePath) => path.normalize(filePath)))];
   for (const filePath of plannedPaths) {
-    if (await pathExists(filePath)) {
+    if (await pathExists(filePath, inspectInstallPath)) {
       throw new Error(`A subagent already exists at ${filePath}. Remove or rename it before adding this subagent.`);
     }
   }
 }
 
-async function pathExists(targetPath: string): Promise<boolean> {
+async function pathExists(
+  targetPath: string,
+  inspectInstallPath: InspectInstallPath,
+): Promise<boolean> {
   try {
-    await lstat(targetPath);
+    await inspectInstallPath(targetPath);
     return true;
   } catch (error) {
     if (isMissingPathError(error)) {
@@ -261,6 +273,10 @@ async function pathExists(targetPath: string): Promise<boolean> {
 
     throw new Error(`Failed to inspect subagent install path ${targetPath}: ${formatUnknownError(error)}`, { cause: error });
   }
+}
+
+async function inspectPath(targetPath: string): Promise<unknown> {
+  return lstat(targetPath);
 }
 
 function isMissingPathError(error: unknown): boolean {

--- a/src/main/add-subagent.ts
+++ b/src/main/add-subagent.ts
@@ -254,7 +254,31 @@ async function pathExists(targetPath: string): Promise<boolean> {
   try {
     await lstat(targetPath);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false;
+    }
+
+    throw new Error(`Failed to inspect subagent install path ${targetPath}: ${formatUnknownError(error)}`, { cause: error });
   }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return isErrnoException(error) && (error.code === 'ENOENT' || error.code === 'ENOTDIR');
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === 'object' && error !== null && 'code' in error;
+}
+
+function formatUnknownError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return 'Unknown error';
 }

--- a/src/main/auto-update.test.ts
+++ b/src/main/auto-update.test.ts
@@ -7,6 +7,8 @@ import {
   getAutoUpdateStatus,
   requestAutoUpdateCheck,
   shouldEnableAutoUpdates,
+  type AutoUpdaterEvent,
+  type AutoUpdaterEventMap,
 } from './auto-update';
 
 describe('auto-update lifecycle', () => {
@@ -53,7 +55,7 @@ describe('auto-update lifecycle', () => {
     const runtime = createRuntime({ buildFlavor: 'standard', isPackaged: true });
 
     configureAutoUpdates(runtime);
-    runtime.listeners.get('update-available')?.({ version: '0.2.0' });
+    runtime.listeners.get('update-available')?.(createUpdateInfo('0.2.0'));
     const downloadingStatus = getAutoUpdateStatus();
     expect(downloadingStatus.phase).toBe('downloading');
     expect(downloadingStatus.version).toBe('0.2.0');
@@ -61,6 +63,7 @@ describe('auto-update lifecycle', () => {
 
     runtime.listeners.get('download-progress')?.({
       bytesPerSecond: 1_024_000,
+      delta: 6_600_000,
       percent: 23.5714,
       total: 28_000_000,
       transferred: 6_600_000,
@@ -76,7 +79,10 @@ describe('auto-update lifecycle', () => {
       version: '0.2.0',
     }));
 
-    runtime.listeners.get('update-downloaded')?.({ version: '0.2.0' });
+    runtime.listeners.get('update-downloaded')?.({
+      ...createUpdateInfo('0.2.0'),
+      downloadedFile: '/tmp/Skill Index-0.2.0.zip',
+    });
     const readyStatus = getAutoUpdateStatus();
     expect(readyStatus.phase).toBe('ready');
     expect(readyStatus.version).toBe('0.2.0');
@@ -100,14 +106,14 @@ interface RuntimeOptions {
 }
 
 function createRuntime(options: RuntimeOptions) {
-  const listeners = new Map<string, (...args: unknown[]) => void>();
+  const listeners = createAutoUpdaterListenerRegistry();
   const scheduledTimeouts: Array<() => void> = [];
   const scheduledIntervals: Array<() => void> = [];
   const updater = {
     autoDownload: false,
     autoInstallOnAppQuit: true,
-    checkForUpdates: vi.fn<() => Promise<unknown>>().mockResolvedValue(null),
-    on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+    checkForUpdates: vi.fn<() => Promise<null>>().mockResolvedValue(null),
+    on: vi.fn(<Event extends AutoUpdaterEvent>(event: Event, listener: AutoUpdaterEventMap[Event]) => {
       listeners.set(event, listener);
       return updater;
     }),
@@ -133,5 +139,28 @@ function createRuntime(options: RuntimeOptions) {
       return 1;
     }),
     updater,
+  };
+}
+
+function createAutoUpdaterListenerRegistry() {
+  const listeners: Partial<AutoUpdaterEventMap> = {};
+
+  return {
+    get<Event extends AutoUpdaterEvent>(event: Event): AutoUpdaterEventMap[Event] | undefined {
+      return listeners[event] as AutoUpdaterEventMap[Event] | undefined;
+    },
+    set<Event extends AutoUpdaterEvent>(event: Event, listener: AutoUpdaterEventMap[Event]): void {
+      listeners[event] = listener;
+    },
+  };
+}
+
+function createUpdateInfo(version: string): Parameters<AutoUpdaterEventMap['update-available']>[0] {
+  return {
+    files: [],
+    path: '',
+    releaseDate: '2026-05-17T00:00:00.000Z',
+    sha512: '',
+    version,
   };
 }

--- a/src/main/auto-update.ts
+++ b/src/main/auto-update.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import type { ProgressInfo, UpdateCheckResult, UpdateDownloadedEvent, UpdateInfo } from 'electron-updater';
 
 import { getSkillIndexBuildFlavor, type SkillIndexBuildFlavor } from '@shared/build-flavor';
 import { IPC_CHANNELS, type AutoUpdateDownloadProgress, type AutoUpdateStatus } from '@shared/contracts';
@@ -13,19 +14,25 @@ export interface AutoUpdateEligibility {
   disableAutoUpdate?: boolean;
 }
 
-type AutoUpdaterEvent = 'error'
-  | 'checking-for-update'
-  | 'download-progress'
-  | 'update-available'
-  | 'update-downloaded'
-  | 'update-not-available';
+export interface AutoUpdaterEventMap {
+  error: (error: Error, message?: string) => void;
+  'checking-for-update': () => void;
+  'download-progress': (info: ProgressInfo) => void;
+  'update-available': (info: UpdateInfo) => void;
+  'update-downloaded': (info: UpdateDownloadedEvent) => void;
+  'update-not-available': (info: UpdateInfo) => void;
+}
+
+export type AutoUpdaterEvent = keyof AutoUpdaterEventMap;
+
+type TimerHandle = NodeJS.Timeout | number;
 
 interface AutoUpdaterLike {
   autoDownload: boolean;
   autoInstallOnAppQuit: boolean;
-  checkForUpdates(): Promise<unknown>;
+  checkForUpdates(): Promise<UpdateCheckResult | null>;
   quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void;
-  on(event: AutoUpdaterEvent, listener: (...args: unknown[]) => void): unknown;
+  on<Event extends AutoUpdaterEvent>(event: Event, listener: AutoUpdaterEventMap[Event]): AutoUpdaterLike;
 }
 
 interface AutoUpdateRuntime {
@@ -33,8 +40,8 @@ interface AutoUpdateRuntime {
   disableAutoUpdate?: boolean;
   isPackaged: boolean;
   logger: Pick<Console, 'error' | 'info'>;
-  setInterval: (callback: () => void, delayMs: number) => unknown;
-  setTimeout: (callback: () => void, delayMs: number) => unknown;
+  setInterval: (callback: () => void, delayMs: number) => TimerHandle;
+  setTimeout: (callback: () => void, delayMs: number) => TimerHandle;
   updater: AutoUpdaterLike;
 }
 
@@ -72,7 +79,7 @@ export function configureAutoUpdates(runtime: AutoUpdateRuntime): boolean {
   runtime.updater.on('update-available', (info) => {
     setAutoUpdateStatus({
       phase: 'downloading',
-      version: readUpdateVersion(info),
+      version: info.version,
       lastCheckedAt: new Date().toISOString(),
     });
   });
@@ -81,13 +88,13 @@ export function configureAutoUpdates(runtime: AutoUpdateRuntime): boolean {
       ...getAutoUpdateStatus(),
       downloadProgress: readDownloadProgress(info),
       phase: 'downloading',
-      version: getAutoUpdateStatus().version ?? readUpdateVersion(info),
+      version: getAutoUpdateStatus().version,
     });
   });
   runtime.updater.on('update-downloaded', (info) => {
     setAutoUpdateStatus({
       phase: 'ready',
-      version: readUpdateVersion(info) ?? getAutoUpdateStatus().version,
+      version: info.version,
       lastCheckedAt: new Date().toISOString(),
     });
   });
@@ -195,32 +202,18 @@ function broadcastAutoUpdateStatus(status: AutoUpdateStatus): void {
   }
 }
 
-function readUpdateVersion(info: unknown): string | undefined {
-  if (!info || typeof info !== 'object' || !('version' in info)) {
-    return undefined;
-  }
-
-  const version = (info as { version?: unknown }).version;
-  return typeof version === 'string' ? version : undefined;
-}
-
-function readDownloadProgress(info: unknown): AutoUpdateDownloadProgress | undefined {
-  if (!info || typeof info !== 'object') {
-    return undefined;
-  }
-
+function readDownloadProgress(info: ProgressInfo): AutoUpdateDownloadProgress | undefined {
   const downloadProgress = removeUndefinedFields({
-    bytesPerSecond: readFiniteNumberField(info, 'bytesPerSecond'),
-    percent: readFiniteNumberField(info, 'percent'),
-    totalBytes: readFiniteNumberField(info, 'total'),
-    transferredBytes: readFiniteNumberField(info, 'transferred'),
+    bytesPerSecond: readFiniteNumber(info.bytesPerSecond),
+    percent: readFiniteNumber(info.percent),
+    totalBytes: readFiniteNumber(info.total),
+    transferredBytes: readFiniteNumber(info.transferred),
   });
 
   return Object.keys(downloadProgress).length > 0 ? downloadProgress : undefined;
 }
 
-function readFiniteNumberField(source: object, field: string): number | undefined {
-  const value = (source as Record<string, unknown>)[field];
+function readFiniteNumber(value: number): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 

--- a/src/main/inventory-runtime.test.ts
+++ b/src/main/inventory-runtime.test.ts
@@ -641,7 +641,7 @@ describe('inventory runtime', () => {
       },
     });
     const connectivityDeferred = createDeferred<McpConnectivityRecord>();
-    let connectivityProbeStarted = false;
+    const connectivityProbeStarted = createDeferred<void>();
 
     const runtime = createInventoryRuntime();
     runtimes.push(runtime);
@@ -663,14 +663,12 @@ describe('inventory runtime', () => {
       includeLiveSources: false,
       mcpConnectivityConcurrency: 1,
       verifyMcpConnectivity: async () => {
-        connectivityProbeStarted = true;
+        connectivityProbeStarted.resolve();
         return connectivityDeferred.promise;
       },
     });
 
-    await waitFor(() => {
-      expect(connectivityProbeStarted).toBe(true);
-    });
+    await connectivityProbeStarted.promise;
 
     const dismissPromise = runtime.dismissDrift({
       skillName: 'identical-drift-skill',
@@ -710,7 +708,7 @@ describe('inventory runtime', () => {
       },
     });
     const connectivityDeferred = createDeferred<McpConnectivityRecord>();
-    let connectivityProbeStarted = false;
+    const connectivityProbeStarted = createDeferred<void>();
 
     const runtime = createInventoryRuntime();
     runtimes.push(runtime);
@@ -733,14 +731,12 @@ describe('inventory runtime', () => {
       includeLiveSources: false,
       mcpConnectivityConcurrency: 1,
       verifyMcpConnectivity: async () => {
-        connectivityProbeStarted = true;
+        connectivityProbeStarted.resolve();
         return connectivityDeferred.promise;
       },
     });
 
-    await waitFor(() => {
-      expect(connectivityProbeStarted).toBe(true);
-    });
+    await connectivityProbeStarted.promise;
 
     runtime.cancelMcpConnectivityTest();
 

--- a/src/main/inventory-runtime.ts
+++ b/src/main/inventory-runtime.ts
@@ -270,7 +270,8 @@ export function createInventoryRuntime(options: CreateInventoryRuntimeOptions = 
   };
 
   const refreshInventory = async (optionsOverride?: ScanSkillInventoryOptions): Promise<SkillInventorySnapshot> => {
-    // Connectivity probing is an explicit one-shot choice; keep source options sticky without making later watcher refreshes inherit probe cost.
+    // Connectivity probing is a one-shot option; watcher refreshes should keep
+    // source choices without inheriting probe cost.
     const verifyMcpConnectivity = optionsOverride?.verifyMcpConnectivity;
     lastScanOptions = resolvePersistentRefreshOptions(optionsOverride);
 

--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -4,7 +4,16 @@ import path from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { IPC_CHANNELS } from '@shared/contracts';
+import {
+  IPC_CHANNELS,
+  type AuditOperation,
+  type CompleteOnboardingRequest,
+  type RescanInventoryRequest,
+  type SeedRepresentativeFixturesResult,
+  type SettingsState,
+  type SkillInventorySnapshot,
+  type UndoAuditOperationResult,
+} from '@shared/contracts';
 import { createInventoryRuntime } from '@main/inventory-runtime';
 import { getInventoryMode, setInventoryMode } from '@main/inventory-mode-session';
 import { completeOnboarding, setDevSidebarInventorySourceSwitcherVisible } from '@main/settings-state';
@@ -159,7 +168,7 @@ describe('registerIpcHandlers', () => {
 
       const seedHandler = electronMocks.ipcHandle.mock.calls.find(
         ([channel]) => channel === IPC_CHANNELS.seedRepresentativeFixtures,
-      )?.[1] as (() => Promise<unknown>) | undefined;
+      )?.[1] as (() => Promise<SeedRepresentativeFixturesResult>) | undefined;
 
       expect(seedHandler).toBeTypeOf('function');
 
@@ -255,7 +264,7 @@ describe('registerIpcHandlers', () => {
 
     const completeOnboardingHandler = electronMocks.ipcHandle.mock.calls.find(
       ([channel]) => channel === IPC_CHANNELS.completeOnboarding,
-    )?.[1] as ((_event: never, request?: { completedAt?: string; preferredCanonicalSourcePath?: string | null }) => Promise<unknown>) | undefined;
+    )?.[1] as ((_event: never, request?: CompleteOnboardingRequest) => Promise<SettingsState>) | undefined;
 
     expect(completeOnboardingHandler).toBeTypeOf('function');
 
@@ -300,10 +309,10 @@ describe('registerIpcHandlers', () => {
 
     const readAuditHandler = electronMocks.ipcHandle.mock.calls.find(
       ([channel]) => channel === IPC_CHANNELS.readAuditLog,
-    )?.[1] as ((_event: never, options?: { limit?: number }) => Promise<unknown>) | undefined;
+    )?.[1] as ((_event: never, options?: { limit?: number }) => Promise<AuditOperation[]>) | undefined;
     const undoAuditHandler = electronMocks.ipcHandle.mock.calls.find(
       ([channel]) => channel === IPC_CHANNELS.undoAuditOperation,
-    )?.[1] as ((_event: never, operationId: string) => Promise<unknown>) | undefined;
+    )?.[1] as ((_event: never, operationId: string) => Promise<UndoAuditOperationResult>) | undefined;
 
     expect(readAuditHandler).toBeTypeOf('function');
     expect(undoAuditHandler).toBeTypeOf('function');
@@ -349,7 +358,7 @@ describe('registerIpcHandlers', () => {
 
       const setSwitcherHandler = electronMocks.ipcHandle.mock.calls.find(
         ([channel]) => channel === IPC_CHANNELS.setDevSidebarInventorySourceSwitcherVisible,
-      )?.[1] as ((_event: never, visible: boolean) => Promise<unknown>) | undefined;
+      )?.[1] as ((_event: never, visible: boolean) => Promise<SettingsState>) | undefined;
 
       expect(setSwitcherHandler).toBeTypeOf('function');
 
@@ -399,7 +408,7 @@ describe('registerIpcHandlers', () => {
 
     const rescanHandler = electronMocks.ipcHandle.mock.calls.find(
       ([channel]) => channel === IPC_CHANNELS.rescanInventory,
-    )?.[1] as ((event: never, request?: { verifyMcpConnectivity?: boolean }) => Promise<unknown>) | undefined;
+    )?.[1] as ((event: never, request?: RescanInventoryRequest) => Promise<SkillInventorySnapshot>) | undefined;
 
     expect(rescanHandler).toBeTypeOf('function');
 
@@ -422,7 +431,7 @@ describe('registerIpcHandlers', () => {
 
     const testConnectivityHandler = electronMocks.ipcHandle.mock.calls.find(
       ([channel]) => channel === IPC_CHANNELS.testMcpConnectivity,
-    )?.[1] as (() => Promise<unknown>) | undefined;
+    )?.[1] as (() => Promise<SkillInventorySnapshot>) | undefined;
 
     expect(testConnectivityHandler).toBeTypeOf('function');
 
@@ -435,7 +444,7 @@ describe('registerIpcHandlers', () => {
     expect(inventoryRuntime.testMcpConnectivity).toHaveBeenCalledWith(expect.objectContaining({}));
   });
 
-  it('registers a standalone MCP connectivity cancellation handler', async () => {
+  it('registers a standalone MCP connectivity cancellation handler', () => {
     electronMocks.ipcHandle.mockClear();
     inventoryRuntime.cancelMcpConnectivityTest.mockClear();
 
@@ -443,7 +452,7 @@ describe('registerIpcHandlers', () => {
 
     const cancelConnectivityHandler = electronMocks.ipcHandle.mock.calls.find(
       ([channel]) => channel === IPC_CHANNELS.cancelMcpConnectivityTest,
-    )?.[1] as (() => Promise<unknown>) | undefined;
+    )?.[1] as (() => void) | undefined;
 
     expect(cancelConnectivityHandler).toBeTypeOf('function');
 
@@ -451,7 +460,7 @@ describe('registerIpcHandlers', () => {
       throw new Error('Expected the MCP connectivity cancellation IPC handler to be registered.');
     }
 
-    await cancelConnectivityHandler();
+    cancelConnectivityHandler();
 
     expect(inventoryRuntime.cancelMcpConnectivityTest).toHaveBeenCalledTimes(1);
   });

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -20,7 +20,14 @@ import type {
   SubagentLocationRecord,
   SubagentRecord,
 } from '@shared/contracts';
-import { MCP_AGENT_LOCAL_KEY, buildPortableMcpDefinition, isMcpDefinitionObject, isMcpServerDefinitions, splitMcpDefinitionForComparison } from '@shared/mcp-definition';
+import {
+  MCP_AGENT_LOCAL_KEY,
+  buildPortableMcpDefinition,
+  getMcpDefinitionArgs,
+  isMcpDefinitionObject,
+  isMcpServerDefinitions,
+  splitMcpDefinitionForComparison,
+} from '@shared/mcp-definition';
 import {
   ensureSkillIndexLayout,
   resolveSkillIndexPaths,
@@ -263,11 +270,7 @@ function canBuildWritableMcpMutationTarget(
   agentId: string,
   configPath: string | undefined,
 ): boolean {
-  try {
-    return buildWritableMcpMutationTarget(snapshot, agentId, configPath) !== null;
-  } catch {
-    return false;
-  }
+  return buildWritableMcpMutationTarget(snapshot, agentId, configPath) !== null;
 }
 
 function getMcpResolutionComparisonKey(location: McpLocationRecord): string {
@@ -2040,7 +2043,7 @@ function toOpenCodeMcpDefinition(definition: McpDefinitionValue): McpDefinitionO
   };
   const command = getMcpCommand(normalizedDefinition);
   if (command) {
-    localDefinition.command = [command, ...getMcpArgs(normalizedDefinition)];
+    localDefinition.command = [command, ...getMcpDefinitionArgs(normalizedDefinition)];
   }
   const environment = isMcpDefinitionObject(normalizedDefinition.environment)
     ? normalizedDefinition.environment
@@ -2129,16 +2132,6 @@ function getMcpCommand(definition: McpDefinitionObject): string | undefined {
   }
 
   return getNonEmptyString(command);
-}
-
-function getMcpArgs(definition: McpDefinitionObject): string[] {
-  if (Array.isArray(definition.command)) {
-    return definition.command.slice(1).filter((value): value is string => typeof value === 'string');
-  }
-
-  return Array.isArray(definition.args)
-    ? definition.args.filter((value): value is string => typeof value === 'string')
-    : [];
 }
 
 function getNonEmptyString(value: McpDefinitionValue | undefined): string | undefined {

--- a/src/main/mcp-connectivity-transport.test.ts
+++ b/src/main/mcp-connectivity-transport.test.ts
@@ -2,13 +2,15 @@
 
 import path from 'node:path';
 
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { McpLocationRecord } from '@shared/contracts';
 
 interface MockClientConnectCall {
-  transport: unknown;
-  options: unknown;
+  transport: Transport;
+  options?: RequestOptions;
 }
 
 interface MockClientInstance {
@@ -56,7 +58,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
       sdkRecords.clients.push(this);
     }
 
-    connect(transport: unknown, options: unknown): Promise<void> {
+    connect(transport: Transport, options?: RequestOptions): Promise<void> {
       this.connectCalls.push({ transport, options });
       return Promise.resolve();
     }

--- a/src/main/mcp-inventory.ts
+++ b/src/main/mcp-inventory.ts
@@ -22,7 +22,14 @@ import type {
   RemoteMcpTransportKind,
   SkillScanSource,
 } from '@shared/contracts';
-import { isMcpDefinitionObject, isMcpServerDefinitions, splitMcpDefinitionForComparison } from '@shared/mcp-definition';
+import {
+  getMcpDefinitionArgs,
+  getMcpDefinitionCommand,
+  getMcpDefinitionRemoteUrl,
+  isMcpDefinitionObject,
+  isMcpServerDefinitions,
+  splitMcpDefinitionForComparison,
+} from '@shared/mcp-definition';
 import { parseTomlMcpServerArray, parseTomlMcpServers } from '@shared/toml-mcp';
 
 import { sanitizeJsonc, stableStringify } from '@main/json-utils';
@@ -766,7 +773,7 @@ function buildMcpEntry(name: string, definition: McpDefinitionValue, owner: McpO
   const connection = resolveMcpConnection(normalizedDefinition);
   invalidDetails.push(...connection.invalidDetails);
 
-  const args = getMcpArgs(normalizedDefinition);
+  const args = getMcpDefinitionArgs(normalizedDefinition);
   const splitDefinition = splitMcpDefinitionForComparison(normalizedDefinition, connection);
   const coreComparisonKey = stableStringify(splitDefinition.core);
   const nativeComparisonKey = stableStringify(splitDefinition.native);
@@ -857,8 +864,8 @@ function getMcpDefinitionComparisonKey(location: McpLocationRecord): string {
 }
 
 function resolveMcpConnection(definition: McpDefinitionObject): ResolvedMcpConnection {
-  const command = getMcpCommand(definition);
-  const url = getMcpRemoteUrl(definition);
+  const command = getMcpDefinitionCommand(definition);
+  const url = getMcpDefinitionRemoteUrl(definition);
   const explicitTransport = getExplicitMcpTransport(definition);
   const inferredTransport = explicitTransport.transport ?? inferMcpTransport({
     command,
@@ -889,29 +896,6 @@ function resolveMcpConnection(definition: McpDefinitionObject): ResolvedMcpConne
 
 function getNonEmptyString(value: McpDefinitionValue | undefined): string | undefined {
   return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
-}
-
-function getMcpRemoteUrl(definition: McpDefinitionObject): string | undefined {
-  return getNonEmptyString(definition.httpUrl) ?? getNonEmptyString(definition.url);
-}
-
-function getMcpCommand(definition: McpDefinitionObject): string | undefined {
-  const command = definition.command;
-  if (Array.isArray(command)) {
-    return getNonEmptyString(command[0]);
-  }
-
-  return getNonEmptyString(command);
-}
-
-function getMcpArgs(definition: McpDefinitionObject): string[] {
-  if (Array.isArray(definition.command)) {
-    return definition.command.slice(1).filter((value): value is string => typeof value === 'string');
-  }
-
-  return Array.isArray(definition.args)
-    ? definition.args.filter((value): value is string => typeof value === 'string')
-    : [];
 }
 
 function getExplicitMcpTransport(definition: McpDefinitionObject): NormalizedExplicitMcpTransport {

--- a/src/main/plugin-inventory.ts
+++ b/src/main/plugin-inventory.ts
@@ -133,7 +133,7 @@ export function buildPluginSkillScanSources(plugins: PluginRecord[]): SkillScanS
     })));
 }
 
-export function createPluginSourceId(plugin: Pick<PluginRecord, 'host' | 'pluginId' | 'version' | 'scope'>): string {
+function createPluginSourceId(plugin: Pick<PluginRecord, 'host' | 'pluginId' | 'version' | 'scope'>): string {
   const scopePrefix = plugin.scope === 'sandbox' ? 'sandbox:' : '';
   return `plugin:${scopePrefix}${plugin.host}:${plugin.pluginId}:${plugin.version ?? 'unknown'}`;
 }
@@ -752,6 +752,7 @@ function isSubagentFileName(fileName: string): boolean {
 }
 
 async function readPluginSubagentName(agentPath: string): Promise<string> {
+  const fallbackName = path.basename(agentPath).replace(/(?:\.agent)?\.(?:md|toml|jsonc?|ya?ml)$/iu, '');
   try {
     const raw = await readFile(agentPath, 'utf8');
     const frontMatterName = readFrontMatterField(raw, 'name');
@@ -774,10 +775,10 @@ async function readPluginSubagentName(agentPath: string): Promise<string> {
       return parsedJson.name.trim();
     }
   } catch {
-    // Fall back to the filename below.
+    return fallbackName;
   }
 
-  return path.basename(agentPath).replace(/(?:\.agent)?\.(?:md|toml|jsonc?|ya?ml)$/iu, '');
+  return fallbackName;
 }
 
 function readFrontMatterField(raw: string, field: string): string | null {

--- a/src/main/scan-inventory.ts
+++ b/src/main/scan-inventory.ts
@@ -29,7 +29,6 @@ import {
   collectMcpRecords,
   compareMcps,
   countMcps,
-  reconcileCachedMcps,
 } from '@main/mcp-inventory';
 import { buildPluginSkillScanSources, scanPluginInventory } from '@main/plugin-inventory';
 import {
@@ -269,7 +268,7 @@ export async function dismissDrift(
   return nextSnapshot;
 }
 
-export async function resolveScanContext(options: ScanSkillInventoryOptions): Promise<{
+async function resolveScanContext(options: ScanSkillInventoryOptions): Promise<{
   config: SkillIndexConfig;
   paths: SkillIndexPaths;
   registeredSources: SkillScanSource[];
@@ -345,36 +344,4 @@ async function scanPluginsForOptions(options: ScanSkillInventoryOptions, paths: 
   ]);
 
   return pluginGroups.flat();
-}
-
-export function reconcileCachedInventory(
-  snapshot: SkillInventorySnapshot,
-  agents: SkillInventorySnapshot['agents'],
-  sources: SkillScanSource[],
-  plugins: PluginRecord[],
-  dismissedDriftSignatures: string[],
-  dismissedMcpSignatures: string[],
-  dismissedSubagentSignatures: string[],
-): SkillInventorySnapshot {
-  const activeAgents = agents ?? [];
-  const reconciledMcps = applyDismissedMcpState(
-    reconcileCachedMcps(snapshot.mcps ?? [], activeAgents, sources, plugins),
-    dismissedMcpSignatures,
-  );
-  const mcpCounts = countMcps(reconciledMcps);
-  const subagents = applyDismissedSubagentState(snapshot.subagents ?? [], dismissedSubagentSignatures);
-  const subagentCounts = countSubagents(subagents);
-  const agentCounts = countAgents(activeAgents);
-
-  return applyDismissedDriftState({
-    ...snapshot,
-    mcps: reconciledMcps,
-    mcpCounts,
-    subagents,
-    subagentCounts,
-    agents: activeAgents,
-    plugins,
-    agentCounts,
-    homeSummary: buildHomeSummary(snapshot.counts, mcpCounts, agentCounts),
-  }, dismissedDriftSignatures, sources);
 }

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -534,9 +534,22 @@ interface NpxSkillLockEntry {
   lockFilePath: string;
 }
 
+interface NpxSkillLockFile {
+  entries: Array<[string, NpxSkillLockRawEntry]>;
+}
+
+interface NpxSkillLockRawEntry {
+  pluginName?: unknown;
+  source?: unknown;
+  sourceType?: unknown;
+  sourceUrl?: unknown;
+  skillPath?: unknown;
+}
+
 const NPX_SKILL_LOCK_PARSE_FAILED = Symbol('npx-skill-lock-parse-failed');
 
-type NpxSkillLockCache = Map<string, unknown>;
+type NpxSkillLockCacheEntry = NpxSkillLockFile | typeof NPX_SKILL_LOCK_PARSE_FAILED;
+type NpxSkillLockCache = Map<string, NpxSkillLockCacheEntry>;
 
 function findNpxSkillLockEntry(
   rootPath: string,
@@ -576,7 +589,7 @@ function readNpxSkillLockEntry(
     return null;
   }
 
-  const entry = getSkillLockEntries(parsed).find(([lockedSkillName, candidate]) =>
+  const entry = parsed.entries.find(([lockedSkillName, candidate]) =>
     lockedSkillName === skillDirName || getLockEntrySkillDirName(candidate) === skillDirName)?.[1];
   if (!entry) {
     return null;
@@ -601,13 +614,13 @@ function readNpxSkillLockEntry(
   };
 }
 
-function readNpxSkillLockFile(lockFilePath: string, npxLockCache: NpxSkillLockCache): unknown {
+function readNpxSkillLockFile(lockFilePath: string, npxLockCache: NpxSkillLockCache): NpxSkillLockCacheEntry {
   if (npxLockCache.has(lockFilePath)) {
-    return npxLockCache.get(lockFilePath);
+    return npxLockCache.get(lockFilePath) ?? NPX_SKILL_LOCK_PARSE_FAILED;
   }
 
   try {
-    const parsed = JSON.parse(readFileSync(lockFilePath, 'utf8')) as unknown;
+    const parsed = parseNpxSkillLockFile(JSON.parse(readFileSync(lockFilePath, 'utf8')) as unknown);
     npxLockCache.set(lockFilePath, parsed);
     return parsed;
   } catch {
@@ -616,22 +629,32 @@ function readNpxSkillLockFile(lockFilePath: string, npxLockCache: NpxSkillLockCa
   }
 }
 
-function getSkillLockEntries(parsed: unknown): Array<[string, Record<string, unknown>]> {
+function parseNpxSkillLockFile(parsed: unknown): NpxSkillLockFile {
+  return {
+    entries: getSkillLockEntries(parsed),
+  };
+}
+
+function getSkillLockEntries(parsed: unknown): Array<[string, NpxSkillLockRawEntry]> {
   if (!isRecord(parsed) || !isRecord(parsed.skills)) {
     return [];
   }
 
-  return Object.entries(parsed.skills).filter((entry): entry is [string, Record<string, unknown>] =>
-    isRecord(entry[1]));
+  return Object.entries(parsed.skills).filter((entry): entry is [string, NpxSkillLockRawEntry] =>
+    isNpxSkillLockRawEntry(entry[1]));
 }
 
-function getLockEntrySkillDirName(entry: Record<string, unknown>): string | null {
+function getLockEntrySkillDirName(entry: NpxSkillLockRawEntry): string | null {
   const skillPath = getOptionalString(entry.skillPath);
   if (!skillPath) {
     return null;
   }
 
   return path.basename(path.dirname(skillPath));
+}
+
+function isNpxSkillLockRawEntry(value: unknown): value is NpxSkillLockRawEntry {
+  return isRecord(value);
 }
 
 function getOptionalString(value: unknown): string | undefined {
@@ -714,7 +737,7 @@ export function countAgents(agents: AgentRecord[]): AgentInventoryCounts {
   );
 }
 
-export function emptyAgentInventoryCounts(): AgentInventoryCounts {
+function emptyAgentInventoryCounts(): AgentInventoryCounts {
   return {
     totalAgents: 0,
     installedAgents: 0,

--- a/src/main/skill-universal-decisions.ts
+++ b/src/main/skill-universal-decisions.ts
@@ -47,7 +47,7 @@ export async function persistSkillUniversalDecisionForSelection(
   });
 }
 
-export function buildSkillUniversalOrigin(location: SkillLocationRecord): SkillUniversalOrigin {
+function buildSkillUniversalOrigin(location: SkillLocationRecord): SkillUniversalOrigin {
   const plugin = location.provenance?.plugin;
   if (plugin) {
     return {
@@ -66,7 +66,7 @@ export function buildSkillUniversalOrigin(location: SkillLocationRecord): SkillU
   };
 }
 
-export function buildSkillUniversalAlternate(location: SkillLocationRecord): SkillUniversalAlternate | null {
+function buildSkillUniversalAlternate(location: SkillLocationRecord): SkillUniversalAlternate | null {
   const plugin = location.provenance?.plugin;
   if (!plugin) {
     return null;

--- a/src/preload/bridge.test.ts
+++ b/src/preload/bridge.test.ts
@@ -249,7 +249,7 @@ describe('createSkillIndexDesktopApi', () => {
     await expect(api.readCachedInventory()).resolves.toEqual(inventorySnapshot);
     await expect(api.scanInventory()).resolves.toEqual(inventorySnapshot);
     await expect(api.rescanInventory({ verifyMcpConnectivity: false })).resolves.toEqual(inventorySnapshot);
-    await expect((api as unknown as { testMcpConnectivity(): Promise<SkillInventorySnapshot> }).testMcpConnectivity()).resolves.toEqual(inventorySnapshot);
+    await expect(api.testMcpConnectivity()).resolves.toEqual(inventorySnapshot);
     await expect(api.cancelMcpConnectivityTest()).resolves.toBeUndefined();
     await expect(api.addSkill({
       sourceType: 'url',

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -70,7 +70,7 @@ import { AgentsWorkspaceView } from './views/AgentsWorkspaceView';
 import { AuditWorkspaceView } from './views/AuditWorkspaceView';
 import { HomeDashboard } from './views/HomeDashboard';
 import { AddServerModal, McpWorkspaceView } from './views/McpWorkspaceView';
-import { OnboardingFlow } from './views/OnboardingFlow';
+import { OnboardingFlow, type OnboardingPreferredSourceSelection } from './views/OnboardingFlow';
 import { PluginsWorkspaceView } from './views/PluginsWorkspaceView';
 import { SettingsWorkspaceView } from './views/SettingsWorkspaceView';
 import { AddSkillModal, SkillsWorkspaceView } from './views/SkillsWorkspaceView';
@@ -89,11 +89,6 @@ function getAutoResolvableRequestsForSnapshot(
   ];
 
   return entity ? requests.filter((request) => request.entity === entity) : requests;
-}
-
-interface OnboardingPreferredSourceSelection {
-  didChangePreferredSource: boolean;
-  preferredSourcePath: string | null;
 }
 
 interface PendingRemoveItem {

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -20,7 +20,10 @@ import {
   buildSkillInspectorModel,
 } from './lib/detail-inspector-model';
 import { getHomeSummary } from './inventory-view-model';
-import { representativeInventorySnapshot } from './representative-preview-data';
+import {
+  representativeInventorySnapshot,
+  type SnapshotWithoutDetailDiagnostics,
+} from './representative-preview-data';
 import {
   AGENT_CATALOG,
   deriveAgentDefaultHomeDir,
@@ -4470,11 +4473,6 @@ function createRepresentativeWrongSymlinkTargetSkillSnapshot(): SkillInventorySn
 
   return snapshot;
 }
-
-type SkillRecordWithoutDetailDiagnostics = Omit<SkillInventorySnapshot['skills'][number], 'detailDiagnostics'>;
-type SnapshotWithoutDetailDiagnostics = Omit<SkillInventorySnapshot, 'skills'> & {
-  skills: SkillRecordWithoutDetailDiagnostics[];
-};
 
 const REPRESENTATIVE_SKILL_DESCRIPTIONS: Record<string, string> = {
   'diagnostic-rich-skill': 'Canonical detail candidate.',

--- a/src/renderer/src/components/ui.tsx
+++ b/src/renderer/src/components/ui.tsx
@@ -163,10 +163,6 @@ export function HeaderSearch({
   );
 }
 
-export function DetailValue({ value }: { value: string }) {
-  return <code className="detail-value">{value}</code>;
-}
-
 export function PageTopBar({
   actions,
   search,
@@ -656,46 +652,6 @@ function getAgentSubagentsTitle(agent: AgentRecord): string {
   }
 
   return agent.subagentsLocation?.path ?? getAgentSubagentsDisplayPath(agent);
-}
-
-export function SettingsCard({
-  children,
-  description,
-  title,
-}: {
-  children: ReactNode;
-  description?: string;
-  title: string;
-}) {
-  return (
-    <section className="settings-card">
-      <div className="settings-card-header">
-        <h3>{title}</h3>
-        {description ? <p>{description}</p> : null}
-      </div>
-      <div className="settings-card-body">{children}</div>
-    </section>
-  );
-}
-
-export function SettingsRow({
-  description,
-  label,
-  trailing,
-}: {
-  description: string;
-  label: string;
-  trailing: ReactNode;
-}) {
-  return (
-    <div className="settings-row">
-      <div className="settings-row-copy">
-        <strong>{label}</strong>
-        <p>{description}</p>
-      </div>
-      <div className="settings-row-trailing">{trailing}</div>
-    </div>
-  );
 }
 
 export function EmptyStatePanel({ message }: { message: string }) {

--- a/src/renderer/src/inventory-view-model.ts
+++ b/src/renderer/src/inventory-view-model.ts
@@ -205,16 +205,6 @@ export function filterSkillRows(rows: SkillRecord[], query: string): SkillRecord
   return rows.filter((row) => matchesSearchFields(normalizedQuery, [getSkillDisplayName(row), row.name, row.description]));
 }
 
-export function filterNamedRows<T extends { name: string }>(rows: T[], query: string): T[] {
-  const normalizedQuery = query.trim().toLocaleLowerCase();
-
-  if (!normalizedQuery) {
-    return rows;
-  }
-
-  return rows.filter((row) => row.name.toLocaleLowerCase().includes(normalizedQuery));
-}
-
 export function filterMcpRows(rows: McpRecord[], query: string): McpRecord[] {
   const normalizedQuery = query.trim().toLocaleLowerCase();
 

--- a/src/renderer/src/lib/inventory-presentation.ts
+++ b/src/renderer/src/lib/inventory-presentation.ts
@@ -4,7 +4,6 @@ import type {
   McpRecord,
   SkillDiffLine,
   SkillDriftPresentation,
-  SkillInventorySnapshot,
   SkillIssueReason,
   SkillRecord,
   SubagentIssueReason,
@@ -180,11 +179,6 @@ export function formatLastScanLabel(value: string | undefined): string {
 
   const hours = Math.round(minutes / 60);
   return `${hours}h ago`;
-}
-
-export function formatSidebarInventorySummary(snapshot: SkillInventorySnapshot): string {
-  const directoryCount = snapshot.sources.length;
-  return `${directoryCount} ${directoryCount === 1 ? 'directory' : 'directories'}`;
 }
 
 export function formatDiffLine(line: SkillDiffLine): string {

--- a/src/renderer/src/lib/inventory-workspace-dom.ts
+++ b/src/renderer/src/lib/inventory-workspace-dom.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+export function useCloseOnEscape({
+  disabled = false,
+  onClose,
+}: {
+  disabled?: boolean;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !disabled) {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [disabled, onClose]);
+}
+
+export function scrollSelectedInventoryRowIntoView(ariaLabel: string) {
+  window.requestAnimationFrame(() => {
+    const list = document.querySelector<HTMLElement>(`[aria-label="${ariaLabel}"]`);
+    const selectedRow = list?.querySelector<HTMLElement>('.master-list-row--selected');
+    selectedRow?.scrollIntoView?.({ block: 'nearest' });
+  });
+}

--- a/src/renderer/src/representative-preview-data.ts
+++ b/src/renderer/src/representative-preview-data.ts
@@ -1361,7 +1361,7 @@ function normalizeSkillEntrypointPath(
 }
 
 type SkillRecordWithoutDetailDiagnostics = Omit<SkillInventorySnapshot['skills'][number], 'detailDiagnostics'>;
-type SnapshotWithoutDetailDiagnostics = Omit<SkillInventorySnapshot, 'skills'> & {
+export type SnapshotWithoutDetailDiagnostics = Omit<SkillInventorySnapshot, 'skills'> & {
   skills: SkillRecordWithoutDetailDiagnostics[];
 };
 

--- a/src/renderer/src/views/McpWorkspaceView.tsx
+++ b/src/renderer/src/views/McpWorkspaceView.tsx
@@ -33,6 +33,7 @@ import {
   RescanToolbarButton,
   WorkspaceFilterBar,
 } from '../components/ui';
+import { scrollSelectedInventoryRowIntoView, useCloseOnEscape } from '../lib/inventory-workspace-dom';
 
 export function McpWorkspaceView({
   addActionControl,
@@ -271,19 +272,7 @@ export function AddServerModal({
   const [headersText, setHeadersText] = useState('');
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && !isSubmitting) {
-        event.preventDefault();
-        onClose();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isSubmitting, onClose]);
+  useCloseOnEscape({ disabled: isSubmitting, onClose });
 
   useEffect(() => {
     setSubmitError(null);
@@ -612,12 +601,4 @@ function McpDetailPanel({
       onVariantSelect={(path: string) => onSelectVariant(path)}
     />
   );
-}
-
-function scrollSelectedInventoryRowIntoView(ariaLabel: string) {
-  window.requestAnimationFrame(() => {
-    const list = document.querySelector<HTMLElement>(`[aria-label="${ariaLabel}"]`);
-    const selectedRow = list?.querySelector<HTMLElement>('.master-list-row--selected');
-    selectedRow?.scrollIntoView?.({ block: 'nearest' });
-  });
 }

--- a/src/renderer/src/views/SkillsWorkspaceView.tsx
+++ b/src/renderer/src/views/SkillsWorkspaceView.tsx
@@ -35,6 +35,7 @@ import {
   RescanToolbarButton,
   WorkspaceFilterBar,
 } from '../components/ui';
+import { scrollSelectedInventoryRowIntoView, useCloseOnEscape } from '../lib/inventory-workspace-dom';
 
 export function SkillsWorkspaceView({
   autoResolvableRequests = [],
@@ -399,14 +400,6 @@ function SkillDetailPanel({
   );
 }
 
-function scrollSelectedInventoryRowIntoView(ariaLabel: string) {
-  window.requestAnimationFrame(() => {
-    const list = document.querySelector<HTMLElement>(`[aria-label="${ariaLabel}"]`);
-    const selectedRow = list?.querySelector<HTMLElement>('.master-list-row--selected');
-    selectedRow?.scrollIntoView?.({ block: 'nearest' });
-  });
-}
-
 function hasPluginSkillLocation(skill: SkillRecord, sourceIndex: Map<string, SkillScanSource>): boolean {
   return skill.locations.some((location) =>
     location.provenance?.kind === 'plugin' || sourceIndex.get(location.sourceId)?.kind === 'plugin');
@@ -427,19 +420,7 @@ export function AddSkillModal({
   const [markdown, setMarkdown] = useState('');
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && !isSubmitting) {
-        event.preventDefault();
-        onClose();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isSubmitting, onClose]);
+  useCloseOnEscape({ disabled: isSubmitting, onClose });
 
   useEffect(() => {
     setSubmitError(null);

--- a/src/renderer/src/views/SubagentsWorkspaceView.tsx
+++ b/src/renderer/src/views/SubagentsWorkspaceView.tsx
@@ -36,6 +36,7 @@ import {
   RescanToolbarButton,
   WorkspaceFilterBar,
 } from '../components/ui';
+import { scrollSelectedInventoryRowIntoView, useCloseOnEscape } from '../lib/inventory-workspace-dom';
 
 export function SubagentsWorkspaceView({
   addActionControl,
@@ -371,19 +372,7 @@ export function AddSubagentModal({
   const [markdown, setMarkdown] = useState('');
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && !isSubmitting) {
-        event.preventDefault();
-        onClose();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isSubmitting, onClose]);
+  useCloseOnEscape({ disabled: isSubmitting, onClose });
 
   useEffect(() => {
     setSubmitError(null);
@@ -492,12 +481,4 @@ function hasPluginSubagentLocation(subagent: SubagentRecord): boolean {
   return subagent.locations.some((location) =>
     location.agentId.startsWith('plugin:')
     || location.provenance?.kind === 'plugin');
-}
-
-function scrollSelectedInventoryRowIntoView(ariaLabel: string) {
-  window.requestAnimationFrame(() => {
-    const list = document.querySelector<HTMLElement>(`[aria-label="${ariaLabel}"]`);
-    const selectedRow = list?.querySelector<HTMLElement>('.master-list-row--selected');
-    selectedRow?.scrollIntoView?.({ block: 'nearest' });
-  });
 }

--- a/src/shared/agent-catalog.ts
+++ b/src/shared/agent-catalog.ts
@@ -74,7 +74,7 @@ type AgentCatalogEntryInput = Omit<
   skillDirectoryMetadataSources?: readonly AgentMetadataSource[];
 };
 
-export function resolveAgentCatalogContext(context: AgentCatalogResolutionContext = {}): ResolvedAgentCatalogContext {
+function resolveAgentCatalogContext(context: AgentCatalogResolutionContext = {}): ResolvedAgentCatalogContext {
   return {
     cwd: context.cwd ?? process.cwd(),
     env: context.env ?? process.env,

--- a/src/shared/mcp-definition.test.ts
+++ b/src/shared/mcp-definition.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildPortableMcpDefinition, normalizeMcpDefinitionForComparison, splitMcpDefinitionForComparison } from './mcp-definition';
+import {
+  buildPortableMcpDefinition,
+  getMcpDefinitionArgs,
+  normalizeMcpDefinitionForComparison,
+  splitMcpDefinitionForComparison,
+} from './mcp-definition';
 
 describe('MCP definition normalization', () => {
   it('compares stdio definitions by launch and environment fields only', () => {
@@ -92,6 +97,24 @@ describe('MCP definition normalization', () => {
         'X-Api-Key': 'secret',
       },
     });
+  });
+
+  it('extracts portable stdio args from command arrays, args fields, and connection hints', () => {
+    expect(getMcpDefinitionArgs({
+      command: ['node', 'server.js', 42, '--verbose'],
+      args: ['ignored.js'],
+    })).toEqual(['server.js', '--verbose']);
+
+    expect(getMcpDefinitionArgs({
+      command: 'node',
+      args: ['server.js', 42, '--verbose'],
+    })).toEqual(['server.js', '--verbose']);
+
+    expect(getMcpDefinitionArgs({}, {
+      transport: 'stdio',
+      command: 'node',
+      args: ['hinted.js'],
+    })).toEqual(['hinted.js']);
   });
 
   it('splits portable core from agent-specific native fields', () => {

--- a/src/shared/mcp-definition.ts
+++ b/src/shared/mcp-definition.ts
@@ -47,12 +47,7 @@ export function normalizeMcpDefinitionForComparison(
   definition: McpDefinitionObject,
   connection?: McpDefinitionConnectionHint,
 ): McpServerDefinition {
-  const comparable = buildComparableMcpDefinition(definition, connection);
-  if (comparable.transport) {
-    return comparable;
-  }
-
-  return comparable;
+  return buildComparableMcpDefinition(definition, connection);
 }
 
 export function splitMcpDefinitionForComparison(
@@ -124,12 +119,12 @@ function buildComparableMcpDefinition(
   }
 
   if (transport === 'stdio' || (!transport && connection?.command)) {
-    const command = getMcpCommand(definition) ?? connection?.command;
+    const command = getMcpDefinitionCommand(definition) ?? connection?.command;
     if (command) {
       comparable.command = command;
     }
 
-    const args = getMcpArgs(definition, connection);
+    const args = getMcpDefinitionArgs(definition, connection);
     if (args.length > 0) {
       comparable.args = args;
     }
@@ -148,7 +143,7 @@ function buildComparableMcpDefinition(
   }
 
   if (isRemoteMcpTransport(transport) || (!transport && connection?.url)) {
-    const url = getMcpRemoteUrl(definition) ?? connection?.url;
+    const url = getMcpDefinitionRemoteUrl(definition) ?? connection?.url;
     if (url) {
       comparable.url = url;
     }
@@ -211,7 +206,7 @@ function getPortableMcpTransport(
     ?? normalizeMcpTransport(definition.type)
     ?? normalizeConnectionHintTransport(connection?.transport)
     ?? inferMcpTransport({
-      command: getMcpCommand(definition),
+      command: getMcpDefinitionCommand(definition),
       url: getNonEmptyString(definition.url),
       httpUrl: getNonEmptyString(definition.httpUrl),
     });
@@ -276,11 +271,11 @@ function getNonEmptyString(value: McpDefinitionValue | undefined): string | unde
   return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
 }
 
-function getMcpRemoteUrl(definition: McpDefinitionObject): string | undefined {
+export function getMcpDefinitionRemoteUrl(definition: McpDefinitionObject): string | undefined {
   return getNonEmptyString(definition.httpUrl) ?? getNonEmptyString(definition.url);
 }
 
-function getMcpCommand(definition: McpDefinitionObject): string | undefined {
+export function getMcpDefinitionCommand(definition: McpDefinitionObject): string | undefined {
   const command = definition.command;
   if (Array.isArray(command)) {
     return getNonEmptyString(command[0]);
@@ -289,7 +284,7 @@ function getMcpCommand(definition: McpDefinitionObject): string | undefined {
   return getNonEmptyString(command);
 }
 
-function getMcpArgs(
+export function getMcpDefinitionArgs(
   definition: McpDefinitionObject,
   connection?: McpDefinitionConnectionHint,
 ): string[] {

--- a/src/shared/skill-index-paths.ts
+++ b/src/shared/skill-index-paths.ts
@@ -117,11 +117,11 @@ export function resolveSandboxSkillIndexPaths(options: ResolveSkillIndexPathOpti
   return usesSandboxSkillIndexStatePaths(paths) ? paths : withSandboxSkillIndexState(paths);
 }
 
-export function usesSandboxSkillIndexState(options: Pick<ResolveSkillIndexScanPathOptions, 'includeSandboxSources' | 'includeLiveSources'>): boolean {
+function usesSandboxSkillIndexState(options: Pick<ResolveSkillIndexScanPathOptions, 'includeSandboxSources' | 'includeLiveSources'>): boolean {
   return options.includeSandboxSources === true && options.includeLiveSources === false;
 }
 
-export function usesSandboxSkillIndexStatePaths(paths: SkillIndexPaths): boolean {
+function usesSandboxSkillIndexStatePaths(paths: SkillIndexPaths): boolean {
   return path.basename(paths.dataDir) === 'sandbox-state'
     && paths.auditLogFile === path.join(paths.dataDir, 'audit-log.jsonl')
     && paths.cacheFile === path.join(paths.dataDir, 'cache.json')
@@ -250,12 +250,12 @@ export function normalizeCustomScanPath(scanPath: string, options: ResolveSkillI
 }
 
 function normalizeConfiguredCustomScanPaths(
-  scanPaths: string[],
+  scanPaths: readonly unknown[],
   options: ResolveSkillIndexPathOptions,
 ): string[] {
   return [...new Set(
     scanPaths
-      .filter((scanPath) => typeof scanPath === 'string' && scanPath.trim().length > 0)
+      .filter((scanPath): scanPath is string => typeof scanPath === 'string' && scanPath.trim().length > 0)
       .map((scanPath) => normalizeCustomScanPath(scanPath, options)),
   )];
 }
@@ -290,26 +290,27 @@ function isString(value: unknown): value is string {
 }
 
 function parseSkillIndexConfig(raw: string, options: ResolveSkillIndexPathOptions): SkillIndexConfig {
-  const parsed = JSON.parse(raw) as Partial<SkillIndexConfig>;
+  const parsed = JSON.parse(raw) as unknown;
+  const config = isRecord(parsed) ? parsed : {};
 
   return {
-    customScanPaths: Array.isArray(parsed.customScanPaths)
-      ? normalizeConfiguredCustomScanPaths(parsed.customScanPaths, options)
+    customScanPaths: Array.isArray(config.customScanPaths)
+      ? normalizeConfiguredCustomScanPaths(config.customScanPaths, options)
       : [],
-    preferredCanonicalSourcePath: normalizeConfiguredOptionalPath(parsed.preferredCanonicalSourcePath, options),
-    showDevSidebarInventorySourceSwitcher: parsed.showDevSidebarInventorySourceSwitcher !== false,
-    onboardingCompletedAt: normalizeConfiguredOptionalTimestamp(parsed.onboardingCompletedAt),
-    dismissedDriftSignatures: Array.isArray(parsed.dismissedDriftSignatures)
-      ? parsed.dismissedDriftSignatures.filter(isString)
+    preferredCanonicalSourcePath: normalizeConfiguredOptionalPath(config.preferredCanonicalSourcePath, options),
+    showDevSidebarInventorySourceSwitcher: config.showDevSidebarInventorySourceSwitcher !== false,
+    onboardingCompletedAt: normalizeConfiguredOptionalTimestamp(config.onboardingCompletedAt),
+    dismissedDriftSignatures: Array.isArray(config.dismissedDriftSignatures)
+      ? config.dismissedDriftSignatures.filter(isString)
       : [],
-    dismissedMcpSignatures: Array.isArray(parsed.dismissedMcpSignatures)
-      ? parsed.dismissedMcpSignatures.filter(isString)
+    dismissedMcpSignatures: Array.isArray(config.dismissedMcpSignatures)
+      ? config.dismissedMcpSignatures.filter(isString)
       : [],
-    dismissedSubagentSignatures: Array.isArray(parsed.dismissedSubagentSignatures)
-      ? parsed.dismissedSubagentSignatures.filter(isString)
+    dismissedSubagentSignatures: Array.isArray(config.dismissedSubagentSignatures)
+      ? config.dismissedSubagentSignatures.filter(isString)
       : [],
-    skillUniversalDecisions: Array.isArray(parsed.skillUniversalDecisions)
-      ? parsed.skillUniversalDecisions.filter(isSkillUniversalDecision)
+    skillUniversalDecisions: Array.isArray(config.skillUniversalDecisions)
+      ? config.skillUniversalDecisions.filter(isSkillUniversalDecision)
       : [],
   };
 }

--- a/src/shared/subagent-format-policy.ts
+++ b/src/shared/subagent-format-policy.ts
@@ -2,7 +2,7 @@ import type { AgentSubagentParserKind } from './contracts';
 
 export type SupportedSubagentDirectoryFormat = Exclude<AgentSubagentParserKind, 'none' | 'unknown'>;
 
-export const SUPPORTED_SUBAGENT_DIRECTORY_FORMATS = [
+const SUPPORTED_SUBAGENT_DIRECTORY_FORMATS = [
   'markdown-frontmatter',
   'codex-toml',
   'json',


### PR DESCRIPTION
Changes:

- Consolidate shared MCP definition parsing helpers and inventory workspace DOM helpers.
- Remove unused helpers and de-export module-local utilities.
- Tighten updater, config, IPC, MCP transport, and npx skill lock typing.
- Preserve path inspection errors and stabilize MCP connectivity runtime tests.

Validation:
`pnpm typecheck`
`pnpm lint`
`pnpm exec vitest run src/shared/mcp-definition.test.ts src/renderer/src/components/ui.test.tsx src/renderer/src/views/InventoryViewChrome.test.tsx src/main/add-skill.test.ts src/main/add-subagent.test.ts src/main/issue-resolution.test.ts src/main/auto-update.test.ts src/main/mcp-connectivity-transport.test.ts src/main/ipc.test.ts src/preload/bridge.test.ts src/shared/skill-index-paths.test.ts src/main/inventory-runtime.test.ts`
`pnpm test`
`pnpm --silent dlx madge --ts-config tsconfig.json --extensions ts,tsx --circular --warning src`
