### PR TITLE
Update AI setup tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 https://github.com/user-attachments/assets/730265b3-46ce-46f9-9150-0e0057e2f00c
 
-Organize and standardize your knowledge across agents, 100% locally.
+Keep your AI setup aligned across every agent, 100% locally.
 
 Skill Index is a local macOS app to standardize the skills, MCP servers, and plugin capabilities you use across AI agents. Each of your 40+ agents should be able to draw from the same body of knowledge instead of slowly drifting into separate setups.
 

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -343,7 +343,7 @@ describe('App shell inventory views', () => {
     render(<App />);
 
     expect(await screen.findByRole('heading', { name: /^How it fits together$/i, level: 1 })).toBeInTheDocument();
-    expect(screen.getByText(/Organize and standardize your knowledge across agents/i)).toBeInTheDocument();
+    expect(screen.getByText(/Keep your AI setup aligned across every agent/i)).toBeInTheDocument();
     expect(screen.getByText('~/.agents/skills')).toBeInTheDocument();
 
     await waitFor(() => {

--- a/src/renderer/src/views/OnboardingFlow.tsx
+++ b/src/renderer/src/views/OnboardingFlow.tsx
@@ -89,7 +89,7 @@ function OnboardingRail() {
         <div className="onboarding-brand-name">Skill Index</div>
       </div>
 
-      <h2>Organize and standardize your knowledge across agents.</h2>
+      <h2>Keep your AI setup aligned across every agent.</h2>
       <p className="onboarding-rail-sub">
         Skill Index keeps your skills and MCPs in sync across every coding agent on your machine - Claude, Codex, and whatever comes next.
       </p>


### PR DESCRIPTION
## Changes

- Updated the Skill Index tagline in the README and onboarding rail to "Keep your AI setup aligned across every agent."
- Updated the onboarding app-shell test expectation for the new copy.

## Validation

- `pnpm typecheck`
- `pnpm test -- src/renderer/src/app-shell.test.tsx`
