### PR TITLE
Gate automatic update restarts

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1518,12 +1518,17 @@ export default function App() {
   }, [desktopApi, showErrorToast]);
 
   useEffect(() => {
-    if (autoUpdateStatus.phase !== 'ready' || didRequestUpdateInstallRef.current) {
+    if (
+      !hasLoadedStartupState
+      || settingsState.onboardingCompletedAt !== null
+      || autoUpdateStatus.phase !== 'ready'
+      || didRequestUpdateInstallRef.current
+    ) {
       return;
     }
 
     void handleInstallUpdate();
-  }, [autoUpdateStatus.phase, handleInstallUpdate]);
+  }, [autoUpdateStatus.phase, handleInstallUpdate, hasLoadedStartupState, settingsState.onboardingCompletedAt]);
 
   useEffect(() => {
     if (autoUpdateStatus.phase === 'downloading' || autoUpdateStatus.phase === 'ready') {

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -580,7 +580,7 @@ describe('App shell inventory views', () => {
     expect(progressbar).toHaveAttribute('aria-valuenow', '24');
   });
 
-  it('relaunches automatically once a downloaded update is ready', async () => {
+  it('keeps downloaded updates manual for users who completed onboarding', async () => {
     readUpdateStatusMock.mockResolvedValue({
       downloadProgress: {
         percent: 100,
@@ -606,15 +606,24 @@ describe('App shell inventory views', () => {
       });
     });
 
-    await waitFor(() => {
-      expect(installUpdateMock).toHaveBeenCalledTimes(1);
-    });
-    expect(await screen.findByRole('dialog', { name: /Updating Skill Index/i })).toHaveTextContent(
-      /Relaunching Skill Index/i,
-    );
+    await screen.findByRole('button', { name: /Restart to install Skill Index 0\.2\.0/i });
+    expect(installUpdateMock).not.toHaveBeenCalled();
   });
 
-  it('relaunches automatically when an update is already ready', async () => {
+  it('keeps already-ready updates manual for users who completed onboarding', async () => {
+    readUpdateStatusMock.mockResolvedValue({
+      phase: 'ready',
+      version: '0.2.0',
+      lastCheckedAt: '2026-05-17T00:00:00.000Z',
+    });
+    render(<App />);
+
+    await screen.findByRole('button', { name: /Restart to install Skill Index 0\.2\.0/i });
+    expect(installUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('relaunches automatically when an update is ready before onboarding has completed', async () => {
+    readSettingsMock.mockResolvedValue(createSettingsState([], null, null));
     readUpdateStatusMock.mockResolvedValue({
       phase: 'ready',
       version: '0.2.0',


### PR DESCRIPTION
## Changes

- Keep downloaded Skill Index updates manual after onboarding has completed.
- Preserve automatic relaunch for users who have not completed onboarding.
- Cover ready-update behavior for completed and incomplete onboarding states.

## Validation

- `pnpm exec vitest run src/renderer/src/app-shell.test.tsx -t "updates manual|update is ready before onboarding"`
- `pnpm exec vitest run src/renderer/src/app-shell.test.tsx --testTimeout=10000`
- `pnpm exec vitest run src/main/auto-update.test.ts`
- `pnpm typecheck`
