### PR TITLE
Move pnpm policy settings to workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,16 +58,5 @@
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24",
     "pnpm": ">=10.0.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "fast-uri": "3.1.2",
-      "hono": "4.12.25",
-      "ip-address": "10.2.0",
-      "postcss": "8.5.14",
-      "tmp": "0.2.7",
-      "electron-vite>esbuild": "0.28.1",
-      "vite>esbuild": "0.28.1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,5 +8,10 @@ overrides:
   vite>esbuild: 0.28.1
 
 allowBuilds:
+  electron: true
   electron-winstaller: false
   esbuild: true
+
+onlyBuiltDependencies:
+  - electron
+  - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
-onlyBuiltDependencies:
-  - electron
-  - esbuild
+overrides:
+  fast-uri: 3.1.2
+  hono: 4.12.25
+  ip-address: 10.2.0
+  postcss: 8.5.14
+  tmp: 0.2.7
+  electron-vite>esbuild: 0.28.1
+  vite>esbuild: 0.28.1
+
+allowBuilds:
+  electron-winstaller: false
+  esbuild: true


### PR DESCRIPTION
## Changes

- Move pnpm dependency overrides from the ignored `package.json#pnpm` field to `pnpm-workspace.yaml`.
- Add pnpm 11 `allowBuilds` policy while preserving pnpm 10 `onlyBuiltDependencies` for Electron and esbuild build scripts.
- Explicitly deny `electron-winstaller` build scripts in the pnpm 11 policy.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm exec vitest run src/preload/bridge.test.ts --maxWorkers=1`
- `pnpm build`
- `npx -y pnpm@11 install --frozen-lockfile`
- `SKILL_INDEX_SANDBOX_ROOT=/private/tmp/skillindex-pr72-sandbox pnpm dev`
- Playwright smoke: completed onboarding, confirmed Sandbox source, opened Skills, and verified attention items rendered
