### PR TITLE
Parse folded inventory descriptions

### DIFF
--- a/src/main/sandbox-fixtures.ts
+++ b/src/main/sandbox-fixtures.ts
@@ -1730,6 +1730,19 @@ async function writeSandboxSubagentFixtures(sandboxRoot: string, agents: AgentRe
       'Reviews implementation changes across supported agents.',
       ['Inspect diffs, note risks, and keep recommendations grounded in repository behavior.'],
     ),
+    writeFileWithParents(
+      canonicalPath('folded-description-subagent'),
+      [
+        '---',
+        'name: folded-description-subagent',
+        'description: >-',
+        '  Code review for a single feature during mission',
+        '  validation. Used only within missions.',
+        '---',
+        'Use this fixture to verify folded descriptions render in list rows.',
+        '',
+      ].join('\n'),
+    ),
     writeMarkdown(
       canonicalPath('missing-from-agents-subagent'),
       'missing-from-agents-subagent',

--- a/src/main/scan-inventory.test.ts
+++ b/src/main/scan-inventory.test.ts
@@ -3199,6 +3199,43 @@ describe('representative-agent scan foundation', () => {
     expect(inventory.skills.find((skill) => skill.name === 'quoted-description-skill')?.description).toBe('Quoted canonical description.');
   });
 
+  it('prefers a folded canonical frontmatter description when building skill rows', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-scan-'));
+    const paths = resolveSkillIndexPaths({
+      env: {
+        SKILL_INDEX_DATA_DIR: root,
+      },
+    });
+
+    await writeSkillFile(
+      paths.sandboxAgentsSkillsDir,
+      'folded-description-skill',
+      [
+        '---',
+        'name: folded-description-skill',
+        'description: >-',
+        '  Build, profile, debug, and refine iOS apps',
+        '  with SwiftUI and Xcode workflows.',
+        '---',
+        '',
+        '# Folded description skill',
+        'Canonical content.',
+        '',
+      ].join('\n'),
+      '2026-01-08T00:00:00.000Z',
+    );
+
+    const inventory = await scanInventory({
+      paths,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+    });
+
+    expect(inventory.skills.find((skill) => skill.name === 'folded-description-skill')?.description).toBe(
+      'Build, profile, debug, and refine iOS apps with SwiftUI and Xcode workflows.',
+    );
+  });
+
   it('uses the frontmatter name as the skill display name and backfills it from legacy cached snapshots', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-scan-'));
     const paths = resolveSkillIndexPaths({

--- a/src/main/skill-inventory.ts
+++ b/src/main/skill-inventory.ts
@@ -63,6 +63,7 @@ import {
   reconcileCachedMcps,
 } from '@main/mcp-inventory';
 import { applyDismissedSubagentState, countSubagents } from '@main/subagent-inventory';
+import { parseYamlBlockScalarHeader, readYamlBlockScalar } from '@main/yaml-scalar';
 
 interface IndexedSkillLocation extends SkillLocationRecord {
   entrypointContent?: string;
@@ -1453,8 +1454,10 @@ function analyzeFrontMatter(content?: string): { parsed: ParsedSkillFrontMatter 
     return { parsed: null, malformed: true };
   }
 
+  const frontMatterLines = lines.slice(1, closingIndex);
   const fields: ParsedSkillFrontMatter = {};
-  for (const line of lines.slice(1, closingIndex)) {
+  for (let index = 0; index < frontMatterLines.length; index += 1) {
+    const line = frontMatterLines[index] ?? '';
     const match = line.match(/^([A-Za-z][A-Za-z0-9-]*):(?:\s*(.*))?$/);
     if (!match) {
       continue;
@@ -1462,6 +1465,14 @@ function analyzeFrontMatter(content?: string): { parsed: ParsedSkillFrontMatter 
 
     const [, rawKey, rawValue = ''] = match;
     if (rawKey === 'name' || rawKey === 'description') {
+      const blockScalarHeader = parseYamlBlockScalarHeader(rawValue);
+      if (blockScalarHeader) {
+        const parsed = readYamlBlockScalar(frontMatterLines, index, blockScalarHeader.fold);
+        fields[rawKey] = parsed.value;
+        index = parsed.endIndex;
+        continue;
+      }
+
       fields[rawKey] = normalizeFrontMatterValue(rawValue);
     }
   }

--- a/src/main/subagent-inventory.test.ts
+++ b/src/main/subagent-inventory.test.ts
@@ -100,6 +100,29 @@ describe('subagent inventory', () => {
     ]);
   });
 
+  it('reads folded Markdown frontmatter descriptions for subagent rows', async () => {
+    const { homeDir, scanOptions } = await createSubagentTestPaths();
+    const canonicalPath = path.join(homeDir, '.agents', 'agents', 'scrutiny-feature-reviewer.md');
+
+    await writeRawFile(canonicalPath, [
+      '---',
+      'name: scrutiny-feature-reviewer',
+      'description: >-',
+      '  Code review for a single feature during mission',
+      '  validation. Used only within missions.',
+      '---',
+      'Review the implementation carefully.',
+      '',
+    ].join('\n'));
+
+    const inventory = await scanInventory(scanOptions);
+    const reviewer = inventory.subagents?.find((subagent) => subagent.name === 'scrutiny-feature-reviewer');
+
+    expect(reviewer?.description).toBe('Code review for a single feature during mission validation. Used only within missions.');
+    expect(reviewer?.locations[0]?.description).toBe('Code review for a single feature during mission validation. Used only within missions.');
+    expect(reviewer?.locations[0]?.invalidDetails).toBeUndefined();
+  });
+
   it('repairs subagent drift by symlinking Markdown agents and rendering Codex TOML', async () => {
     const { homeDir, scanOptions } = await createSubagentTestPaths();
     const canonicalPath = path.join(homeDir, '.agents', 'agents', 'planner.md');
@@ -642,6 +665,9 @@ describe('subagent inventory', () => {
     });
     expect(byName.get('missing-universal-claude-subagent')?.issueReasons).toEqual(['missing-universal']);
     expect(byName.get('missing-universal-codex-subagent')?.issueReasons).toEqual(['missing-universal']);
+    expect(byName.get('folded-description-subagent')).toMatchObject({
+      description: 'Code review for a single feature during mission validation. Used only within missions.',
+    });
     expect(byName.get('identical-copies-subagent')?.issueReasons).toEqual(['identical-copies']);
     expect(byName.get('definition-mismatch-subagent')?.issueReasons).toEqual(['definition-mismatch']);
     expect(byName.get('broken-symlink-subagent')?.issueReasons).toEqual(expect.arrayContaining(['broken-symlink']));

--- a/src/main/subagent-inventory.ts
+++ b/src/main/subagent-inventory.ts
@@ -18,6 +18,7 @@ import type {
 import type { SkillIndexPaths } from '@shared/skill-index-paths';
 
 import { sanitizeJsonc, stableStringify } from '@main/json-utils';
+import { getLeadingWhitespace, parseYamlBlockScalarHeader, readYamlBlockScalar } from '@main/yaml-scalar';
 import {
   getRequiredMarkdownSubagentFields,
   getSubagentFileNameForFormat,
@@ -832,8 +833,10 @@ function parseFrontMatter(raw: string): {
     return { body: normalizedContent, fields: {}, malformed: true };
   }
 
+  const frontMatterLines = lines.slice(1, closingIndex);
   const fields: Record<string, unknown> = {};
-  for (const line of lines.slice(1, closingIndex)) {
+  for (let index = 0; index < frontMatterLines.length; index += 1) {
+    const line = frontMatterLines[index] ?? '';
     const match = /^([A-Za-z][A-Za-z0-9_.-]*):(?:\s*(.*))?$/u.exec(line);
     if (!match) {
       continue;
@@ -842,6 +845,14 @@ function parseFrontMatter(raw: string): {
     const key = match[1];
     const rawValue = match[2] ?? '';
     if (key) {
+      const blockScalarHeader = parseYamlBlockScalarHeader(rawValue);
+      if (blockScalarHeader) {
+        const parsed = readYamlBlockScalar(frontMatterLines, index, blockScalarHeader.fold);
+        fields[key] = parsed.value;
+        index = parsed.endIndex;
+        continue;
+      }
+
       fields[key] = parseYamlScalar(rawValue);
     }
   }
@@ -871,8 +882,9 @@ function parseFlatYaml(raw: string): Record<string, unknown> {
     const key = match[1];
     if (key) {
       const rawValue = match[2] ?? '';
-      if (rawValue.trim() === '|' || rawValue.trim() === '>') {
-        const parsed = readYamlBlockScalar(lines, index, rawValue.trim() === '>');
+      const blockScalarHeader = parseYamlBlockScalarHeader(rawValue);
+      if (blockScalarHeader) {
+        const parsed = readYamlBlockScalar(lines, index, blockScalarHeader.fold);
         values[key] = parsed.value;
         index = parsed.endIndex;
         continue;
@@ -892,30 +904,6 @@ function parseFlatYaml(raw: string): Record<string, unknown> {
   }
 
   return values;
-}
-
-function readYamlBlockScalar(
-  lines: string[],
-  startIndex: number,
-  fold: boolean,
-): { value: string; endIndex: number } {
-  const chunks: string[] = [];
-  let endIndex = startIndex;
-  for (let index = startIndex + 1; index < lines.length; index += 1) {
-    const line = lines[index] ?? '';
-    if (line.trim().length > 0 && getLeadingWhitespace(line).length === 0) {
-      break;
-    }
-
-    chunks.push(line);
-    endIndex = index;
-  }
-
-  const normalized = trimYamlIndentedBlock(chunks);
-  return {
-    value: fold ? normalized.replace(/\n+/gu, ' ').trim() : normalized,
-    endIndex,
-  };
 }
 
 function readYamlIndentedList(
@@ -946,23 +934,6 @@ function readYamlIndentedList(
   }
 
   return values.length > 0 ? { value: values, endIndex } : null;
-}
-
-function trimYamlIndentedBlock(lines: string[]): string {
-  const nonEmptyLines = lines.filter((line) => line.trim().length > 0);
-  const indent = nonEmptyLines.reduce(
-    (current, line) => Math.min(current, getLeadingWhitespace(line).length),
-    Number.POSITIVE_INFINITY,
-  );
-  const trimLength = Number.isFinite(indent) ? indent : 0;
-  return lines
-    .map((line) => line.slice(trimLength))
-    .join('\n')
-    .replace(/\n+$/u, '');
-}
-
-function getLeadingWhitespace(line: string): string {
-  return /^\s*/u.exec(line)?.[0] ?? '';
 }
 
 function parseFlatToml(raw: string): Record<string, unknown> {

--- a/src/main/yaml-scalar.ts
+++ b/src/main/yaml-scalar.ts
@@ -1,0 +1,50 @@
+export function parseYamlBlockScalarHeader(rawValue: string): { fold: boolean } | null {
+  const trimmedValue = rawValue.trim();
+  const match = /^([>|])(?:[+-])?$/u.exec(trimmedValue);
+  if (!match) {
+    return null;
+  }
+
+  return { fold: match[1] === '>' };
+}
+
+export function readYamlBlockScalar(
+  lines: string[],
+  startIndex: number,
+  fold: boolean,
+): { value: string; endIndex: number } {
+  const chunks: string[] = [];
+  let endIndex = startIndex;
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    if (line.trim().length > 0 && getLeadingWhitespace(line).length === 0) {
+      break;
+    }
+
+    chunks.push(line);
+    endIndex = index;
+  }
+
+  const normalized = trimYamlIndentedBlock(chunks);
+  return {
+    value: fold ? normalized.replace(/\n+/gu, ' ').trim() : normalized,
+    endIndex,
+  };
+}
+
+export function trimYamlIndentedBlock(lines: string[]): string {
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0);
+  const indent = nonEmptyLines.reduce(
+    (current, line) => Math.min(current, getLeadingWhitespace(line).length),
+    Number.POSITIVE_INFINITY,
+  );
+  const trimLength = Number.isFinite(indent) ? indent : 0;
+  return lines
+    .map((line) => line.slice(trimLength))
+    .join('\n')
+    .replace(/\n+$/u, '');
+}
+
+export function getLeadingWhitespace(line: string): string {
+  return /^\s*/u.exec(line)?.[0] ?? '';
+}


### PR DESCRIPTION
## Changes

- Parse YAML folded and literal block-scalar descriptions in skill and subagent inventory metadata.
- Add a representative sandbox subagent fixture with a folded description.
- Cover folded descriptions in subagent, sandbox, and skill inventory tests.

## Validation

- `pnpm exec vitest run src/main/subagent-inventory.test.ts`
- `pnpm exec vitest run src/main/scan-inventory.test.ts`
- `pnpm typecheck`
