### PR TITLE
Bump hono security override

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "pnpm": {
     "overrides": {
       "fast-uri": "3.1.2",
-      "hono": "4.12.21",
+      "hono": "4.12.25",
       "ip-address": "10.2.0",
       "postcss": "8.5.14",
       "tmp": "0.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   fast-uri: 3.1.2
-  hono: 4.12.21
+  hono: 4.12.25
   ip-address: 10.2.0
   postcss: 8.5.14
   tmp: 0.2.7
@@ -518,7 +518,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.21
+      hono: 4.12.25
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1684,8 +1684,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.21:
-    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -3124,9 +3124,9 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
-  '@hono/node-server@1.19.14(hono@4.12.21)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
-      hono: 4.12.21
+      hono: 4.12.25
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3182,7 +3182,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.21)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -3192,7 +3192,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.21
+      hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4551,7 +4551,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.21: {}
+  hono@4.12.25: {}
 
   hosted-git-info@4.1.0:
     dependencies:


### PR DESCRIPTION
## Changes

- Bump the pinned `hono` override from `4.12.21` to `4.12.25` so the MCP SDK dependency graph uses the patched release.
- Refresh `pnpm-lock.yaml` entries for `hono` and `@hono/node-server`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm exec vitest run src/shared/renderer-dev-config.test.ts --maxWorkers=1 --no-file-parallelism --reporter=dot`
- `pnpm exec vitest run src/main/mcp-connectivity-transport.test.ts --maxWorkers=1 --no-file-parallelism --reporter=dot`
- `pnpm build`
- Playwright smoke: onboarding, Sandbox Home, MCPs, Settings

Note: a broad local `pnpm test` run was stopped after unrelated timeout-heavy failures across existing sandbox/inventory suites.
