### PR TITLE
Ignore read-only plugin copies in copy repairs

### DIFF
--- a/src/main/issue-resolution.test.ts
+++ b/src/main/issue-resolution.test.ts
@@ -711,6 +711,56 @@ describe('resolveInventoryIssue', () => {
     expect(resolvedSkill?.issueReasons).toEqual(['missing-symlinks']);
   });
 
+  it('rejects stale identical skill copy repairs for plugin cache copies with no writable targets', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-resolve-plugin-identical-no-targets-'));
+    const homeDir = path.join(root, 'home');
+    const dataDir = path.join(root, 'data');
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: dataDir,
+      },
+      homeDir,
+    });
+    const firstPluginRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'official', 'tools', '1.0.0');
+    const secondPluginRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'official', 'tools', '1.1.0');
+    const pluginSkillContent = [
+      '---',
+      'name: foo',
+      'description: Plugin foo.',
+      '---',
+      '',
+      '# Foo',
+      'Plugin content shared by two cached versions.',
+      '',
+    ].join('\n');
+
+    for (const [pluginRoot, version] of [[firstPluginRoot, '1.0.0'], [secondPluginRoot, '1.1.0']] as const) {
+      await mkdir(path.join(pluginRoot, '.claude-plugin'), { recursive: true });
+      await writeFile(path.join(pluginRoot, '.claude-plugin', 'plugin.json'), JSON.stringify({
+        name: 'tools',
+        version,
+      }, null, 2), 'utf8');
+      await writeSkillFile(path.join(pluginRoot, 'skills', 'foo', 'SKILL.md'), pluginSkillContent);
+    }
+    await mkdir(path.join(homeDir, '.agents', 'skills'), { recursive: true });
+    await mkdir(path.join(homeDir, '.factory'), { recursive: true });
+    await writeFile(path.join(homeDir, '.factory', 'settings.json'), '{}\n', 'utf8');
+
+    await expect(resolveInventoryIssue(
+      {
+        entity: 'skill',
+        issue: 'identical-copies',
+        skillName: 'tools:foo',
+      },
+      {
+        paths,
+        homeDir,
+        includeLiveSources: true,
+        includeSandboxSources: false,
+      },
+    )).rejects.toThrow('Skill "tools:foo" no longer has Identical Copies.');
+  });
+
   it('repairs identical skill copies without repairing broken existing symlinks', async () => {
     const paths = await createPaths('skillindex-resolve-');
     await seedRepresentativeFixtures({ paths });

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -335,8 +335,12 @@ async function resolveSkillIssueIfCurrent(
         .filter((location) =>
           location.fileType === 'real-file'
           && location.path !== canonicalPath
-          && location.provenance?.kind !== 'plugin')
+          && location.provenance?.kind !== 'plugin'
+          && location.mutability === 'writable')
         .map((location) => location.path);
+      if (duplicatePaths.length === 0) {
+        throw new Error(`Skill "${request.skillName}" has no writable copies to convert.`);
+      }
       await Promise.all(dedupeNormalizedPaths(duplicatePaths).map((locationPath) => replaceWritableWithCanonicalSymlink(locationPath, canonicalPath, snapshot)));
       await persistSkillUniversalDecisionForSelection(skill, canonicalPackage.location, options);
       return;

--- a/src/main/sandbox-fixtures.ts
+++ b/src/main/sandbox-fixtures.ts
@@ -1991,6 +1991,7 @@ async function writeSandboxClaudePluginState(sandboxRoot: string): Promise<void>
       enabledPlugins: {
         'sandbox-plugin-pack': true,
         'example-workflow-kit@sandbox-gallery': true,
+        'version-shadow-kit@sandbox-gallery': true,
         'alloy-kit@sandbox-gallery': true,
         'data-lens@sandbox-gallery': false,
       },
@@ -2019,6 +2020,8 @@ async function writeSandboxExamplePluginBundles(sandboxRoot: string): Promise<vo
   const dataLensRoot = path.join(sandboxRoot, '.claude', 'plugins', 'cache', 'sandbox-gallery', 'data-lens', '0.8.0');
   const relayHubRoot = path.join(sandboxRoot, '.claude', 'plugins', 'cache', 'sandbox-gallery', 'relay-hub', '3.2.0');
   const alloyKitRoot = path.join(sandboxRoot, '.claude', 'plugins', 'cache', 'sandbox-gallery', 'alloy-kit', '1.1.0');
+  const versionShadowOldRoot = path.join(sandboxRoot, '.claude', 'plugins', 'cache', 'sandbox-gallery', 'version-shadow-kit', '1.0.0');
+  const versionShadowNewRoot = path.join(sandboxRoot, '.claude', 'plugins', 'cache', 'sandbox-gallery', 'version-shadow-kit', '1.1.0');
   const signalMapServerPath = path.join(signalToolsRoot, 'servers', 'signal-map.js');
   const relayHubServerPath = path.join(relayHubRoot, 'servers', 'relay-hub.js');
   const alloyPlannerServerPath = path.join(alloyKitRoot, 'servers', 'alloy-planner.js');
@@ -2136,6 +2139,12 @@ async function writeSandboxExamplePluginBundles(sandboxRoot: string): Promise<vo
     title: 'Alloy planner',
     bodyLines: ['Plan a composite workflow across every plugin asset type.'],
   });
