### PR TITLE
Pin DefinitelyTyped registry for Dependabot

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@types:registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Changes

- Add an npm registry override for the `@types` scope so Dependabot resolves DefinitelyTyped packages from the public npm registry instead of GitHub Packages.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
