### PR TITLE
Preserve OpenCode environment-backed headers

### DIFF
--- a/src/main/issue-resolution.test.ts
+++ b/src/main/issue-resolution.test.ts
@@ -368,6 +368,65 @@ describe('resolveInventoryIssue', () => {
     });
   });
 
+  it('round-trips portable bearer token environment variables through OpenCode headers', async () => {
+    const paths = await createPaths('skillindex-resolve-mcp-opencode-bearer-');
+    const agentsConfigPath = path.join(paths.sandboxRoot, '.agents', 'mcp.json');
+    const opencodeConfigPath = path.join(paths.sandboxRoot, '.config', 'opencode', 'opencode.json');
+
+    await Promise.all([
+      writeSkillFile(agentsConfigPath, `${JSON.stringify({
+        servers: {
+          github: {
+            type: 'http',
+            url: 'https://api.githubcopilot.com/mcp/',
+            bearer_token_env_var: 'GITHUB_PAT_TOKEN',
+          },
+        },
+      }, null, 2)}\n`),
+      writeSkillFile(opencodeConfigPath, `${JSON.stringify({
+        $schema: 'https://opencode.ai/config.json',
+        mcp: {
+          github: {
+            type: 'remote',
+            url: 'https://api.githubcopilot.com/mcp/',
+          },
+        },
+      }, null, 2)}\n`),
+    ]);
+
+    const resolvedSnapshot = await resolveInventoryIssue(
+      {
+        entity: 'mcp',
+        issue: 'definition-mismatch',
+        mcpName: 'github',
+        selectedVariantPath: agentsConfigPath,
+      },
+      {
+        paths,
+        includeSandboxSources: true,
+        includeLiveSources: false,
+        env: {
+          SKILL_INDEX_AGENT_SUBSET: 'opencode',
+        },
+      },
+    );
+
+    const opencodeConfig = await readFileJson(opencodeConfigPath) as {
+      mcp?: Record<string, Record<string, unknown>>;
+    };
+    expect(opencodeConfig.mcp?.github).toEqual({
+      type: 'remote',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: {
+        Authorization: 'Bearer {env:GITHUB_PAT_TOKEN}',
+      },
+    });
+    expect(resolvedSnapshot.mcps?.find((mcp) => mcp.name === 'github')).toMatchObject({
+      status: 'healthy',
+      issueReasons: [],
+    });
+  });
+
   it('adds explicit remote MCP types when copying inferred HTTP definitions into Claude Code', async () => {
     const paths = await createPaths('skillindex-resolve-claude-remote-type-');
     await seedRepresentativeFixtures({ paths });

--- a/src/main/issue-resolution.test.ts
+++ b/src/main/issue-resolution.test.ts
@@ -368,7 +368,7 @@ describe('resolveInventoryIssue', () => {
     });
   });
 