+  const cacheShadowSkill = buildSkillMarkdown({
+    skillName: 'cache-shadow',
+    description: 'Identical skill content cached in two plugin versions.',
+    title: 'Cache shadow',
+    bodyLines: ['Two read-only plugin cache versions should not create copy-conversion work.'],
+  });
 
   await Promise.all([
     writePluginManifest(path.join(codexRoot, '.codex-plugin', 'plugin.json'), 'example-workflow-kit'),
@@ -2205,6 +2214,10 @@ async function writeSandboxExamplePluginBundles(sandboxRoot: string): Promise<vo
     }),
     writeFileWithParents(alloyPlannerServerPath, buildSandboxMcpServerScript('alloy-planner')),
     writePluginHooks(path.join(alloyKitRoot, 'hooks', 'hooks.json'), ['Notification', 'Stop']),
+    writePluginManifest(path.join(versionShadowOldRoot, '.claude-plugin', 'plugin.json'), 'version-shadow-kit', '1.0.0'),
+    writePluginManifest(path.join(versionShadowNewRoot, '.claude-plugin', 'plugin.json'), 'version-shadow-kit', '1.1.0'),
+    writeFileWithParents(path.join(versionShadowOldRoot, 'skills', 'cache-shadow', 'SKILL.md'), cacheShadowSkill),
+    writeFileWithParents(path.join(versionShadowNewRoot, 'skills', 'cache-shadow', 'SKILL.md'), cacheShadowSkill),
   ]);
 }
 

