### PR TITLE
Show broken symlink targets

### DIFF
--- a/src/main/scan-inventory.test.ts
+++ b/src/main/scan-inventory.test.ts
@@ -1059,9 +1059,15 @@ describe('representative-agent scan foundation', () => {
         ]),
       },
     });
-    expect(inventory.skills.find((skill) => skill.name === 'broken-symlink-skill')).toMatchObject({
+    const brokenSymlinkSkill = inventory.skills.find((skill) => skill.name === 'broken-symlink-skill');
+    expect(brokenSymlinkSkill).toMatchObject({
       structuralState: 'missing-symlinks',
       issueReasons: arrayContaining(['broken-symlink']),
+    });
+    expect(brokenSymlinkSkill?.locations.find((location) =>
+      location.sourceId === 'sandbox-claude' && location.fileType === 'symlink' && !location.resolvedPath,
+    )).toMatchObject({
+      symlinkTarget: path.join(paths.sandboxRoot, '.agents', 'skills', 'missing-broken-symlink-target'),
     });
     expect(inventory.skills.find((skill) => skill.name === 'wrong-symlink-target-skill')).toMatchObject({
       structuralState: 'missing-symlinks',

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { readFileSync, type Dirent } from 'node:fs';
-import { lstat, readdir, readFile, realpath, stat, writeFile } from 'node:fs/promises';
+import { lstat, readdir, readFile, readlink, realpath, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type {
@@ -441,7 +441,7 @@ async function readSkillLocation(
   const fileStats = await lstat(rootPath);
   const fileType: SkillLocationType = fileStats.isSymbolicLink() ? 'symlink' : 'real-file';
   const resolvedPath = await safeRealpath(rootPath);
-  const symlinkTarget = fileType === 'symlink' ? resolvedPath : undefined;
+  const symlinkTarget = fileType === 'symlink' ? await safeReadlink(rootPath) ?? resolvedPath : undefined;
   const modifiedAt = await getLocationModifiedAt(rootPath, packageEntry.entrypointPath, fileType, resolvedPath);
   const packageFiles = fileType === 'symlink' && resolvedPath === undefined
     ? []
@@ -2711,6 +2711,14 @@ async function safeStat(filePath: string) {
 async function safeRealpath(filePath: string): Promise<string | undefined> {
   try {
     return await realpath(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function safeReadlink(filePath: string): Promise<string | undefined> {
+  try {
+    return await readlink(filePath);
   } catch {
     return undefined;
   }

--- a/src/main/subagent-inventory.test.ts
+++ b/src/main/subagent-inventory.test.ts
@@ -228,13 +228,19 @@ describe('subagent inventory', () => {
 
     await writeMarkdownSubagent(canonicalPath, 'broken-link', 'Covers broken symlink repair.', 'Repair safely.');
     await mkdir(path.dirname(claudePath), { recursive: true });
-    await symlink(path.join(homeDir, '.agents', 'agents', 'missing-target.md'), claudePath);
+    const missingTargetPath = path.join(homeDir, '.agents', 'agents', 'missing-target.md');
+    await symlink(missingTargetPath, claudePath);
 
     const inventory = await scanInventory(scanOptions);
     const brokenLink = inventory.subagents?.find((subagent) => subagent.name === 'broken-link');
 
     expect(brokenLink?.issueReasons).toContain('broken-symlink');
     expect(brokenLink?.issueReasons).not.toContain('invalid-definition');
+    expect(brokenLink?.locations.find((location) =>
+      location.path === claudePath && location.fileType === 'symlink' && !location.resolvedPath,
+    )).toMatchObject({
+      symlinkTarget: missingTargetPath,
+    });
 
     const repaired = await resolveInventoryIssue({
       entity: 'subagent',

--- a/src/main/subagent-inventory.ts
+++ b/src/main/subagent-inventory.ts
@@ -1,4 +1,4 @@
-import { lstatSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { lstatSync, readlinkSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import type {
@@ -303,6 +303,7 @@ function buildSubagentLocation(
   const stats = lstatSync(filePath);
   const fileType: SkillLocationType = stats.isSymbolicLink() ? 'symlink' : 'real-file';
   const resolvedPath = safeRealpathSync(filePath);
+  const symlinkTarget = fileType === 'symlink' ? safeReadlinkSync(filePath) ?? resolvedPath : undefined;
   const modifiedAt = new Date(stats.mtimeMs).toISOString();
   const definitionComparisonKey = fileType === 'real-file'
     ? getSubagentDefinitionComparisonKey(parsed)
@@ -327,7 +328,7 @@ function buildSubagentLocation(
     localExtrasKeys: localExtrasKeys.length > 0 ? localExtrasKeys : undefined,
     invalidDetails: parsed.invalidDetails.length > 0 ? parsed.invalidDetails : undefined,
     resolvedPath,
-    symlinkTarget: fileType === 'symlink' ? resolvedPath : undefined,
+    symlinkTarget,
     provenance: createSubagentProvenance(filePath, owner, modifiedAt),
     canonicalRole: owner.canonical ? 'canonical' : 'materialized-copy',
     mutability: owner.writable ? 'writable' : owner.plugin ? 'read-only-managed' : 'unknown',
@@ -1419,6 +1420,14 @@ function safeFileExists(filePath: string): boolean {
 function safeRealpathSync(filePath: string): string | undefined {
   try {
     return realpathSync(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+function safeReadlinkSync(filePath: string): string | undefined {
+  try {
+    return readlinkSync(filePath);
   } catch {
     return undefined;
   }

--- a/src/renderer/src/components/DetailInspectorPanel.test.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.test.tsx
@@ -586,7 +586,7 @@ describe('DetailInspectorPanel', () => {
           ...claudeLocation,
           path: packagePath('~/.skillindex/sandbox/.claude/skills/broken-symlink-skill.md'),
           resolvedPath: undefined,
-          symlinkTarget: undefined,
+          symlinkTarget: packagePath('~/.skillindex/sandbox/.agents/skills/missing-broken-symlink-target.md'),
         },
       ],
     };
@@ -612,6 +612,14 @@ describe('DetailInspectorPanel', () => {
     })).not.toBeInTheDocument();
     expect(screen.queryByText(/Broken:/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/expected/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Locations/i }));
+    const installedPaths = screen.getByRole('list', { name: 'Installed Paths' });
+    const row = within(installedPaths).getByText('Broken Symlink').closest('.detail-inspector-panel__location-row');
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText(
+      `Points to ${packagePath('~/.skillindex/sandbox/.agents/skills/missing-broken-symlink-target.md')}`,
+    )).toBeInTheDocument();
   });
 
   it('renders wrong symlink target rows with the compact path and current target underneath', () => {

--- a/src/renderer/src/components/DetailInspectorPanel.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.tsx
@@ -557,21 +557,28 @@ export function DetailInspectorPanel({
                           <strong className="detail-inspector-panel__location-label">{renderLocationLabel(row.label)}</strong>
                         ) : null}
                       </span>
-                      {row.path ? (
-                        <button
-                          aria-label={`Open ${formatDisplayPath(row.path)} in the default editor`}
-                          className="detail-inspector-panel__location-path-button"
-                          title={formatDisplayPath(row.path)}
-                          type="button"
-                          onClick={() => handleOpenPath(row.path as string)}
-                        >
-                          {formatDisplayPath(row.path)}
-                        </button>
-                      ) : (
-                        <span className={`detail-inspector-panel__location-path detail-inspector-panel__location-path--${row.tone}`}>
-                          {row.pathText}
-                        </span>
-                      )}
+                      <span className="detail-inspector-panel__location-path-cell">
+                        {row.path ? (
+                          <button
+                            aria-label={`Open ${formatDisplayPath(row.path)} in the default editor`}
+                            className="detail-inspector-panel__location-path-button"
+                            title={formatDisplayPath(row.path)}
+                            type="button"
+                            onClick={() => handleOpenPath(row.path as string)}
+                          >
+                            {formatDisplayPath(row.path)}
+                          </button>
+                        ) : (
+                          <span className={`detail-inspector-panel__location-path detail-inspector-panel__location-path--${row.tone}`}>
+                            {row.pathText}
+                          </span>
+                        )}
+                        {row.detailText ? (
+                          <span className="detail-inspector-panel__location-detail">
+                            {row.detailText}
+                          </span>
+                        ) : null}
+                      </span>
                       <span className="detail-inspector-panel__location-status-cell">
                         <span
                           className={[

--- a/src/renderer/src/lib/detail-inspector-model.test.ts
+++ b/src/renderer/src/lib/detail-inspector-model.test.ts
@@ -1,4 +1,4 @@
-import type { AgentRecord, SkillRecord, SkillScanSource } from '@shared/contracts';
+import type { AgentRecord, SkillRecord, SkillScanSource, SubagentRecord } from '@shared/contracts';
 
 import { describe, expect, it } from 'vitest';
 
@@ -6,6 +6,7 @@ import { representativeInventorySnapshot } from '../representative-preview-data'
 import {
   DETAIL_DIFF_TITLE,
   buildMcpInspectorModel,
+  buildSubagentInspectorModel,
   buildSkillInspectorModel,
   type InspectorActiveProblemModel,
   type StructuralRepairProblemModel,
@@ -1722,7 +1723,7 @@ describe('buildSkillInspectorModel', () => {
           ...claudeLocation,
           path: packagePath('~/.skillindex/sandbox/.claude/skills/broken-symlink-skill.md'),
           resolvedPath: undefined,
-          symlinkTarget: undefined,
+          symlinkTarget: packagePath('~/.skillindex/sandbox/.agents/skills/missing-broken-symlink-target.md'),
         },
       ],
     };
@@ -1749,6 +1750,71 @@ describe('buildSkillInspectorModel', () => {
         path: packagePath('~/.skillindex/sandbox/.claude/skills/broken-symlink-skill.md'),
       }),
     ]);
+    expect(model.locations.flatMap((section) => section.rows)).toEqual(arrayContaining([
+      objectContaining({
+        path: packagePath('~/.skillindex/sandbox/.claude/skills/broken-symlink-skill.md'),
+        statusLabel: 'Broken Symlink',
+        detailText: `Points to ${packagePath('~/.skillindex/sandbox/.agents/skills/missing-broken-symlink-target.md')}`,
+      }),
+    ]));
+  });
+
+  it('shows the current broken subagent symlink target in Locations', () => {
+    const canonicalPath = '~/.skillindex/sandbox/.agents/agents/broken-link.md';
+    const claudePath = '~/.skillindex/sandbox/.claude/agents/broken-link.md';
+    const missingTargetPath = '~/.skillindex/sandbox/.agents/agents/missing-target.md';
+    const subagent: SubagentRecord = {
+      name: 'broken-link',
+      description: 'Covers broken symlink repair.',
+      status: 'needs-attention',
+      presentation: 'active',
+      issueReasons: ['broken-symlink'],
+      locations: [
+        {
+          agentId: 'sandbox-agents-subagents',
+          agentLabel: 'Sandbox .agents',
+          scope: 'sandbox',
+          path: canonicalPath,
+          directoryPath: '~/.skillindex/sandbox/.agents/agents',
+          fileType: 'real-file',
+          modifiedAt: '2026-05-15T00:00:00.000Z',
+          canonical: true,
+          format: 'markdown-frontmatter',
+          definitionText: '---\nname: broken-link\ndescription: Covers broken symlink repair.\n---\nRepair safely.\n',
+          definitionComparisonKey: 'canonical-broken-link',
+        },
+        {
+          agentId: 'sandbox-claude',
+          agentLabel: 'Claude Code',
+          scope: 'sandbox',
+          path: claudePath,
+          directoryPath: '~/.skillindex/sandbox/.claude/agents',
+          fileType: 'symlink',
+          modifiedAt: '2026-05-15T01:00:00.000Z',
+          canonical: false,
+          format: 'markdown-frontmatter',
+          description: null,
+          resolvedPath: undefined,
+          symlinkTarget: missingTargetPath,
+        },
+      ],
+      expectedLocations: [],
+      missingLocations: [],
+    };
+
+    const model = buildSubagentInspectorModel(subagent, {
+      selectedProblemKey: 'broken-symlink',
+      selectedVariantPath: null,
+    }, agentIndex);
+
+    expect(model.locations.flatMap((section) => section.rows)).toEqual(arrayContaining([
+      objectContaining({
+        label: 'Claude Code',
+        path: claudePath,
+        statusLabel: 'Broken Symlink',
+        detailText: `Points to ${missingTargetPath}`,
+      }),
+    ]));
   });
 
   it('shows the current wrong symlink target underneath the affected path', () => {

--- a/src/renderer/src/lib/detail-inspector-model.ts
+++ b/src/renderer/src/lib/detail-inspector-model.ts
@@ -105,6 +105,7 @@ export interface InspectorLocationRow {
   label: string | null;
   path: string | null;
   pathText: string;
+  detailText?: string;
   statusLabel?: string;
   tone: InspectorLocationTone;
   action?: InspectorLocationAction;
@@ -1550,6 +1551,7 @@ function buildSkillLocationSections(
               label: formatSkillInstallSourceLabel(source, sourceIndex, agentIndex),
               path: location?.path ?? null,
               pathText: location?.path ?? 'not installed',
+              detailText: getBrokenSymlinkLocationDetail(issue, location),
               statusLabel: issue.statusLabel,
               tone: issue.tone,
             };
@@ -1656,6 +1658,7 @@ function mapSkillLocationRow(
     label,
     path: location.path,
     pathText: location.path,
+    detailText: getBrokenSymlinkLocationDetail(issue, location),
     statusLabel: issue.statusLabel,
     tone: issue.tone,
     action: getSkillLocationAction(skill, location, sourceIndex),
@@ -2219,6 +2222,7 @@ function buildSubagentLocationSections(
         label: entry.label,
         path: entry.location?.path ?? entry.path ?? null,
         pathText: entry.location?.path ?? entry.path ?? 'Not configured',
+        detailText: getBrokenSymlinkLocationDetail(issue, entry.location),
         statusLabel: issue.statusLabel,
         tone: issue.tone,
       };
@@ -2281,9 +2285,22 @@ function mapSubagentLocationRow(
     label,
     path: location.path,
     pathText: location.path,
+    detailText: getBrokenSymlinkLocationDetail(issue, location),
     statusLabel: issue.statusLabel,
     tone: issue.tone,
   };
+}
+
+function getBrokenSymlinkLocationDetail(
+  issue: { statusLabel?: string },
+  location: { resolvedPath?: string; symlinkTarget?: string } | null,
+): string | undefined {
+  if (issue.statusLabel !== 'Broken Symlink') {
+    return undefined;
+  }
+
+  const target = location?.symlinkTarget ?? location?.resolvedPath;
+  return target ? `Points to ${target}` : undefined;
 }
 
 function getSubagentAgentEntries(

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -9340,6 +9340,12 @@ body {
   white-space: nowrap;
 }
 
+.detail-inspector-panel__location-path-cell {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
 .detail-inspector-panel__location-path,
 .detail-inspector-panel__location-path-button {
   min-width: 0;
@@ -9374,6 +9380,16 @@ body {
 .detail-inspector-panel__location-path-button:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--detail-inspector-accent) 36%, white);
   outline-offset: 1px;
+}
+
+.detail-inspector-panel__location-detail {
+  min-width: 0;
+  color: var(--detail-inspector-text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 14px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .detail-inspector-panel__location-status-cell {


### PR DESCRIPTION
Changes:

- Preserve raw `readlink` targets for broken Skill and Subagent symlinks.
- Show `Points to ...` in Locations rows when a symlink is marked Broken Symlink.

Validation:
`pnpm test -- src/main/scan-inventory.test.ts src/main/subagent-inventory.test.ts src/renderer/src/lib/detail-inspector-model.test.ts src/renderer/src/components/DetailInspectorPanel.test.tsx`
`pnpm typecheck`
Playwright visual check against the dev renderer.