-  it('round-trips portable bearer token environment variables through OpenCode headers', async () => {
+  it('round-trips portable environment-backed HTTP headers through OpenCode headers', async () => {
     const paths = await createPaths('skillindex-resolve-mcp-opencode-bearer-');
     const agentsConfigPath = path.join(paths.sandboxRoot, '.agents', 'mcp.json');
     const opencodeConfigPath = path.join(paths.sandboxRoot, '.config', 'opencode', 'opencode.json');
@@ -379,6 +379,13 @@ describe('resolveInventoryIssue', () => {
           github: {
             type: 'http',
             url: 'https://api.githubcopilot.com/mcp/',
+            headers: {
+              'X-Client': 'skill-index',
+            },
+            env_http_headers: {
+              'X-Api-Key': 'GITHUB_API_KEY',
+              'X-Organization': 'GITHUB_ORG',
+            },
             bearer_token_env_var: 'GITHUB_PAT_TOKEN',
           },
         },
@@ -394,6 +401,15 @@ describe('resolveInventoryIssue', () => {
       }, null, 2)}\n`),
     ]);
 
+    const resolutionOptions = {
+      paths,
+      includeSandboxSources: true,
+      includeLiveSources: false,
+      env: {
+        SKILL_INDEX_AGENT_SUBSET: 'opencode',
+      },
+    };
+
     const resolvedSnapshot = await resolveInventoryIssue(
       {
         entity: 'mcp',
@@ -401,14 +417,7 @@ describe('resolveInventoryIssue', () => {
         mcpName: 'github',
         selectedVariantPath: agentsConfigPath,
       },
-      {
-        paths,
-        includeSandboxSources: true,
-        includeLiveSources: false,
-        env: {
-          SKILL_INDEX_AGENT_SUBSET: 'opencode',
-        },
-      },
+      resolutionOptions,
     );
 
     const opencodeConfig = await readFileJson(opencodeConfigPath) as {
@@ -419,9 +428,42 @@ describe('resolveInventoryIssue', () => {
       url: 'https://api.githubcopilot.com/mcp/',
       headers: {
         Authorization: 'Bearer {env:GITHUB_PAT_TOKEN}',
+        'X-Api-Key': '{env:GITHUB_API_KEY}',
+        'X-Client': 'skill-index',
+        'X-Organization': '{env:GITHUB_ORG}',
       },
     });
     expect(resolvedSnapshot.mcps?.find((mcp) => mcp.name === 'github')).toMatchObject({
+      status: 'healthy',
+      issueReasons: [],
+    });
+
+    await writeSkillFile(agentsConfigPath, `${JSON.stringify({ servers: {} }, null, 2)}\n`);
+    const recreatedSnapshot = await resolveInventoryIssue(
+      {
+        entity: 'mcp',
+        issue: 'missing-universal',
+        mcpName: 'github',
+        selectedVariantPath: opencodeConfigPath,
+      },
+      resolutionOptions,
+    );
+    const universalConfig = await readFileJson(agentsConfigPath) as {
+      servers?: Record<string, Record<string, unknown>>;
+    };
+    expect(universalConfig.servers?.github).toEqual({
+      type: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: {
+        'X-Client': 'skill-index',
+      },
+      env_http_headers: {
+        'X-Api-Key': 'GITHUB_API_KEY',
+        'X-Organization': 'GITHUB_ORG',
+      },
+      bearer_token_env_var: 'GITHUB_PAT_TOKEN',
+    });
+    expect(recreatedSnapshot.mcps?.find((mcp) => mcp.name === 'github')).toMatchObject({
       status: 'healthy',
       issueReasons: [],
     });

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -26,6 +26,7 @@ import {
   getMcpDefinitionArgs,
   isMcpDefinitionObject,
   isMcpServerDefinitions,
+  normalizeMcpDefinitionForParser,
   splitMcpDefinitionForComparison,
 } from '@shared/mcp-definition';
 import {
@@ -1420,11 +1421,12 @@ function parseSelectedMcpDefinition(location: McpLocationRecord): SelectedMcpDef
     throw new Error('The selected MCP definition must use a supported object structure.');
   }
 
-  const splitDefinition = splitMcpDefinitionForComparison(parsed, location);
+  const normalizedDefinition = normalizeMcpDefinitionForParser(parsed, location.parserKind);
+  const splitDefinition = splitMcpDefinitionForComparison(normalizedDefinition, location);
   return {
     agentLocal: splitDefinition.agentLocal,
     agentLocalKey: location.agentLocalKey,
-    core: buildPortableMcpDefinition(parsed, location),
+    core: buildPortableMcpDefinition(normalizedDefinition, location),
     native: splitDefinition.native,
   };
 }
@@ -2053,15 +2055,23 @@ function toOpenCodeMcpDefinition(definition: McpDefinitionValue): McpDefinitionO
     if (url) {
       remoteDefinition.url = url;
     }
-    if (isMcpDefinitionObject(normalizedDefinition.headers)) {
-      remoteDefinition.headers = normalizedDefinition.headers;
+    const headers: McpDefinitionObject = isMcpDefinitionObject(normalizedDefinition.headers)
+      ? { ...normalizedDefinition.headers }
+      : {};
+    if (isMcpDefinitionObject(normalizedDefinition.env_http_headers)) {
+      for (const [header, rawEnvironmentVariable] of Object.entries(normalizedDefinition.env_http_headers)) {
+        const environmentVariable = getNonEmptyString(rawEnvironmentVariable);
+        if (environmentVariable) {
+          headers[header] = `{env:${environmentVariable}}`;
+        }
+      }
     }
     const bearerTokenEnvVar = getNonEmptyString(normalizedDefinition.bearer_token_env_var);
     if (bearerTokenEnvVar) {
-      remoteDefinition.headers = {
-        ...(isMcpDefinitionObject(remoteDefinition.headers) ? remoteDefinition.headers : {}),
-        Authorization: `Bearer {env:${bearerTokenEnvVar}}`,
-      };
+      headers.Authorization = `Bearer {env:${bearerTokenEnvVar}}`;
+    }
+    if (Object.keys(headers).length > 0) {
+      remoteDefinition.headers = headers;
     }
     copyOptionalOpenCodeFields(normalizedDefinition, remoteDefinition, ['enabled', 'oauth', 'timeout']);
     return remoteDefinition;

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -26,7 +26,6 @@ import {
   getMcpDefinitionArgs,
   isMcpDefinitionObject,
   isMcpServerDefinitions,
-  normalizeMcpDefinitionForParser,
   splitMcpDefinitionForComparison,
 } from '@shared/mcp-definition';
 import {
@@ -1402,6 +1401,15 @@ function isAgentsMcpConfigPath(value: string): boolean {
 }
 
 function parseSelectedMcpDefinition(location: McpLocationRecord): SelectedMcpDefinition {
+  if (location.portableDefinition) {
+    return {
+      agentLocal: location.agentLocal ?? {},
+      agentLocalKey: location.agentLocalKey,
+      core: buildPortableMcpDefinition(location.portableDefinition, location),
+      native: location.nativeDefinition ?? {},
+    };
+  }
+
   if (!location.definitionText) {
     const fallbackDefinition = {
       ...(location.command ? { command: location.command } : {}),
@@ -1421,12 +1429,11 @@ function parseSelectedMcpDefinition(location: McpLocationRecord): SelectedMcpDef
     throw new Error('The selected MCP definition must use a supported object structure.');
   }
 
-  const normalizedDefinition = normalizeMcpDefinitionForParser(parsed, location.parserKind);
-  const splitDefinition = splitMcpDefinitionForComparison(normalizedDefinition, location);
+  const splitDefinition = splitMcpDefinitionForComparison(parsed, location);
   return {
     agentLocal: splitDefinition.agentLocal,
     agentLocalKey: location.agentLocalKey,
-    core: buildPortableMcpDefinition(normalizedDefinition, location),
+    core: buildPortableMcpDefinition(parsed, location),
     native: splitDefinition.native,
   };
 }

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -2056,6 +2056,13 @@ function toOpenCodeMcpDefinition(definition: McpDefinitionValue): McpDefinitionO
     if (isMcpDefinitionObject(normalizedDefinition.headers)) {
       remoteDefinition.headers = normalizedDefinition.headers;
     }
+    const bearerTokenEnvVar = getNonEmptyString(normalizedDefinition.bearer_token_env_var);
+    if (bearerTokenEnvVar) {
+      remoteDefinition.headers = {
+        ...(isMcpDefinitionObject(remoteDefinition.headers) ? remoteDefinition.headers : {}),
+        Authorization: `Bearer {env:${bearerTokenEnvVar}}`,
+      };
+    }
     copyOptionalOpenCodeFields(normalizedDefinition, remoteDefinition, ['enabled', 'oauth', 'timeout']);
     return remoteDefinition;
   }

--- a/src/main/mcp-inventory.ts
+++ b/src/main/mcp-inventory.ts
@@ -28,6 +28,7 @@ import {
   getMcpDefinitionRemoteUrl,
   isMcpDefinitionObject,
   isMcpServerDefinitions,
+  normalizeMcpDefinitionForParser,
   splitMcpDefinitionForComparison,
 } from '@shared/mcp-definition';
 import { parseTomlMcpServerArray, parseTomlMcpServers } from '@shared/toml-mcp';
@@ -745,6 +746,7 @@ function getNestedMcpDefinitionsField(parsed: McpDefinitionObject, pathSegments:
 function buildMcpEntry(name: string, definition: McpDefinitionValue, owner: McpOwnerRecord): ParsedMcpEntry {
   const invalidDetails: string[] = [];
   const normalizedDefinition: McpDefinitionObject = isMcpDefinitionObject(definition) ? definition : {};
+  const comparableDefinition = normalizeMcpDefinitionForParser(normalizedDefinition, owner.parserKind);
   const definitionText = stableStringify(normalizedDefinition, true);
 
   if (!isMcpDefinitionObject(definition)) {
@@ -755,7 +757,7 @@ function buildMcpEntry(name: string, definition: McpDefinitionValue, owner: McpO
   invalidDetails.push(...connection.invalidDetails);
 
   const args = getMcpDefinitionArgs(normalizedDefinition);
-  const splitDefinition = splitMcpDefinitionForComparison(normalizedDefinition, connection);
+  const splitDefinition = splitMcpDefinitionForComparison(comparableDefinition, connection);
   const coreComparisonKey = stableStringify(splitDefinition.core);
   const nativeComparisonKey = stableStringify(splitDefinition.native);
 
@@ -770,6 +772,7 @@ function buildMcpEntry(name: string, definition: McpDefinitionValue, owner: McpO
       scope: owner.scope,
       configPath: owner.configPath as string,
       configName: name,
+      parserKind: owner.parserKind,
       transport: connection.transport,
       command: connection.command,
       url: connection.url,

--- a/src/main/mcp-inventory.ts
+++ b/src/main/mcp-inventory.ts
@@ -772,7 +772,6 @@ function buildMcpEntry(name: string, definition: McpDefinitionValue, owner: McpO
       scope: owner.scope,
       configPath: owner.configPath as string,
       configName: name,
-      parserKind: owner.parserKind,
       transport: connection.transport,
       command: connection.command,
       url: connection.url,

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -541,7 +541,6 @@ export interface McpLocationRecord {
   scope: SkillSourceScope;
   configPath: string;
   configName?: string;
-  parserKind?: AgentMcpParserKind;
   transport?: McpTransportKind;
   command?: string;
   url?: string;

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -541,6 +541,7 @@ export interface McpLocationRecord {
   scope: SkillSourceScope;
   configPath: string;
   configName?: string;
+  parserKind?: AgentMcpParserKind;
   transport?: McpTransportKind;
   command?: string;
   url?: string;

--- a/src/shared/mcp-definition.test.ts
+++ b/src/shared/mcp-definition.test.ts
@@ -70,6 +70,24 @@ describe('MCP definition normalization', () => {
     });
   });
 
+  it('normalizes OpenCode bearer environment headers to the portable auth field', () => {
+    expect(normalizeMcpDefinitionForComparison({
+      type: 'remote',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: {
+        Authorization: 'Bearer {env:GITHUB_PAT_TOKEN}',
+        'X-Client': 'skill-index',
+      },
+    })).toEqual({
+      transport: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: {
+        'X-Client': 'skill-index',
+      },
+      bearer_token_env_var: 'GITHUB_PAT_TOKEN',
+    });
+  });
+
   it('uses parsed connection hints when the raw definition omits transport fields', () => {
     expect(normalizeMcpDefinitionForComparison({
       args: ['server.js'],

--- a/src/shared/mcp-definition.test.ts
+++ b/src/shared/mcp-definition.test.ts
@@ -4,6 +4,7 @@ import {
   buildPortableMcpDefinition,
   getMcpDefinitionArgs,
   normalizeMcpDefinitionForComparison,
+  normalizeMcpDefinitionForParser,
   splitMcpDefinitionForComparison,
 } from './mcp-definition';
 
@@ -70,21 +71,38 @@ describe('MCP definition normalization', () => {
     });
   });
 
-  it('normalizes OpenCode bearer environment headers to the portable auth field', () => {
-    expect(normalizeMcpDefinitionForComparison({
+  it('normalizes environment-backed headers to portable remote auth fields', () => {
+    const definition = {
       type: 'remote',
       url: 'https://api.githubcopilot.com/mcp/',
       headers: {
         Authorization: 'Bearer {env:GITHUB_PAT_TOKEN}',
+        'X-Api-Key': '{env:GITHUB_API_KEY}',
         'X-Client': 'skill-index',
       },
-    })).toEqual({
+    };
+
+    expect(normalizeMcpDefinitionForComparison(
+      normalizeMcpDefinitionForParser(definition, 'jsonc-opencode-mcp'),
+    )).toEqual({
       transport: 'http',
       url: 'https://api.githubcopilot.com/mcp/',
       headers: {
         'X-Client': 'skill-index',
       },
+      env_http_headers: {
+        'X-Api-Key': 'GITHUB_API_KEY',
+      },
       bearer_token_env_var: 'GITHUB_PAT_TOKEN',
+    });
+    expect(normalizeMcpDefinitionForComparison(definition)).toEqual({
+      transport: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      headers: {
+        Authorization: 'Bearer {env:GITHUB_PAT_TOKEN}',
+        'X-Api-Key': '{env:GITHUB_API_KEY}',
+        'X-Client': 'skill-index',
+      },
     });
   });
 

--- a/src/shared/mcp-definition.ts
+++ b/src/shared/mcp-definition.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentMcpParserKind,
   McpConfiguredTransportKind,
   McpDefinitionObject,
   McpDefinitionValue,
@@ -48,6 +49,50 @@ export function normalizeMcpDefinitionForComparison(
   connection?: McpDefinitionConnectionHint,
 ): McpServerDefinition {
   return buildComparableMcpDefinition(definition, connection);
+}
+
+export function normalizeMcpDefinitionForParser(
+  definition: McpDefinitionObject,
+  parserKind: AgentMcpParserKind | undefined,
+): McpDefinitionObject {
+  if (parserKind !== 'jsonc-opencode-mcp') {
+    return definition;
+  }
+
+  const headers = getMcpHeaders(definition);
+  if (!headers) {
+    return definition;
+  }
+
+  const explicitEnvironmentHeaders = isMcpDefinitionObject(definition.env_http_headers)
+    ? definition.env_http_headers
+    : undefined;
+  const explicitBearerTokenEnvVar = getNonEmptyString(definition.bearer_token_env_var);
+  const partitionedHeaders = partitionPortableMcpHeaders(
+    headers,
+    explicitEnvironmentHeaders,
+    explicitBearerTokenEnvVar,
+  );
+  const normalized: McpDefinitionObject = { ...definition };
+  const environmentHeaders = {
+    ...partitionedHeaders.environment,
+    ...explicitEnvironmentHeaders,
+  };
+
+  if (Object.keys(partitionedHeaders.literal).length > 0) {
+    normalized.headers = partitionedHeaders.literal;
+  } else {
+    delete normalized.headers;
+  }
+  delete normalized.http_headers;
+  if (Object.keys(environmentHeaders).length > 0) {
+    normalized.env_http_headers = environmentHeaders;
+  }
+  if (partitionedHeaders.bearerTokenEnvVar) {
+    normalized.bearer_token_env_var = partitionedHeaders.bearerTokenEnvVar;
+  }
+
+  return normalized;
 }
 
 export function splitMcpDefinitionForComparison(
@@ -149,26 +194,15 @@ function buildComparableMcpDefinition(
     }
 
     const headers = getMcpHeaders(definition);
-    const explicitBearerTokenEnvVar = getNonEmptyString(definition.bearer_token_env_var);
-    const detectedBearerHeader = headers ? getBearerTokenEnvironmentHeader(headers) : undefined;
-    const bearerHeader = detectedBearerHeader
-      && (!explicitBearerTokenEnvVar || explicitBearerTokenEnvVar === detectedBearerHeader.envVar)
-      ? detectedBearerHeader
-      : undefined;
     if (headers) {
-      const comparableHeaders = bearerHeader
-        ? Object.fromEntries(Object.entries(headers).filter(([key]) => key !== bearerHeader.key))
-        : headers;
-      if (Object.keys(comparableHeaders).length > 0) {
-        comparable.headers = comparableHeaders;
-      }
+      comparable.headers = headers;
     }
 
     if (isMcpDefinitionObject(definition.env_http_headers)) {
       comparable.env_http_headers = definition.env_http_headers;
     }
 
-    const bearerTokenEnvVar = explicitBearerTokenEnvVar ?? bearerHeader?.envVar;
+    const bearerTokenEnvVar = getNonEmptyString(definition.bearer_token_env_var);
     if (bearerTokenEnvVar) {
       comparable.bearer_token_env_var = bearerTokenEnvVar;
     }
@@ -325,19 +359,51 @@ function getMcpHeaders(definition: McpDefinitionObject): McpDefinitionObject | u
   return undefined;
 }
 
-function getBearerTokenEnvironmentHeader(
+function partitionPortableMcpHeaders(
   headers: McpDefinitionObject,
-): { key: string; envVar: string } | undefined {
+  explicitEnvironmentHeaders: McpDefinitionObject | undefined,
+  explicitBearerTokenEnvVar: string | undefined,
+): {
+  literal: McpDefinitionObject;
+  environment: McpDefinitionObject;
+  bearerTokenEnvVar?: string;
+} {
+  const literal: McpDefinitionObject = {};
+  const environment: McpDefinitionObject = {};
+  let bearerTokenEnvVar: string | undefined;
+
   for (const [key, value] of Object.entries(headers)) {
-    if (key.toLowerCase() !== 'authorization' || typeof value !== 'string') {
+    if (typeof value !== 'string') {
+      literal[key] = value;
       continue;
     }
-    const match = /^Bearer\s+\{env:([A-Za-z_][A-Za-z0-9_]*)\}$/i.exec(value.trim());
-    if (match) {
-      return { key, envVar: match[1] };
+
+    const bearerMatch = key.toLowerCase() === 'authorization'
+      ? /^Bearer\s+\{env:([A-Za-z_][A-Za-z0-9_]*)\}$/i.exec(value.trim())
+      : null;
+    if (
+      bearerMatch
+      && !bearerTokenEnvVar
+      && (!explicitBearerTokenEnvVar || explicitBearerTokenEnvVar === bearerMatch[1])
+    ) {
+      bearerTokenEnvVar = bearerMatch[1];
+      continue;
     }
+
+    const environmentMatch = /^\{env:([A-Za-z_][A-Za-z0-9_]*)\}$/i.exec(value.trim());
+    const explicitEnvironmentVariable = getNonEmptyString(explicitEnvironmentHeaders?.[key]);
+    if (
+      environmentMatch
+      && (!explicitEnvironmentVariable || explicitEnvironmentVariable === environmentMatch[1])
+    ) {
+      environment[key] = environmentMatch[1];
+      continue;
+    }
+
+    literal[key] = value;
   }
-  return undefined;
+
+  return { literal, environment, bearerTokenEnvVar };
 }
 
 export function isMcpDefinitionObject(value: unknown): value is McpDefinitionObject {

--- a/src/shared/mcp-definition.ts
+++ b/src/shared/mcp-definition.ts
@@ -149,15 +149,26 @@ function buildComparableMcpDefinition(
     }
 
     const headers = getMcpHeaders(definition);
+    const explicitBearerTokenEnvVar = getNonEmptyString(definition.bearer_token_env_var);
+    const detectedBearerHeader = headers ? getBearerTokenEnvironmentHeader(headers) : undefined;
+    const bearerHeader = detectedBearerHeader
+      && (!explicitBearerTokenEnvVar || explicitBearerTokenEnvVar === detectedBearerHeader.envVar)
+      ? detectedBearerHeader
+      : undefined;
     if (headers) {
-      comparable.headers = headers;
+      const comparableHeaders = bearerHeader
+        ? Object.fromEntries(Object.entries(headers).filter(([key]) => key !== bearerHeader.key))
+        : headers;
+      if (Object.keys(comparableHeaders).length > 0) {
+        comparable.headers = comparableHeaders;
+      }
     }
 
     if (isMcpDefinitionObject(definition.env_http_headers)) {
       comparable.env_http_headers = definition.env_http_headers;
     }
 
-    const bearerTokenEnvVar = getNonEmptyString(definition.bearer_token_env_var);
+    const bearerTokenEnvVar = explicitBearerTokenEnvVar ?? bearerHeader?.envVar;
     if (bearerTokenEnvVar) {
       comparable.bearer_token_env_var = bearerTokenEnvVar;
     }
@@ -311,6 +322,21 @@ function getMcpHeaders(definition: McpDefinitionObject): McpDefinitionObject | u
     return definition.http_headers;
   }
 
+  return undefined;
+}
+
+function getBearerTokenEnvironmentHeader(
+  headers: McpDefinitionObject,
+): { key: string; envVar: string } | undefined {
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== 'authorization' || typeof value !== 'string') {
+      continue;
+    }
+    const match = /^Bearer\s+\{env:([A-Za-z_][A-Za-z0-9_]*)\}$/i.exec(value.trim());
+    if (match) {
+      return { key, envVar: match[1] };
+    }
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## Changes

- Normalize OpenCode's native environment-header syntax once at the inventory scanning boundary.
- Reuse each scanned location's portable core, native fields, and `agentLocal` data during resolution instead of reparsing its raw config text.
- Round-trip literal and environment-backed HTTP headers between portable definitions and OpenCode, including bearer Authorization headers.
- Cover Universal-to-OpenCode and OpenCode-to-Universal resolution flows.

## Why OpenCode needs normalization

Skill Index's portable MCP model keeps literal headers, environment-backed headers, and bearer-token environment variables in separate fields. OpenCode represents all three inside one native `headers` object: an environment-backed value is written as `{env:NAME}`, while bearer auth is written as `Bearer {env:NAME}`.

Earlier parser differences were recoverable from ordinary JSON fields and shapes, such as `command` arrays, `environment`, `httpUrl`, or transport aliases. Their normalization did not require knowing which parser produced the definition. OpenCode is different because the same JSON header string can have parser-specific meaning: `{env:TOKEN}` is an environment reference in OpenCode, but could be literal header text in another client's config. Applying this interpretation in the shared normalizer would therefore create false matches outside OpenCode.

The scanner already knows the parser kind and already stores a portable core, native fields, and `agentLocal` data on each MCP location. This change applies the OpenCode-only conversion there, then makes resolution consume those stored semantic fields. No parser kind is added to `McpLocationRecord`; raw `definitionText` remains available for inspection and as a compatibility fallback, but it is no longer reparsed as the primary source for scanned locations.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run src/shared/mcp-definition.test.ts src/main/issue-resolution.test.ts src/main/scan-inventory.test.ts`
- `git diff --check`
