### PR TITLE
Update Agent Directory path columns

### DIFF
--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -1594,8 +1594,9 @@ describe('App shell inventory views', () => {
 
     expect(within(list).getByText('INSTALLED')).toBeInTheDocument();
     expect(within(list).getByText('NOT INSTALLED')).toBeInTheDocument();
-    expect(within(list).getAllByText('Skills source')).toHaveLength(2);
-    expect(within(list).getAllByText('MCP / config')).toHaveLength(2);
+    expect(within(list).getAllByText('Primary Skills Directory')).toHaveLength(2);
+    expect(within(list).getAllByText('Primary MCP Definition')).toHaveLength(2);
+    expect(within(list).getAllByText('Primary Subagents Directory')).toHaveLength(2);
     expect(within(list).getByText('Codex')).toBeInTheDocument();
     expect(within(list).getByText('Claude Code')).toBeInTheDocument();
     expect(within(list).getByText('Claude Desktop')).toBeInTheDocument();
@@ -1603,13 +1604,13 @@ describe('App shell inventory views', () => {
     expect(within(list).getByText('Factory')).toBeInTheDocument();
     expect(within(list).getByText('OpenCode')).toBeInTheDocument();
     expect(within(list).getByText('Windsurf')).toBeInTheDocument();
-    expect(within(getAgentRow('Codex')).getByText('~/.agents/skills')).toBeInTheDocument();
-    expect(within(getAgentRow('Claude Code')).getByText('~/.claude/skills')).toBeInTheDocument();
+    expect(within(getAgentRow('Codex')).getByText('~/.skillindex/sandbox/.agents/skills')).toBeInTheDocument();
+    expect(within(getAgentRow('Claude Code')).getByText('~/.skillindex/sandbox/.claude/skills')).toBeInTheDocument();
     expect(within(getAgentRow('Claude Desktop')).getByText('Cloud account managed')).toBeInTheDocument();
     expect(within(getAgentRow('Claude Desktop')).queryByText('No local skills folder to install into')).not.toBeInTheDocument();
     expect(within(getAgentRow('Claude Desktop')).getByText('~/.skillindex/sandbox/Library/Application Support/Claude/claude_desktop_config.json')).toBeInTheDocument();
-    expect(within(getAgentRow('OpenCode')).getByText('~/.agents/skills')).toBeInTheDocument();
-    expect(within(getAgentRow('Windsurf')).getByText('~/.codeium/windsurf/skills')).toBeInTheDocument();
+    expect(within(getAgentRow('OpenCode')).getByText('~/.skillindex/sandbox/.agents/skills')).toBeInTheDocument();
+    expect(within(getAgentRow('Windsurf')).getByText('~/.skillindex/sandbox/.codeium/windsurf/skills')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /^Not installed/i }));
     expect(getAgentDataRows()).toHaveLength(AGENT_CATALOG.length - 4);

--- a/src/renderer/src/components/ui.tsx
+++ b/src/renderer/src/components/ui.tsx
@@ -20,6 +20,7 @@ export const PLUGIN_SUBAGENT_TOOLTIP = 'This subagent was installed via one or m
 
 const PLUGIN_TOOLTIP_MARGIN = 12;
 const PLUGIN_TOOLTIP_FALLBACK_WIDTH = 360;
+const AGENT_LOCATION_TOOLTIP_FALLBACK_WIDTH = 560;
 
 type PluginTooltipPosition = {
   arrowLeft: number;
@@ -494,13 +495,9 @@ export function AgentStatusRow({
   agent: AgentRecord;
 }) {
   const isUnavailable = agent.installState !== 'installed';
-  const skillsPath = getAgentSkillsDisplayPath(agent);
-  const skillsTitle = getAgentSkillsTitle(agent);
-  const isAccountManagedSkills = agent.skillsLocation.reason === 'account-managed';
-  const mcpConfigPath = getAgentConfigDisplayPath(agent);
-  const mcpConfigTitle = getAgentConfigTitle(agent);
-  const subagentsPath = getAgentSubagentsDisplayPath(agent);
-  const subagentsTitle = getAgentSubagentsTitle(agent);
+  const skillsLocation = getAgentSkillsDisplayLocation(agent);
+  const mcpConfigLocation = getAgentConfigDisplayLocation(agent);
+  const subagentsLocation = getAgentSubagentsDisplayLocation(agent);
 
   return (
     <div className="agent-status-row">
@@ -511,37 +508,155 @@ export function AgentStatusRow({
         </div>
       </div>
       <div className="agent-location-column">
-        <code
-          className={`agent-location-path${isAccountManagedSkills ? ' agent-location-path--account-managed' : ''}`}
-          title={skillsTitle}
-        >
-          {skillsPath}
-        </code>
+        <AgentLocationValue location={skillsLocation} />
       </div>
       <div className="agent-location-column">
-        <code className="agent-location-path" title={mcpConfigTitle}>{mcpConfigPath}</code>
+        <AgentLocationValue location={mcpConfigLocation} />
       </div>
       <div className="agent-location-column">
-        <code className="agent-location-path" title={subagentsTitle}>{subagentsPath}</code>
+        <AgentLocationValue location={subagentsLocation} />
       </div>
     </div>
   );
 }
 
-function getAgentSkillsDisplayPath(agent: AgentRecord): string {
-  if (agent.skillsLocation.reason === 'account-managed') {
-    return 'Cloud account managed';
+type AgentLocationDisplay = {
+  kind: 'path' | 'note';
+  label: string;
+  title: string;
+};
+
+function AgentLocationValue({ location }: { location: AgentLocationDisplay }) {
+  const tooltipId = useId();
+  const anchorRef = useRef<HTMLElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const [position, setPosition] = useState<PluginTooltipPosition | null>(null);
+  const className = location.kind === 'note'
+    ? 'agent-location-path agent-location-note'
+    : 'agent-location-path';
+
+  useLayoutEffect(() => {
+    if (!isTooltipOpen) {
+      setPosition(null);
+      return;
+    }
+
+    const updatePosition = () => {
+      const anchor = anchorRef.current;
+      const tooltipElement = tooltipRef.current;
+      if (!anchor || !tooltipElement) {
+        return;
+      }
+
+      const anchorRect = anchor.getBoundingClientRect();
+      const tooltipWidth = tooltipElement.offsetWidth || AGENT_LOCATION_TOOLTIP_FALLBACK_WIDTH;
+      const tooltipHeight = tooltipElement.offsetHeight;
+      const viewportWidth = document.documentElement.clientWidth || window.innerWidth;
+      const viewportHeight = document.documentElement.clientHeight || window.innerHeight;
+      const anchorCenter = anchorRect.left + anchorRect.width / 2;
+      const minLeft = PLUGIN_TOOLTIP_MARGIN;
+      const maxLeft = Math.max(minLeft, viewportWidth - tooltipWidth - PLUGIN_TOOLTIP_MARGIN);
+      const left = Math.min(Math.max(anchorCenter - tooltipWidth / 2, minLeft), maxLeft);
+      const aboveTop = anchorRect.top - tooltipHeight - 8;
+      const bottomTop = anchorRect.bottom + 8;
+      const canFitAbove = aboveTop >= PLUGIN_TOOLTIP_MARGIN;
+      const canFitBelow = bottomTop + tooltipHeight + PLUGIN_TOOLTIP_MARGIN <= viewportHeight;
+      const shouldPlaceAbove = canFitAbove || !canFitBelow;
+      const top = shouldPlaceAbove ? Math.max(PLUGIN_TOOLTIP_MARGIN, aboveTop) : bottomTop;
+
+      setPosition({
+        arrowLeft: Math.min(Math.max(anchorCenter - left, 10), Math.max(10, tooltipWidth - 10)),
+        left,
+        placement: shouldPlaceAbove ? 'top' : 'bottom',
+        top,
+      });
+    };
+
+    updatePosition();
+    const frame = window.requestAnimationFrame(updatePosition);
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [isTooltipOpen]);
+
+  const tooltipStyle = {
+    '--plugin-tooltip-arrow-left': position ? `${position.arrowLeft}px` : '50%',
+    left: position?.left ?? 0,
+    top: position?.top ?? 0,
+    visibility: position ? 'visible' : 'hidden',
+  } as CSSProperties;
+
+  const sharedProps = {
+    'aria-describedby': isTooltipOpen ? tooltipId : undefined,
+    className,
+    ref: anchorRef,
+    tabIndex: 0,
+    onBlur: () => setIsTooltipOpen(false),
+    onFocus: () => setIsTooltipOpen(true),
+    onMouseEnter: () => setIsTooltipOpen(true),
+    onMouseLeave: () => setIsTooltipOpen(false),
+  };
+  const tooltip = isTooltipOpen
+    ? createPortal(
+        <div
+          className="plugin-tooltip agent-location-tooltip"
+          data-placement={position?.placement ?? 'bottom'}
+          id={tooltipId}
+          ref={tooltipRef}
+          role="tooltip"
+          style={tooltipStyle}
+        >
+          {location.title}
+        </div>,
+        document.body,
+      )
+    : null;
+
+  if (location.kind === 'note') {
+    return (
+      <>
+        <span {...sharedProps}>
+          {location.label}
+        </span>
+        {tooltip}
+      </>
+    );
   }
 
-  return agent.defaultGlobalSkillsDir;
+  return (
+    <>
+      <code {...sharedProps}>
+        {location.label}
+      </code>
+      {tooltip}
+    </>
+  );
 }
 
-function getAgentSkillsTitle(agent: AgentRecord): string {
+function getAgentSkillsDisplayLocation(agent: AgentRecord): AgentLocationDisplay {
   if (agent.skillsLocation.reason === 'account-managed') {
-    return "Skills are managed through this agent's cloud account; Skill Index cannot scan or install local skill files for it.";
+    return {
+      kind: 'note',
+      label: 'Cloud account managed',
+      title: "Skills are managed through this agent's cloud account; Skill Index cannot scan or install local skill files for it.",
+    };
   }
 
-  return agent.defaultGlobalSkillsDir;
+  if (agent.skillsLocation.path) {
+    return {
+      kind: 'path',
+      label: agent.skillsLocation.displayPath ?? agent.skillsLocation.path,
+      title: agent.skillsLocation.path,
+    };
+  }
+
+  return noKnownSupportLocation();
 }
 
 function AgentAvatar({
@@ -604,54 +719,76 @@ function isRenderableAgentIconFormat(format: string): boolean {
     || format === 'avif';
 }
 
-function getAgentConfigDisplayPath(agent: AgentRecord): string {
+function getAgentConfigDisplayLocation(agent: AgentRecord): AgentLocationDisplay {
   if (agent.mcpConfigLocation.displayPath) {
-    return agent.mcpConfigLocation.displayPath;
+    return {
+      kind: 'path',
+      label: agent.mcpConfigLocation.displayPath,
+      title: agent.mcpConfigLocation.path ?? agent.mcpConfigLocation.displayPath,
+    };
   }
 
   if (agent.mcpConfigLocation.path) {
-    return agent.mcpConfigLocation.path;
+    return {
+      kind: 'path',
+      label: agent.mcpConfigLocation.path,
+      title: agent.mcpConfigLocation.path,
+    };
   }
 
   if (agent.configLocation?.displayPath) {
-    return agent.configLocation.displayPath;
+    return {
+      kind: 'path',
+      label: agent.configLocation.displayPath,
+      title: agent.configLocation.path ?? agent.configLocation.displayPath,
+    };
   }
 
   if (agent.configLocation?.path) {
-    return agent.configLocation.path;
+    return {
+      kind: 'path',
+      label: agent.configLocation.path,
+      title: agent.configLocation.path,
+    };
   }
 
-  return '-';
+  return noKnownSupportLocation();
 }
 
-function getAgentConfigTitle(agent: AgentRecord): string {
-  return agent.mcpConfigLocation.path
-    ?? agent.configLocation?.path
-    ?? getAgentConfigDisplayPath(agent);
-}
-
-function getAgentSubagentsDisplayPath(agent: AgentRecord): string {
+function getAgentSubagentsDisplayLocation(agent: AgentRecord): AgentLocationDisplay {
   if (agent.subagentsLocation?.displayPath) {
-    return agent.subagentsLocation.displayPath;
+    return {
+      kind: 'path',
+      label: agent.subagentsLocation.displayPath,
+      title: agent.subagentsLocation.path ?? agent.subagentsLocation.displayPath,
+    };
   }
 
   if (agent.subagentsLocation?.path) {
-    return agent.subagentsLocation.path;
+    return {
+      kind: 'path',
+      label: agent.subagentsLocation.path,
+      title: agent.subagentsLocation.path,
+    };
   }
 
   if (agent.subagentsLocation?.reason === 'account-managed') {
-    return 'Cloud account managed';
+    return {
+      kind: 'note',
+      label: 'Cloud account managed',
+      title: "Subagents are managed through this agent's cloud account; Skill Index cannot scan or install local subagent files for it.",
+    };
   }
 
-  return '-';
+  return noKnownSupportLocation();
 }
 
-function getAgentSubagentsTitle(agent: AgentRecord): string {
-  if (agent.subagentsLocation?.reason === 'account-managed') {
-    return "Subagents are managed through this agent's cloud account; Skill Index cannot scan or install local subagent files for it.";
-  }
-
-  return agent.subagentsLocation?.path ?? getAgentSubagentsDisplayPath(agent);
+function noKnownSupportLocation(): AgentLocationDisplay {
+  return {
+    kind: 'note',
+    label: 'No known support',
+    title: 'No known support',
+  };
 }
 
 export function EmptyStatePanel({ message }: { message: string }) {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2044,9 +2044,22 @@ body {
   color: var(--text-primary);
 }
 
-.agent-location-path--account-managed {
+.agent-location-path:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid color-mix(in srgb, var(--action) 34%, transparent);
+  outline-offset: 2px;
+}
+
+.agent-location-note {
   color: var(--text-muted);
   font-style: italic;
+}
+
+.agent-location-tooltip {
+  max-width: min(560px, calc(100vw - 24px));
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono);
+  font-weight: 500;
 }
 
 .not-installed-agent-row {

--- a/src/renderer/src/views/AgentsWorkspaceView.test.tsx
+++ b/src/renderer/src/views/AgentsWorkspaceView.test.tsx
@@ -65,6 +65,7 @@ describe('AgentsWorkspaceView', () => {
       installState: 'not-installed',
       defaultHomeDir: '~/.adal',
       defaultGlobalSkillsDir: '~/.config/agents/skills',
+      skillsLocation: createAvailableLocation('~/.config/agents/skills'),
       mcpConfigLocation: {
         state: 'available',
         exists: false,
@@ -95,8 +96,9 @@ describe('AgentsWorkspaceView', () => {
     expect(screen.getByRole('button', { name: 'All2' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: 'Installed1' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Not installed1' })).toBeInTheDocument();
-    expect(screen.getAllByText('Skills source')).toHaveLength(2);
-    expect(screen.getAllByText('MCP / config')).toHaveLength(2);
+    expect(screen.getAllByText('Primary Skills Directory')).toHaveLength(2);
+    expect(screen.getAllByText('Primary MCP Definition')).toHaveLength(2);
+    expect(screen.getAllByText('Primary Subagents Directory')).toHaveLength(2);
     expect(screen.queryByText('Installed agents on this machine.')).not.toBeInTheDocument();
     expect(screen.queryByText('Detected in the registry but not on this machine.')).not.toBeInTheDocument();
 
@@ -104,8 +106,8 @@ describe('AgentsWorkspaceView', () => {
     expect(missingRow).not.toBeNull();
     expect(within(missingRow as HTMLElement).getByText('~/.config/agents/skills')).toBeInTheDocument();
     expect(within(missingRow as HTMLElement).getByText('~/.config/agents/mcp.json')).toBeInTheDocument();
-    expect(within(missingRow as HTMLElement).queryByText('Skills source')).not.toBeInTheDocument();
-    expect(within(missingRow as HTMLElement).queryByText('MCP / config')).not.toBeInTheDocument();
+    expect(within(missingRow as HTMLElement).queryByText('Primary Skills Directory')).not.toBeInTheDocument();
+    expect(within(missingRow as HTMLElement).queryByText('Primary MCP Definition')).not.toBeInTheDocument();
     expect(within(missingRow as HTMLElement).queryByText('Not installed')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Not installed1' }));
@@ -146,14 +148,77 @@ describe('AgentsWorkspaceView', () => {
 
     const installedRow = container.querySelector('.agent-status-row');
     expect(installedRow).not.toBeNull();
-    expect(within(installedRow as HTMLElement).getByText('Cloud account managed')).toHaveClass(
-      'agent-location-path--account-managed',
-    );
+    const accountManagedNote = within(installedRow as HTMLElement).getByText('Cloud account managed');
+    expect(accountManagedNote).toHaveClass('agent-location-note');
     expect(within(installedRow as HTMLElement).queryByText('No local skills folder to install into')).not.toBeInTheDocument();
-    expect(within(installedRow as HTMLElement).getByTitle(
+    fireEvent.mouseEnter(accountManagedNote);
+    expect(screen.getByRole('tooltip')).toHaveTextContent(
       "Skills are managed through this agent's cloud account; Skill Index cannot scan or install local skill files for it.",
-    )).toBeInTheDocument();
+    );
+    fireEvent.mouseLeave(accountManagedNote);
     expect(within(installedRow as HTMLElement).queryByText('claude.ai Customize > Skills')).not.toBeInTheDocument();
+  });
+
+  it('shows resolved sandbox skills paths and exposes full paths in hover tooltips', () => {
+    const installedAgent = createAgent({
+      defaultGlobalSkillsDir: '~/.agents/skills',
+      skillsLocation: {
+        state: 'available',
+        exists: true,
+        path: '/tmp/skillindex-data/sandbox/.agents/skills',
+        displayPath: '/tmp/skillindex-data/sandbox/.agents/skills',
+      },
+      mcpConfigLocation: {
+        state: 'available',
+        exists: true,
+        path: '/tmp/skillindex-data/sandbox/.codex/config.toml',
+        displayPath: '/tmp/skillindex-data/sandbox/.codex/config.toml',
+      },
+      subagentsLocation: {
+        state: 'available',
+        exists: true,
+        path: '/tmp/skillindex-data/sandbox/.agents/agents',
+        displayPath: '/tmp/skillindex-data/sandbox/.agents/agents',
+      },
+    });
+
+    const { container } = renderAgentsView([installedAgent]);
+
+    const installedRow = container.querySelector('.agent-status-row');
+    expect(installedRow).not.toBeNull();
+    const skillsPath = within(installedRow as HTMLElement).getByText('/tmp/skillindex-data/sandbox/.agents/skills');
+    fireEvent.mouseEnter(skillsPath);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('/tmp/skillindex-data/sandbox/.agents/skills');
+    fireEvent.mouseLeave(skillsPath);
+    expect(within(installedRow as HTMLElement).queryByText('~/.agents/skills')).not.toBeInTheDocument();
+  });
+
+  it('italicizes non-path location notes and uses no known support instead of a dash', () => {
+    const installedAgent = createAgent({
+      mcpConfigLocation: {
+        state: 'unavailable',
+        exists: false,
+        reason: 'not-supported',
+      },
+      configLocation: {
+        state: 'unavailable',
+        exists: false,
+        reason: 'not-supported',
+      },
+      subagentsLocation: {
+        state: 'unavailable',
+        exists: false,
+        reason: 'account-managed',
+      },
+    });
+
+    const { container } = renderAgentsView([installedAgent]);
+
+    const installedRow = container.querySelector('.agent-status-row');
+    expect(installedRow).not.toBeNull();
+    expect(within(installedRow as HTMLElement).getByText('No known support')).toHaveClass('agent-location-note');
+    expect(within(installedRow as HTMLElement).getByText('Cloud account managed')).toHaveClass('agent-location-note');
+    expect(within(installedRow as HTMLElement).queryByText('-')).not.toBeInTheDocument();
   });
 
   it('renders a real icon image when the agent provides a usable image asset', () => {

--- a/src/renderer/src/views/AgentsWorkspaceView.tsx
+++ b/src/renderer/src/views/AgentsWorkspaceView.tsx
@@ -37,9 +37,9 @@ export function AgentsWorkspaceView({
       title: 'INSTALLED',
       metaLabel: (
         <div className="agent-section-columns" aria-hidden="true">
-          <span className="agent-section-column-label">Skills source</span>
-          <span className="agent-section-column-label">MCP / config</span>
-          <span className="agent-section-column-label">Subagents</span>
+          <span className="agent-section-column-label">Primary Skills Directory</span>
+          <span className="agent-section-column-label">Primary MCP Definition</span>
+          <span className="agent-section-column-label">Primary Subagents Directory</span>
         </div>
       ),
       rows: installedAgents,
@@ -50,9 +50,9 @@ export function AgentsWorkspaceView({
       title: 'NOT INSTALLED',
       metaLabel: (
         <div className="agent-section-columns" aria-hidden="true">
-          <span className="agent-section-column-label">Skills source</span>
-          <span className="agent-section-column-label">MCP / config</span>
-          <span className="agent-section-column-label">Subagents</span>
+          <span className="agent-section-column-label">Primary Skills Directory</span>
+          <span className="agent-section-column-label">Primary MCP Definition</span>
+          <span className="agent-section-column-label">Primary Subagents Directory</span>
         </div>
       ),
       rows: missingAgents,


### PR DESCRIPTION
Changes:

Rename the Agent Directory path columns, show sandbox skills paths, add hover/focus tooltips for full location text, italicize non-path notes, and replace unsupported dashes with No known support.

Validation:
pnpm typecheck
pnpm exec vitest run src/renderer/src/views/AgentsWorkspaceView.test.tsx
pnpm exec vitest run src/renderer/src/app-shell.test.tsx -t "renders Agents as grouped installed and not-installed rows with path evidence"
Browser check: Cursor skills tooltip rendered above the cell with the full sandbox path
