### PR TITLE
Compare MCP definitions by core fields

### DIFF
--- a/src/main/mcp-inventory.ts
+++ b/src/main/mcp-inventory.ts
@@ -81,7 +81,7 @@ interface ParsedMcpConfigResult {
 
 interface PluginMcpIndexEntry {
   inventoryName: string;
-  definitionComparisonKey?: string;
+  coreDefinitionComparisonKey?: string;
 }
 
 interface ResolvedMcpConnection {
@@ -249,7 +249,7 @@ function buildPluginMcpIndex(results: ParsedMcpConfigResult[]): Map<string, Plug
       const existing = pluginMcpIndex.get(entry.name) ?? [];
       existing.push({
         inventoryName: `${result.owner.plugin.pluginName}:${entry.name}`,
-        definitionComparisonKey: entry.location.definitionComparisonKey,
+        coreDefinitionComparisonKey: getMcpCoreDefinitionComparisonKey(entry.location),
       });
       pluginMcpIndex.set(entry.name, existing);
     }
@@ -269,7 +269,7 @@ function createInventoryMcpName(
 
   const pluginCandidates = pluginMcpIndex.get(entry.name) ?? [];
   const matchingDefinitionCandidates = pluginCandidates.filter((candidate) =>
-    candidate.definitionComparisonKey === entry.location.definitionComparisonKey);
+    candidate.coreDefinitionComparisonKey === getMcpCoreDefinitionComparisonKey(entry.location));
 
   if (matchingDefinitionCandidates.length === 1) {
     return matchingDefinitionCandidates[0].inventoryName;
@@ -432,18 +432,7 @@ function hasMcpDefinitionMismatch(
 ): boolean {
   if (universalLocation) {
     const universalCoreKey = getMcpCoreDefinitionComparisonKey(universalLocation);
-    return locations.some((location) => {
-      if (getMcpCoreDefinitionComparisonKey(location) !== universalCoreKey) {
-        return true;
-      }
-
-      if (isUniversalMcpLocation(location) || !location.agentLocalKey) {
-        return false;
-      }
-
-      return getMcpNativeDefinitionComparisonKey(location)
-        !== getUniversalAgentLocalComparisonKey(universalLocation, location.agentLocalKey);
-    });
+    return locations.some((location) => getMcpCoreDefinitionComparisonKey(location) !== universalCoreKey);
   }
 
   return new Set(locations.map(getMcpCoreDefinitionComparisonKey)).size > 1;
@@ -455,14 +444,6 @@ function isUniversalMcpLocation(location: McpLocationRecord): boolean {
 
 function getMcpCoreDefinitionComparisonKey(location: McpLocationRecord): string {
   return location.coreDefinitionComparisonKey ?? location.definitionComparisonKey ?? location.definitionText ?? 'null';
-}
-
-function getMcpNativeDefinitionComparisonKey(location: McpLocationRecord): string {
-  return location.nativeDefinitionComparisonKey ?? stableStringify(location.nativeDefinition ?? {});
-}
-
-function getUniversalAgentLocalComparisonKey(location: McpLocationRecord, agentLocalKey: string): string {
-  return stableStringify(location.agentLocal?.[agentLocalKey] ?? {});
 }
 
 function buildMcpExpectedLocation(
@@ -860,7 +841,7 @@ function createMcpSignature(
 }
 
 function getMcpDefinitionComparisonKey(location: McpLocationRecord): string {
-  return location.definitionComparisonKey ?? location.definitionText ?? 'null';
+  return getMcpCoreDefinitionComparisonKey(location);
 }
 
 function resolveMcpConnection(definition: McpDefinitionObject): ResolvedMcpConnection {

--- a/src/main/scan-inventory.test.ts
+++ b/src/main/scan-inventory.test.ts
@@ -505,7 +505,7 @@ describe('representative-agent scan foundation', () => {
     });
   });
 
-  it('folds agent-specific native field drift into definition mismatch', async () => {
+  it('treats agent-specific native field drift as agreement when core fields match', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-mcp-native-mismatch-'));
     const paths = resolveSkillIndexPaths({
       env: {
@@ -543,8 +543,8 @@ describe('representative-agent scan foundation', () => {
     });
 
     expect(inventory.mcps?.find((mcp) => mcp.name === 'nativeMismatch')).toMatchObject({
-      status: 'needs-attention',
-      issueReasons: ['definition-mismatch'],
+      status: 'healthy',
+      issueReasons: [],
       locations: arrayContaining([
         objectContaining({
           agentId: 'sandbox-factory',
@@ -557,14 +557,15 @@ describe('representative-agent scan foundation', () => {
     });
   });
 
-  it('includes universal agentLocal drift in MCP dismissal signatures', async () => {
+  it('ignores universal agentLocal drift in MCP dismissal signatures', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-mcp-agent-local-signature-'));
     const env = {
       SKILL_INDEX_DATA_DIR: root,
-      SKILL_INDEX_AGENT_SUBSET: 'factory',
+      SKILL_INDEX_AGENT_SUBSET: 'codex,factory',
     };
     const paths = resolveSkillIndexPaths({ env });
     const agentsConfigPath = path.join(paths.sandboxRoot, '.agents', 'mcp.json');
+    const codexConfigPath = path.join(paths.sandboxRoot, '.codex', 'config.toml');
     const factoryConfigPath = path.join(paths.sandboxRoot, '.factory', 'mcp.json');
     const writeUniversalConfig = async (timeoutMs: number) => {
       await writeFile(agentsConfigPath, `${JSON.stringify({
@@ -583,7 +584,9 @@ describe('representative-agent scan foundation', () => {
     };
 
     await mkdir(path.dirname(agentsConfigPath), { recursive: true });
+    await mkdir(path.dirname(codexConfigPath), { recursive: true });
     await mkdir(path.dirname(factoryConfigPath), { recursive: true });
+    await writeFile(codexConfigPath, 'model = "gpt-5"\n', 'utf8');
     await writeFile(path.join(paths.sandboxRoot, '.factory', 'settings.json'), '{}\n', 'utf8');
     await writeUniversalConfig(1_000);
     await writeFile(factoryConfigPath, `${JSON.stringify({
@@ -614,10 +617,12 @@ describe('representative-agent scan foundation', () => {
     const secondSignature = secondInventory.mcps?.find((mcp) => mcp.name === 'nativeMismatch')?.signature;
 
     expect(firstInventory.mcps?.find((mcp) => mcp.name === 'nativeMismatch')?.issueReasons)
-      .toContain('definition-mismatch');
+      .toEqual(['missing-from-agents']);
+    expect(secondInventory.mcps?.find((mcp) => mcp.name === 'nativeMismatch')?.issueReasons)
+      .toEqual(['missing-from-agents']);
     expect(firstSignature).toBeTruthy();
     expect(secondSignature).toBeTruthy();
-    expect(secondSignature).not.toBe(firstSignature);
+    expect(secondSignature).toBe(firstSignature);
   });
 
   it('compares MCP definitions using portable launch, cwd, and auth fields only', async () => {

--- a/src/renderer/src/components/DetailInspectorPanel.test.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.test.tsx
@@ -411,6 +411,13 @@ describe('DetailInspectorPanel', () => {
       />,
     );
 
+    const problemVariantList = screen.getByRole('list', { name: 'Detected Definitions' });
+    expect(within(problemVariantList).getByText('Augment, Codex, Claude Code')).toBeInTheDocument();
+    expect(within(problemVariantList).getByText('3 agents')).toBeInTheDocument();
+    expect(within(problemVariantList).getByText('Factory')).toBeInTheDocument();
+    expect(within(problemVariantList).getByText('1 agent')).toBeInTheDocument();
+    expect(within(problemVariantList).queryByText('~/.skillindex/sandbox/.augment/settings.json')).not.toBeInTheDocument();
+
     fireEvent.click(screen.getByRole('tab', { name: 'Definition' }));
 
     const variantList = screen.getByRole('list', { name: 'Detected Definitions' });

--- a/src/renderer/src/components/DetailInspectorPanel.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.tsx
@@ -266,11 +266,16 @@ export function DetailInspectorPanel({
                     const isSelected = variant.path === model.selectedVariantPath;
                     const isCanonical = variant.path === activeProblem.baselineVariant?.path;
                     const isCanonicalComparison = isCanonical && !isSelected && activeProblem.selectedVariant?.path !== activeProblem.baselineVariant?.path;
+                    const variantPrimaryLabel = entityKind === 'mcp' ? variant.label : formatPath(variant.path, 62);
+                    const variantSecondaryLabel = entityKind === 'mcp' ? variant.secondaryLabel : null;
+                    const ariaLabel = entityKind === 'mcp'
+                      ? `${variant.label} ${variant.secondaryLabel} ${variant.path}`
+                      : `${variant.label} ${variant.path}`;
 
                     return (
                       <div key={variant.id} role="listitem">
                         <button
-                          aria-label={`${variant.label} ${variant.path}`}
+                          aria-label={ariaLabel}
                           aria-pressed={isSelected}
                           className={[
                             'detail-inspector-panel__variant-card',
@@ -283,7 +288,14 @@ export function DetailInspectorPanel({
                           onClick={() => onVariantSelect?.(variant.path)}
                         >
                           <>
-                            <span className="detail-inspector-panel__variant-path">{formatPath(variant.path, 62)}</span>
+                            {entityKind === 'mcp' ? (
+                              <span className="detail-inspector-panel__variant-copy">
+                                <strong className="detail-inspector-panel__variant-primary">{variantPrimaryLabel}</strong>
+                                {variantSecondaryLabel ? <span>{variantSecondaryLabel}</span> : null}
+                              </span>
+                            ) : (
+                              <span className="detail-inspector-panel__variant-path">{variantPrimaryLabel}</span>
+                            )}
                             {isCanonical ? (
                               <span className="detail-inspector-panel__variant-badges">
                                 <span

--- a/src/renderer/src/lib/detail-inspector-model.test.ts
+++ b/src/renderer/src/lib/detail-inspector-model.test.ts
@@ -2144,6 +2144,89 @@ describe('buildMcpInspectorModel', () => {
     ]);
   });
 
+  it('groups MCP detected definitions by portable core when native settings differ', () => {
+    const coreComparisonKey = JSON.stringify({
+      headers: { 'X-Goog-Api-Key': 'test-key' },
+      transport: 'http',
+      url: 'https://stitch.googleapis.com/mcp',
+    });
+    const mcp: RepresentativeMcp = {
+      name: 'stitch',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['missing-universal'],
+      locations: [
+        {
+          agentId: 'sandbox-augment',
+          agentLabel: 'Augment',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/.augment/settings.json',
+          transport: 'http',
+          url: 'https://stitch.googleapis.com/mcp',
+          args: [],
+          definitionText: JSON.stringify({
+            url: 'https://stitch.googleapis.com/mcp',
+            headers: { 'X-Goog-Api-Key': 'test-key' },
+          }, null, 2),
+          definitionComparisonKey: JSON.stringify({
+            agentLocal: {},
+            core: {
+              headers: { 'X-Goog-Api-Key': 'test-key' },
+              transport: 'http',
+              url: 'https://stitch.googleapis.com/mcp',
+            },
+            native: {},
+          }),
+          coreDefinitionComparisonKey: coreComparisonKey,
+        },
+        {
+          agentId: 'sandbox-factory',
+          agentLabel: 'Factory',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/.factory/mcp.json',
+          transport: 'http',
+          url: 'https://stitch.googleapis.com/mcp',
+          args: [],
+          definitionText: JSON.stringify({
+            type: 'http',
+            url: 'https://stitch.googleapis.com/mcp',
+            headers: { 'X-Goog-Api-Key': 'test-key' },
+            disabled: false,
+          }, null, 2),
+          definitionComparisonKey: JSON.stringify({
+            agentLocal: {},
+            core: {
+              headers: { 'X-Goog-Api-Key': 'test-key' },
+              transport: 'http',
+              url: 'https://stitch.googleapis.com/mcp',
+            },
+            native: { disabled: false },
+          }),
+          coreDefinitionComparisonKey: coreComparisonKey,
+          nativeDefinition: { disabled: false },
+          agentLocalKey: 'factory',
+        },
+      ],
+    };
+
+    const model = buildMcpInspectorModel(mcp, {
+      selectedProblemKey: 'missing-universal',
+      selectedVariantPath: '~/.skillindex/sandbox/.factory/mcp.json',
+    }, agentIndex, sourceIndex);
+
+    const activeProblem = expectVariantResolution(model.activeProblem);
+    expect(activeProblem.variants).toEqual([
+      objectContaining({
+        label: 'Augment, Factory',
+        secondaryLabel: '2 agents',
+        locations: [
+          { label: 'Augment', path: '~/.skillindex/sandbox/.augment/settings.json' },
+          { label: 'Factory', path: '~/.skillindex/sandbox/.factory/mcp.json' },
+        ],
+      }),
+    ]);
+  });
+
   it('builds a multi-problem inspector with definition mismatch selection', () => {
     const mcp = findRepresentativeMcp('diagnostic-rich-mcp');
 

--- a/src/renderer/src/lib/detail-inspector-model.test.ts
+++ b/src/renderer/src/lib/detail-inspector-model.test.ts
@@ -2227,6 +2227,96 @@ describe('buildMcpInspectorModel', () => {
     ]);
   });
 
+  it('marks only core-different MCP locations as definition mismatches', () => {
+    const matchingCoreKey = JSON.stringify({
+      args: ['server.js'],
+      command: 'node',
+      transport: 'stdio',
+    });
+    const divergentCoreKey = JSON.stringify({
+      args: ['other-server.js'],
+      command: 'node',
+      transport: 'stdio',
+    });
+    const mcp: RepresentativeMcp = {
+      name: 'mixed-core-mcp',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['definition-mismatch'],
+      locations: [
+        {
+          agentId: 'sandbox-agents',
+          agentLabel: 'Universal',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/.agents/mcp.json',
+          transport: 'stdio',
+          command: 'node',
+          args: ['server.js'],
+          definitionText: JSON.stringify({
+            command: 'node',
+            args: ['server.js'],
+          }, null, 2),
+          coreDefinitionComparisonKey: matchingCoreKey,
+          provenance: {
+            kind: 'universal',
+            sourcePath: '~/.skillindex/sandbox/.agents/mcp.json',
+            discoveredAt: '2026-01-01T00:00:00.000Z',
+          },
+        },
+        {
+          agentId: 'sandbox-claude',
+          agentLabel: 'Claude Code',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/.claude.json',
+          transport: 'stdio',
+          command: 'node',
+          args: ['other-server.js'],
+          definitionText: JSON.stringify({
+            command: 'node',
+            args: ['other-server.js'],
+          }, null, 2),
+          coreDefinitionComparisonKey: divergentCoreKey,
+        },
+        {
+          agentId: 'sandbox-factory',
+          agentLabel: 'Factory',
+          scope: 'sandbox',
+          configPath: '~/.skillindex/sandbox/.factory/mcp.json',
+          transport: 'stdio',
+          command: 'node',
+          args: ['server.js'],
+          definitionText: JSON.stringify({
+            command: 'node',
+            args: ['server.js'],
+            disabled: false,
+          }, null, 2),
+          coreDefinitionComparisonKey: matchingCoreKey,
+          nativeDefinition: { disabled: false },
+          agentLocalKey: 'factory',
+        },
+      ],
+    };
+
+    const model = buildMcpInspectorModel(mcp, {
+      selectedProblemKey: 'definition-mismatch',
+      selectedVariantPath: '~/.skillindex/sandbox/.claude.json',
+    }, agentIndex, sourceIndex);
+    const installedRows = model.locations.find((section) => section.id === 'installed-paths')?.rows ?? [];
+
+    expect(installedRows).toEqual(arrayContaining([
+      objectContaining({
+        label: 'Claude Code',
+        statusLabel: 'Definition Mismatch',
+        tone: 'warning',
+      }),
+      objectContaining({
+        label: 'Factory',
+        statusLabel: undefined,
+        tone: 'healthy',
+      }),
+    ]));
+  });
+
   it('builds a multi-problem inspector with definition mismatch selection', () => {
     const mcp = findRepresentativeMcp('diagnostic-rich-mcp');
 

--- a/src/renderer/src/lib/detail-inspector-model.ts
+++ b/src/renderer/src/lib/detail-inspector-model.ts
@@ -2179,8 +2179,7 @@ function getMcpLocationIssueState(
   }
 
   if (mcp.issueReasons.includes('definition-mismatch') && canonicalLocation) {
-    if (isMcpCoreDefinitionMismatch(location, canonicalLocation)
-      || isMcpAgentSpecificDefinitionMismatch(location, canonicalLocation)) {
+    if (isMcpCoreDefinitionMismatch(location, canonicalLocation)) {
       return { statusLabel: 'Definition Mismatch', tone: 'warning' };
     }
   }
@@ -2201,19 +2200,6 @@ function getMcpCoreDefinitionKey(location: McpLocationRecord): string {
     ?? normalizeDefinitionText(location.definitionText ?? buildMcpDefinitionText(location))
     ?? 'null';
 }
-
-function isMcpAgentSpecificDefinitionMismatch(
-  location: McpLocationRecord,
-  canonicalLocation: McpLocationRecord,
-): boolean {
-  if (isUniversalMcpLocation(location) || !location.agentLocalKey) {
-    return false;
-  }
-
-  return stableDefinitionString(location.nativeDefinition ?? {})
-    !== stableDefinitionString(canonicalLocation.agentLocal?.[location.agentLocalKey] ?? {});
-}
-
 
 function buildSubagentLocationSections(
   subagent: SubagentRecord,

--- a/src/renderer/src/lib/detail-inspector-model.ts
+++ b/src/renderer/src/lib/detail-inspector-model.ts
@@ -2995,7 +2995,9 @@ function groupMcpVariants(locations: McpLocationRecord[]): McpVariantGroup[] {
 
   for (const location of locations) {
     const definitionText = normalizeDefinitionText(location.definitionText ?? buildMcpDefinitionText(location));
-    const key = location.definitionComparisonKey ?? (definitionText || `${location.command ?? ''}:${location.args.join('\0')}`);
+    const key = location.coreDefinitionComparisonKey
+      ?? location.definitionComparisonKey
+      ?? (definitionText || `${location.command ?? ''}:${location.args.join('\0')}`);
     const existing = groups.get(key) ?? [];
     existing.push(location);
     groups.set(key, existing);


### PR DESCRIPTION
Changes:

- Compare MCP definitions by portable core fields so agent-specific native and agentLocal settings do not create definition drift.
- Use grouped friendly MCP definition labels in the Problems tab to match the Definition tab.

Validation:
pnpm exec vitest run src/renderer/src/components/DetailInspectorPanel.test.tsx
pnpm exec vitest run src/renderer/src/lib/detail-inspector-model.test.ts
pnpm exec vitest run src/main/scan-inventory.test.ts -t "agent-specific native field drift|universal agentLocal drift|portable launch"
pnpm typecheck
pnpm lint