--- a/src/main/scan-inventory.test.ts
+++ b/src/main/scan-inventory.test.ts
@@ -743,7 +743,7 @@ describe('representative-agent scan foundation', () => {
 
     expect(seeded.fixtureSet).toBe('representative-agent-scan-foundation');
     expect(seeded.ignoredPaths).toHaveLength(2);
-    expect(inventory.skills).toHaveLength(88);
+    expect(inventory.skills).toHaveLength(89);
     expect(inventory.skills.map((skill) => skill.name)).toEqual(expect.arrayContaining([
       'broken-symlink-skill',
       'double-broken-symlink-skill',
@@ -787,6 +787,7 @@ describe('representative-agent scan foundation', () => {
       'data-lens:data-sketch',
       'alloy-kit:alloy-planner',
       'alloy-kit:release-notes',
+      'version-shadow-kit:cache-shadow',
       'single-source-skill',
       'wrong-symlink-target-skill',
       'representative-healthy-skill-37',
@@ -853,6 +854,13 @@ describe('representative-agent scan foundation', () => {
         bundledMcps: arrayContaining([objectContaining({ name: 'alloyPlanner' })]),
         unsupportedHooksCount: 2,
       }),
+      objectContaining({
+        host: 'claude',
+        pluginId: 'version-shadow-kit@sandbox-gallery',
+        bundledSkills: arrayContaining([objectContaining({ name: 'cache-shadow' })]),
+        bundledMcps: [],
+        unsupportedHooksCount: 0,
+      }),
     ]));
     expect((inventory.plugins ?? []).filter((plugin) => plugin.pluginName === 'example-workflow-kit')
       .map((plugin) => plugin.host).sort()).toEqual(['claude', 'codex']);
@@ -862,9 +870,24 @@ describe('representative-agent scan foundation', () => {
     expect(examplePluginSkill?.issueReasons).toEqual(['missing-symlinks']);
     expect(examplePluginSkill?.locations).toHaveLength(2);
     expect(examplePluginSkill?.locations.map((location) => location.provenance?.plugin?.host).sort()).toEqual(['claude', 'codex']);
-    expect(inventory.skills.find((skill) => skill.name === 'plugin-manual-identical-skill')).toMatchObject({
+    const versionShadowSkill = inventory.skills.find((skill) => skill.name === 'version-shadow-kit:cache-shadow');
+    expect(versionShadowSkill).toMatchObject({
+      structuralState: 'missing-symlinks',
+      isDrifted: true,
+      issueReasons: ['missing-symlinks'],
+    });
+    expect(versionShadowSkill?.locations).toHaveLength(2);
+    expect(versionShadowSkill?.locations
+      .map((location) => location.provenance?.plugin?.version)
+      .sort()).toEqual(['1.0.0', '1.1.0']);
+    expect(versionShadowSkill?.detailDiagnostics.duplicateCandidates).toHaveLength(2);
+    expect(inventory.skills.find((skill) => skill.name === 'mixed-plugin-skill')).toMatchObject({
       structuralState: 'identical-drift',
-      issueReasons: arrayContaining(['identical-copies', 'missing-symlinks']),
+      issueReasons: arrayContaining(['identical-copies']),
+    });
+    expect(inventory.skills.find((skill) => skill.name === 'plugin-manual-identical-skill')).toMatchObject({
+      structuralState: 'missing-symlinks',
+      issueReasons: ['missing-symlinks'],
     });
     expect(inventory.skills.find((skill) => skill.name === 'plugin-manual-diverged-skill')).toMatchObject({
       structuralState: 'diverged-drift',
@@ -3550,6 +3573,67 @@ describe('representative-agent scan foundation', () => {
       isDrifted: true,
       issueReasons: ['missing-symlinks'],
     });
+    expect(skill?.detailDiagnostics.missingInstallSources).toEqual(expect.arrayContaining([
+      expect.objectContaining({ sourceId: 'live-agents', canonical: false, writable: true }),
+      expect.objectContaining({ sourceId: 'live-factory', kind: 'agent', writable: true }),
+    ]));
+  });
+
+  it('does not report identical copies for read-only plugin cache versions with matching content', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-plugin-cache-identical-'));
+    const homeDir = path.join(root, 'home');
+    const dataDir = path.join(root, 'data');
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: dataDir,
+      },
+      homeDir,
+    });
+    const firstPluginRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'official', 'tools', '1.0.0');
+    const secondPluginRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'official', 'tools', '1.1.0');
+    const pluginSkillContent = [
+      '---',
+      'name: foo',
+      'description: Plugin foo.',
+      '---',
+      '',
+      '# Foo',
+      'Plugin content shared by two cached versions.',
+      '',
+    ].join('\n');
+
+    for (const [pluginRoot, version] of [[firstPluginRoot, '1.0.0'], [secondPluginRoot, '1.1.0']] as const) {
+      await mkdir(path.join(pluginRoot, '.claude-plugin'), { recursive: true });
+      await writeFile(path.join(pluginRoot, '.claude-plugin', 'plugin.json'), JSON.stringify({
+        name: 'tools',
+        version,
+      }, null, 2), 'utf8');
+      await writeSkillFile(
+        path.join(pluginRoot, 'skills'),
+        'foo',
+        pluginSkillContent,
+        version === '1.0.0' ? '2026-01-08T00:00:00.000Z' : '2026-01-08T00:01:00.000Z',
+      );
+    }
+    await mkdir(path.join(homeDir, '.agents', 'skills'), { recursive: true });
+    await mkdir(path.join(homeDir, '.factory'), { recursive: true });
+    await writeFile(path.join(homeDir, '.factory', 'settings.json'), '{}\n', 'utf8');
+
+    const inventory = await scanInventory({
+      paths,
+      homeDir,
+      includeLiveSources: true,
+      includeSandboxSources: false,
+    });
+
+    const skill = inventory.skills.find((entry) => entry.name === 'tools:foo');
+    expect(skill).toMatchObject({
+      structuralState: 'missing-symlinks',
+      isDrifted: true,
+      issueReasons: ['missing-symlinks'],
+    });
+    expect(skill?.issueReasons).not.toContain('identical-copies');
+    expect(skill?.detailDiagnostics.duplicateCandidates).toHaveLength(2);
     expect(skill?.detailDiagnostics.missingInstallSources).toEqual(expect.arrayContaining([
       expect.objectContaining({ sourceId: 'live-agents', canonical: false, writable: true }),
       expect.objectContaining({ sourceId: 'live-factory', kind: 'agent', writable: true }),

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -1839,12 +1839,19 @@ function getSkillIssueReasons({
       getSkillComparisonContentHash(location, usePluginMirrorComparison)));
     if (contentHashes.size > 1) {
       reasons.add('diverged-copies');
-    } else if (!usePluginMirrorComparison) {
+    } else if (!usePluginMirrorComparison && realFileLocations.some(isActionableIdenticalSkillCopyTarget)) {
       reasons.add('identical-copies');
     }
   }
 
   return [...reasons].sort(compareSkillIssueReasons);
+}
+
+function isActionableIdenticalSkillCopyTarget(location: SkillLocationRecord): boolean {
+  return location.fileType === 'real-file'
+    && !location.canonical
+    && location.mutability === 'writable'
+    && location.provenance?.kind !== 'plugin';
 }
 
 function isCrossHostPluginMirror(locations: SkillLocationRecord[]): boolean {

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -1159,18 +1159,18 @@ describe('App shell inventory views', () => {
     });
 
     await openSkills();
-    fireEvent.click(getSkillRow('identical-drift-skill'));
+    fireEvent.click(getSkillRow('diverged-drift-skill'));
 
-    expect(await screen.findByRole('button', { name: /^Convert Copies to Symlinks$/i })).toBeEnabled();
+    expect(await screen.findByRole('button', { name: /^Use as Universal$/i })).toBeEnabled();
     expect(screen.getByRole('button', { name: /^Add Skill$/i })).toBeEnabled();
 
-    fireEvent.click(screen.getByRole('button', { name: /^Convert Copies to Symlinks$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Use as Universal$/i }));
 
     await waitFor(() => {
       expect(makeCanonicalMock).toHaveBeenCalledWith({
         entity: 'skill',
-        issue: 'identical-copies',
-        skillName: 'identical-drift-skill',
+        issue: 'diverged-copies',
+        skillName: 'diverged-drift-skill',
         selectedVariantPath: '/Users/arjitjaiswal/.skillindex/sandbox/.agents',
       });
     });
@@ -2060,6 +2060,7 @@ describe('App shell inventory views', () => {
     fireEvent.click(getSkillRow('healthy-skill'));
 
     expect(await screen.findByRole('heading', { name: 'healthy-skill', level: 3 })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /Locations/i }));
     expect(screen.getAllByText('/tmp/skillindex/custom-scan/healthy-skill.md').length).toBeGreaterThan(0);
 
     await openSettings();

--- a/src/renderer/src/lib/detail-inspector-model.ts
+++ b/src/renderer/src/lib/detail-inspector-model.ts
@@ -326,7 +326,7 @@ export function buildSkillInspectorModel(
       key,
       label: formatSkillIssueReason(key),
       detail: getSkillProblemDetail(skill, key),
-      summary: getSkillProblemSummary(skill, key),
+      summary: getSkillProblemSummary(skill, key, sourceIndex),
       isActive: key === activeProblem.key,
     })),
     problemSections: buildProblemSections(problemKeys),
@@ -458,7 +458,7 @@ function buildSkillProblemModel(
         title: formatSkillIssueReason(problemKey),
         listTitle: 'Matching Copies',
         items: skill.detailDiagnostics.duplicateCandidates
-          .filter((candidate) => candidate.fileType === 'real-file' && !candidate.canonical)
+          .filter((candidate) => isActionableIdenticalSkillDuplicateCandidate(candidate, sourceIndex))
           .sort(compareNewestCandidate)
           .map((candidate) => ({
             id: candidate.path,
@@ -612,7 +612,17 @@ function isWritableNonPluginLocation(
   sourceIndex: Map<string, SkillScanSource>,
 ): boolean {
   const source = sourceIndex.get(location.sourceId);
-  return source?.writable === true && source.kind !== 'plugin';
+  return location.provenance?.kind !== 'plugin'
+    && (location.mutability === 'writable' || (source?.writable === true && source.kind !== 'plugin'));
+}
+
+function isActionableIdenticalSkillDuplicateCandidate(
+  candidate: SkillDuplicateCandidate,
+  sourceIndex: Map<string, SkillScanSource>,
+): boolean {
+  return candidate.fileType === 'real-file'
+    && !candidate.canonical
+    && isWritableNonPluginLocation(candidate, sourceIndex);
 }
 
 function formatUseAsUniversalSummary({
@@ -1188,7 +1198,11 @@ function getSkillProblemKeys(skill: SkillRecord): SkillIssueReason[] {
   return keys;
 }
 
-function getSkillProblemSummary(skill: SkillRecord, key: SkillIssueReason): string {
+function getSkillProblemSummary(
+  skill: SkillRecord,
+  key: SkillIssueReason,
+  sourceIndex: Map<string, SkillScanSource>,
+): string {
   switch (key) {
     case 'diverged-copies': {
       const groupedCount = groupSkillVariants(skill.detailDiagnostics.duplicateCandidates).length;
@@ -1198,7 +1212,8 @@ function getSkillProblemSummary(skill: SkillRecord, key: SkillIssueReason): stri
     case 'missing-canonical':
       return '1 issue';
     case 'identical-copies': {
-      const count = skill.detailDiagnostics.duplicateCandidates.filter((candidate) => candidate.fileType === 'real-file' && !candidate.canonical).length;
+      const count = skill.detailDiagnostics.duplicateCandidates
+        .filter((candidate) => isActionableIdenticalSkillDuplicateCandidate(candidate, sourceIndex)).length;
       return `${count} cop${count === 1 ? 'y' : 'ies'}`;
     }
     case 'missing-symlinks': {

--- a/src/renderer/src/lib/issue-resolution.test.ts
+++ b/src/renderer/src/lib/issue-resolution.test.ts
@@ -109,6 +109,109 @@ describe('issue resolution request builder', () => {
     expect(getAutoResolvableSkillRequests(snapshot, pluginSourceIndex)).toEqual([]);
   });
 
+  it('does not build an identical-copy repair request when only read-only plugin copies match', () => {
+    const firstPath = '/Users/tester/.claude/plugins/cache/official/tools/1.0.0/skills/foo';
+    const secondPath = '/Users/tester/.claude/plugins/cache/official/tools/1.1.0/skills/foo';
+    const buildPluginLocation = (
+      locationPath: string,
+      sourceId: string,
+      version: string,
+      canonical: boolean,
+    ): SkillRecord['locations'][number] => ({
+      path: locationPath,
+      sourceId,
+      sourceLabel: `Claude Plugin tools ${version}`,
+      sourceScope: 'live',
+      fileType: 'real-file',
+      installKind: 'directory',
+      modifiedAt: '2026-01-08T00:00:00.000Z',
+      canonical,
+      resolvedPath: locationPath,
+      contentHash: 'plugin-foo',
+      provenance: {
+        kind: 'plugin',
+        sourcePath: locationPath,
+        discoveredAt: '2026-01-08T00:00:00.000Z',
+        plugin: {
+          host: 'claude',
+          pluginId: 'tools@official',
+          version,
+        },
+      },
+      mutability: 'read-only-managed',
+    });
+    const firstLocation = buildPluginLocation(firstPath, 'live-plugin-tools-v1', '1.0.0', true);
+    const secondLocation = buildPluginLocation(secondPath, 'live-plugin-tools-v2', '1.1.0', false);
+    const skill: SkillRecord = {
+      name: 'tools:foo',
+      structuralState: 'identical-drift',
+      isDrifted: true,
+      driftPresentation: 'active',
+      issueReasons: ['identical-copies'],
+      locations: [firstLocation, secondLocation],
+      detailDiagnostics: {
+        duplicateCandidates: [firstLocation, secondLocation].map((location) => ({
+          ...location,
+          installSource: {
+            sourceId: location.sourceId,
+            label: location.sourceLabel,
+            kind: 'plugin',
+            scope: 'live',
+            writable: false,
+            canonical: true,
+          },
+        })),
+        installSources: [
+          {
+            sourceId: 'live-plugin-tools-v1',
+            label: 'Claude Plugin tools 1.0.0',
+            kind: 'plugin',
+            scope: 'live',
+            writable: false,
+            canonical: true,
+          },
+          {
+            sourceId: 'live-plugin-tools-v2',
+            label: 'Claude Plugin tools 1.1.0',
+            kind: 'plugin',
+            scope: 'live',
+            writable: false,
+            canonical: true,
+          },
+        ],
+        missingInstallSources: [],
+        definitionIssues: [],
+      },
+    };
+    const pluginSourceIndex = new Map(sourceIndex);
+    const dirname = (locationPath: string) => locationPath.slice(0, locationPath.lastIndexOf('/'));
+    for (const source of skill.detailDiagnostics.installSources) {
+      pluginSourceIndex.set(source.sourceId, {
+        id: source.sourceId,
+        label: source.label,
+        canonical: true,
+        kind: 'plugin',
+        writable: false,
+        scope: 'live',
+        skillsDir: dirname(source.sourceId === 'live-plugin-tools-v1' ? firstPath : secondPath),
+        compatibleAgentFamilies: ['claude'],
+      });
+    }
+    const model = buildSkillInspectorModel(skill, pluginSourceIndex, {
+      selectedProblemKey: 'identical-copies',
+      selectedVariantPath: null,
+    }, agentIndex);
+
+    if (model.activeProblem.kind !== 'structural-repair') {
+      throw new Error('Expected identical copies to build a structural repair model.');
+    }
+    expect(model.activeProblem.items).toEqual([]);
+    expect(getSkillResolveActionState(skill, model, pluginSourceIndex)).toEqual({
+      disabledReason: 'There are no writable copies to convert.',
+      request: null,
+    });
+  });
+
   it('keeps wrong symlink target repairs out of Home auto-resolve batches', () => {
     const skill: SkillRecord = {
       name: 'wrong-link-skill',

--- a/src/renderer/src/lib/issue-resolution.ts
+++ b/src/renderer/src/lib/issue-resolution.ts
@@ -49,6 +49,7 @@ const SUBAGENT_RESOLVABLE_ISSUES = new Set([
   'wrong-symlink-target',
 ] as const);
 const SKILL_UNIVERSAL_TARGET_REQUIRED_REASON = 'Choose a Universal version first. Symlink repairs need a Universal target.';
+const SKILL_NO_WRITABLE_IDENTICAL_COPIES_REASON = 'There are no writable copies to convert.';
 
 export function getSkillResolveActionState(
   skill: SkillRecord,
@@ -84,6 +85,13 @@ export function getSkillResolveActionState(
   if (requiresVariantSelection && !selectedVariantPath) {
     return {
       disabledReason: getSkillMissingUniversalTargetReason(activeProblem.key, hasUniversalRealFile),
+      request: null,
+    };
+  }
+
+  if (activeProblem.key === 'identical-copies' && !hasWritableIdenticalSkillCopyTarget(skill, sourceIndex)) {
+    return {
+      disabledReason: SKILL_NO_WRITABLE_IDENTICAL_COPIES_REASON,
       request: null,
     };
   }
@@ -354,6 +362,19 @@ function hasSubagentLocalExtras(location: { localExtrasKeys?: string[] }): boole
 
 function hasCanonicalRealFile(skill: SkillRecord): boolean {
   return skill.locations.some((location) => location.canonical && location.fileType === 'real-file');
+}
+
+function hasWritableIdenticalSkillCopyTarget(
+  skill: SkillRecord,
+  sourceIndex: Map<string, SkillScanSource>,
+): boolean {
+  return skill.locations.some((location) => {
+    const source = sourceIndex.get(location.sourceId);
+    return location.fileType === 'real-file'
+      && !location.canonical
+      && location.provenance?.kind !== 'plugin'
+      && (location.mutability === 'writable' || (source?.writable === true && source.kind !== 'plugin'));
+  });
 }
 
 function getSkillMissingUniversalTargetReason(


### PR DESCRIPTION
## Changes

- Treat identical skill copies as actionable only when a writable non-plugin duplicate can be converted to a symlink.
- Keep identical-copy resolution from acting on read-only plugin cache versions with no writable targets.
- Add a representative sandbox fixture for identical cached plugin versions and focused scanner, resolver, renderer action-state, and detail-inspector coverage.

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run src/main/scan-inventory.test.ts src/main/issue-resolution.test.ts src/renderer/src/lib/issue-resolution.test.ts src/renderer/src/lib/detail-inspector-model.test.ts`
- `SKILL_INDEX_ENABLE_DEV_TOOLS=1 pnpm build`
- Real Electron sandbox verification for `version-shadow-kit:cache-shadow` with representative fixtures reset; confirmed only `Missing Symlinks` appears.
