### PR TITLE
Show complete error traces

### DIFF
--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -423,6 +423,36 @@ describe('registerIpcHandlers', () => {
     );
   });
 
+  it('returns the complete main-process trace when an IPC handler fails', async () => {
+    electronMocks.ipcHandle.mockClear();
+    const trace = [
+      'Error: Failed to parse Skill Index config.',
+      '    at scanInventory (src/main/scan-inventory.ts:42:7)',
+      '    at refreshInventory (src/main/inventory-runtime.ts:318:11)',
+    ].join('\n');
+    const failure = new Error('Failed to parse Skill Index config.');
+    failure.stack = trace;
+    inventoryRuntime.rescanInventory.mockRejectedValueOnce(failure);
+
+    registerIpcHandlers();
+
+    const rescanHandler = electronMocks.ipcHandle.mock.calls.find(
+      ([channel]) => channel === IPC_CHANNELS.rescanInventory,
+    )?.[1] as ((event: never) => Promise<unknown>) | undefined;
+
+    expect(rescanHandler).toBeTypeOf('function');
+
+    if (!rescanHandler) {
+      throw new Error('Expected the rescan IPC handler to be registered.');
+    }
+
+    await expect(rescanHandler({} as never)).resolves.toEqual({
+      __skillIndexIpcError: true,
+      message: 'Failed to parse Skill Index config.',
+      trace,
+    });
+  });
+
   it('registers a standalone MCP connectivity test handler', async () => {
     electronMocks.ipcHandle.mockClear();
     inventoryRuntime.testMcpConnectivity.mockResolvedValue({});

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -18,6 +18,7 @@ import {
   type ResolveIssueRequest,
   type InventorySourceMode,
 } from '@shared/contracts';
+import { serializeIpcError } from '@shared/ipc-error';
 import { createAuditLogService, type AuditOperationRequest } from '@main/audit-log';
 import { getAutoUpdateStatus, installReadyAutoUpdate, requestAutoUpdateCheck } from '@main/auto-update';
 import { getAppShellState } from '@main/app-shell';
@@ -107,20 +108,20 @@ export function registerIpcHandlers(): void {
     hasRegisteredAuditBroadcast = true;
   }
 
-  ipcMain.handle(IPC_CHANNELS.getShellState, () => getAppShellState());
-  ipcMain.handle(IPC_CHANNELS.readUpdateStatus, () => getAutoUpdateStatus());
-  ipcMain.handle(IPC_CHANNELS.checkForUpdates, () => requestAutoUpdateCheck());
-  ipcMain.handle(IPC_CHANNELS.installUpdate, () => installReadyAutoUpdate());
-  ipcMain.handle(IPC_CHANNELS.openPathInEditor, async (_event, filePath: string) => {
+  registerIpcHandler(IPC_CHANNELS.getShellState, () => getAppShellState());
+  registerIpcHandler(IPC_CHANNELS.readUpdateStatus, () => getAutoUpdateStatus());
+  registerIpcHandler(IPC_CHANNELS.checkForUpdates, () => requestAutoUpdateCheck());
+  registerIpcHandler(IPC_CHANNELS.installUpdate, () => installReadyAutoUpdate());
+  registerIpcHandler(IPC_CHANNELS.openPathInEditor, async (_event, filePath: string) => {
     const errorMessage = await shell.openPath(resolveOpenPath(filePath));
     if (errorMessage) {
       throw new Error(errorMessage);
     }
   });
-  ipcMain.handle(IPC_CHANNELS.revealPathInFinder, (_event, filePath: string) => {
+  registerIpcHandler(IPC_CHANNELS.revealPathInFinder, (_event, filePath: string) => {
     shell.showItemInFolder(resolveOpenPath(filePath));
   });
-  ipcMain.handle(IPC_CHANNELS.chooseDirectory, async (_event, request?: ChooseDirectoryRequest) => {
+  registerIpcHandler(IPC_CHANNELS.chooseDirectory, async (_event, request?: ChooseDirectoryRequest) => {
     const result = await dialog.showOpenDialog({
       title: request?.title ?? 'Choose directory',
       properties: ['openDirectory', 'createDirectory'],
@@ -131,61 +132,61 @@ export function registerIpcHandlers(): void {
   ipcMain.on(IPC_CHANNELS.readInitialInventoryBootstrap, (event) => {
     event.returnValue = readCachedInventorySync(resolveInventoryScanOptions());
   });
-  ipcMain.handle(IPC_CHANNELS.readSettings, () => readSettingsState(resolveInventoryScanOptions()));
-  ipcMain.handle(IPC_CHANNELS.readCachedInventory, () =>
+  registerIpcHandler(IPC_CHANNELS.readSettings, () => readSettingsState(resolveInventoryScanOptions()));
+  registerIpcHandler(IPC_CHANNELS.readCachedInventory, () =>
     inventoryRuntime.readCachedInventory(resolveInventoryScanOptions()),
   );
-  ipcMain.handle(IPC_CHANNELS.scanInventory, () =>
+  registerIpcHandler(IPC_CHANNELS.scanInventory, () =>
     inventoryRuntime.scanInventory(resolveInventoryScanOptions()),
   );
-  ipcMain.handle(IPC_CHANNELS.rescanInventory, (_event, request?: RescanInventoryRequest) =>
+  registerIpcHandler(IPC_CHANNELS.rescanInventory, (_event, request?: RescanInventoryRequest) =>
     triggerInventoryRescan(request),
   );
-  ipcMain.handle(IPC_CHANNELS.testMcpConnectivity, () =>
+  registerIpcHandler(IPC_CHANNELS.testMcpConnectivity, () =>
     inventoryRuntime.testMcpConnectivity(resolveInventoryScanOptions()),
   );
-  ipcMain.handle(IPC_CHANNELS.cancelMcpConnectivityTest, () => {
+  registerIpcHandler(IPC_CHANNELS.cancelMcpConnectivityTest, () => {
     inventoryRuntime.cancelMcpConnectivityTest();
   });
-  ipcMain.handle(
+  registerIpcHandler(
     IPC_CHANNELS.addSkill,
     (_event, request: AddSkillRequest) =>
       inventoryRuntime.addSkill(request, resolveInventoryScanOptions()),
   );
-  ipcMain.handle(
+  registerIpcHandler(
     IPC_CHANNELS.addMcpServer,
     (_event, request: AddMcpServerRequest) =>
       inventoryRuntime.addMcpServer(request, resolveInventoryScanOptions()),
   );
-  ipcMain.handle(
+  registerIpcHandler(
     IPC_CHANNELS.addSubagent,
     (_event, request: AddSubagentRequest) =>
       inventoryRuntime.addSubagent(request, resolveInventoryScanOptions()),
   );
-  ipcMain.handle(IPC_CHANNELS.resolveIssue, (_event, request: ResolveIssueRequest) =>
+  registerIpcHandler(IPC_CHANNELS.resolveIssue, (_event, request: ResolveIssueRequest) =>
     inventoryRuntime.resolveIssue(request),
   );
-  ipcMain.handle(IPC_CHANNELS.applyCapabilityAction, (_event, request: CapabilityActionRequest) =>
+  registerIpcHandler(IPC_CHANNELS.applyCapabilityAction, (_event, request: CapabilityActionRequest) =>
     inventoryRuntime.applyCapabilityAction(request, resolveInventoryScanOptions()),
   );
-  ipcMain.handle(IPC_CHANNELS.dismissDrift, (_event, request: DismissDriftRequest) =>
+  registerIpcHandler(IPC_CHANNELS.dismissDrift, (_event, request: DismissDriftRequest) =>
     inventoryRuntime.dismissDrift(request),
   );
-  ipcMain.handle(IPC_CHANNELS.removeInventoryItem, (_event, request: RemoveInventoryItemRequest) =>
+  registerIpcHandler(IPC_CHANNELS.removeInventoryItem, (_event, request: RemoveInventoryItemRequest) =>
     inventoryRuntime.removeInventoryItem(request, resolveInventoryScanOptions()),
   );
-  ipcMain.handle(IPC_CHANNELS.readAuditLog, (_event, options?: { limit?: number }) =>
+  registerIpcHandler(IPC_CHANNELS.readAuditLog, (_event, options?: { limit?: number }) =>
     inventoryRuntime.readAuditLog(options, resolveInventoryScanOptions()),
   );
-  ipcMain.handle(IPC_CHANNELS.undoAuditOperation, async (_event, operationId: string) => ({
+  registerIpcHandler(IPC_CHANNELS.undoAuditOperation, async (_event, operationId: string) => ({
     ...await inventoryRuntime.undoAuditOperation(operationId),
     settingsState: await readSettingsState(resolveInventoryScanOptions()),
   }));
-  ipcMain.handle(IPC_CHANNELS.releaseStartupObservation, () => {
+  registerIpcHandler(IPC_CHANNELS.releaseStartupObservation, () => {
     inventoryRuntime.releaseStartupObservation();
   });
   if (isDevToolsEnabled()) {
-    ipcMain.handle(IPC_CHANNELS.seedRepresentativeFixtures, async () => {
+    registerIpcHandler(IPC_CHANNELS.seedRepresentativeFixtures, async () => {
       const { seedRepresentativeFixtures } = await import('@main/sandbox-fixtures');
       const paths = resolveSandboxSkillIndexPaths();
       const result = await runAuditedIpcOperation({
@@ -199,30 +200,43 @@ export function registerIpcHandlers(): void {
       }, () => seedRepresentativeFixtures({ env: process.env }), paths);
       return result;
     });
-    ipcMain.handle(IPC_CHANNELS.setInventoryMode, (_event, mode: InventorySourceMode) => setInventoryMode(mode));
+    registerIpcHandler(IPC_CHANNELS.setInventoryMode, (_event, mode: InventorySourceMode) => setInventoryMode(mode));
   }
-  ipcMain.handle(IPC_CHANNELS.addCustomScanPath, (_event, scanPath: string) =>
+  registerIpcHandler(IPC_CHANNELS.addCustomScanPath, (_event, scanPath: string) =>
     runAuditedSettingsOperation('Added custom scan path', (scanOptions) => addCustomScanPath(scanPath, scanOptions)),
   );
-  ipcMain.handle(IPC_CHANNELS.removeCustomScanPath, (_event, scanPath: string) =>
+  registerIpcHandler(IPC_CHANNELS.removeCustomScanPath, (_event, scanPath: string) =>
     runAuditedSettingsOperation('Removed custom scan path', (scanOptions) => removeCustomScanPath(scanPath, scanOptions)),
   );
-  ipcMain.handle(IPC_CHANNELS.setPreferredCanonicalSourcePath, (_event, scanPath: string) =>
+  registerIpcHandler(IPC_CHANNELS.setPreferredCanonicalSourcePath, (_event, scanPath: string) =>
     runAuditedSettingsOperation('Set preferred Universal source', (scanOptions) => setPreferredCanonicalSourcePath(scanPath, scanOptions)),
   );
-  ipcMain.handle(IPC_CHANNELS.clearPreferredCanonicalSourcePath, () =>
+  registerIpcHandler(IPC_CHANNELS.clearPreferredCanonicalSourcePath, () =>
     runAuditedSettingsOperation('Cleared preferred Universal source', (scanOptions) => clearPreferredCanonicalSourcePath(scanOptions)),
   );
-  ipcMain.handle(IPC_CHANNELS.setDevSidebarInventorySourceSwitcherVisible, (_event, visible: boolean) =>
+  registerIpcHandler(IPC_CHANNELS.setDevSidebarInventorySourceSwitcherVisible, (_event, visible: boolean) =>
     runAuditedGlobalSettingsOperation(
       visible ? 'Show sidebar inventory source switcher' : 'Hide sidebar inventory source switcher',
       (scanOptions) => setDevSidebarInventorySourceSwitcherVisible(visible, scanOptions),
     ),
   );
-  ipcMain.handle(IPC_CHANNELS.completeOnboarding, (_event, request: CompleteOnboardingRequest = {}) =>
+  registerIpcHandler(IPC_CHANNELS.completeOnboarding, (_event, request: CompleteOnboardingRequest = {}) =>
     runAuditedSettingsOperation('Completed onboarding', (scanOptions) => completeOnboarding(request, scanOptions)),
   );
-  ipcMain.handle(IPC_CHANNELS.ping, () => 'pong');
+  registerIpcHandler(IPC_CHANNELS.ping, () => 'pong');
+}
+
+function registerIpcHandler<TArgs extends unknown[], TResult>(
+  channel: string,
+  handler: (event: Electron.IpcMainInvokeEvent, ...args: TArgs) => TResult | Promise<TResult>,
+): void {
+  ipcMain.handle(channel, async (event, ...args: TArgs) => {
+    try {
+      return await handler(event, ...args);
+    } catch (error) {
+      return serializeIpcError(error);
+    }
+  });
 }
 
 async function runAuditedSettingsOperation<T>(title: string, run: (scanOptions: ReturnType<typeof resolveInventoryScanOptions>) => Promise<T>): Promise<T> {

--- a/src/preload/bridge.test.ts
+++ b/src/preload/bridge.test.ts
@@ -374,4 +374,26 @@ describe('createSkillIndexDesktopApi', () => {
     });
     expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.ping);
   });
+
+  it('restores a complete main-process trace from an IPC failure response', async () => {
+    const trace = [
+      'Error: Failed to parse Skill Index config.',
+      '    at scanInventory (src/main/scan-inventory.ts:42:7)',
+      '    at refreshInventory (src/main/inventory-runtime.ts:318:11)',
+    ].join('\n');
+    const invoke = vi.fn().mockResolvedValue({
+      __skillIndexIpcError: true,
+      message: 'Failed to parse Skill Index config.',
+      trace,
+    });
+    const api = createSkillIndexDesktopApi(invoke, vi.fn(() => () => undefined));
+
+    const error = await api.rescanInventory().catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({
+      message: 'Failed to parse Skill Index config.',
+      stack: trace,
+    });
+  });
 });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,12 +17,16 @@ const desktopApi = createSkillIndexDesktopApi(
       ipcRenderer.off(channel, wrappedListener);
     };
   },
+  { unwrapIpcErrors: false },
 );
 const bootstrapState = readInitialInventoryBootstrapState();
 
 contextBridge.exposeInMainWorld('skillIndex', desktopApi);
 if (isPreloadDevToolsEnabled()) {
-  const devApi = createSkillIndexDevApi((channel, ...args) => ipcRenderer.invoke(channel, ...args));
+  const devApi = createSkillIndexDevApi(
+    (channel, ...args) => ipcRenderer.invoke(channel, ...args),
+    { unwrapIpcErrors: false },
+  );
   contextBridge.exposeInMainWorld('skillIndexDev', devApi);
 }
 contextBridge.exposeInMainWorld('skillIndexBootstrap', bootstrapState);

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -1149,6 +1149,42 @@ describe('App shell inventory views', () => {
     connectivityDeferred.resolve(createReconciledInventorySnapshot());
   });
 
+  it('shows and copies the complete trace from a failed manual rescan', async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: writeTextMock,
+      },
+    });
+    const trace = [
+      'Error: Failed to parse Skill Index config.',
+      '    at scanInventory (src/main/scan-inventory.ts:42:7)',
+      '    at refreshInventory (src/main/inventory-runtime.ts:318:11)',
+    ].join('\n');
+    const failure = new Error('Failed to parse Skill Index config.');
+    failure.stack = trace;
+    rescanInventoryMock.mockRejectedValueOnce(failure);
+
+    render(<App />);
+
+    await screen.findByLabelText(/Home inventory metrics/i);
+    fireEvent.click(screen.getByRole('button', { name: /^Rescan$/i }));
+
+    const toast = await screen.findByLabelText(/^Inventory refresh failed$/i);
+    expect(within(toast).getByText('Inventory refresh failed')).toBeInTheDocument();
+    expect(within(toast).getByText('Failed to parse Skill Index config.')).toBeInTheDocument();
+
+    fireEvent.click(within(toast).getByRole('button', { name: /^Show failure trace$/i }));
+
+    expect((await within(toast).findByText(/refreshInventory/)).textContent).toBe(trace);
+    fireEvent.click(within(toast).getByRole('button', { name: /^Copy failure trace$/i }));
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(trace);
+    });
+  });
+
   it('keeps issue actions enabled while MCP connectivity testing runs in the background', async () => {
     const rescanDeferred = createDeferred<SkillInventorySnapshot>();
     const connectivityDeferred = createDeferred<SkillInventorySnapshot>();

--- a/src/renderer/src/app/bootstrap.test.ts
+++ b/src/renderer/src/app/bootstrap.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { SkillIndexDesktopApi } from '@shared/contracts';
+import { getDesktopApi } from './bootstrap';
+
+describe('getDesktopApi', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('restores the complete trace after an IPC error crosses contextBridge', async () => {
+    const trace = [
+      'Error: Failed to parse Skill Index config.',
+      '    at scanInventory (src/main/scan-inventory.ts:42:7)',
+      '    at refreshInventory (src/main/inventory-runtime.ts:318:11)',
+    ].join('\n');
+    const bridgedApi = Object.freeze({
+      rescanInventory: vi.fn().mockResolvedValue({
+        __skillIndexIpcError: true,
+        message: 'Failed to parse Skill Index config.',
+        trace,
+      }),
+    }) as unknown as SkillIndexDesktopApi;
+    Object.defineProperty(window, 'skillIndex', {
+      configurable: true,
+      value: bridgedApi,
+    });
+
+    const error = await getDesktopApi().rescanInventory().catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({
+      message: 'Failed to parse Skill Index config.',
+      stack: trace,
+    });
+  });
+});

--- a/src/renderer/src/app/bootstrap.ts
+++ b/src/renderer/src/app/bootstrap.ts
@@ -1,4 +1,5 @@
 import { type SkillInventorySnapshot, type SkillIndexDesktopApi, type SkillIndexDevApi } from '@shared/contracts';
+import { unwrapIpcResponse } from '@shared/ipc-error';
 import {
   getBrowserPreviewDesktopApi,
   getBrowserPreviewDevApi,
@@ -9,10 +10,11 @@ export { createInitialSettingsState } from './browser-preview-adapter';
 
 const cachedInventorySnapshotPromises = new WeakMap<SkillIndexDesktopApi, Map<string, Promise<SkillInventorySnapshot | null>>>();
 const inventorySnapshotPromises = new WeakMap<SkillIndexDesktopApi, Map<string, Promise<SkillInventorySnapshot>>>();
+const diagnosticApiByBridge = new WeakMap<object, object>();
 
 export function getDesktopApi(): SkillIndexDesktopApi {
   if (typeof window !== 'undefined' && window.skillIndex) {
-    return window.skillIndex;
+    return withIpcErrorUnwrapping(window.skillIndex);
   }
 
   return getBrowserPreviewDesktopApi();
@@ -20,7 +22,7 @@ export function getDesktopApi(): SkillIndexDesktopApi {
 
 export function getDevApi(): SkillIndexDevApi | null {
   if (typeof window !== 'undefined' && window.skillIndexDev) {
-    return window.skillIndexDev;
+    return withIpcErrorUnwrapping(window.skillIndexDev);
   }
 
   if (typeof window === 'undefined' || !window.skillIndex) {
@@ -28,6 +30,35 @@ export function getDevApi(): SkillIndexDevApi | null {
   }
 
   return null;
+}
+
+function withIpcErrorUnwrapping<T extends object>(api: T): T {
+  const existingApi = diagnosticApiByBridge.get(api);
+  if (existingApi) {
+    return existingApi as T;
+  }
+
+  const diagnosticApi: Record<PropertyKey, unknown> = {};
+  for (const property of Reflect.ownKeys(api)) {
+    const value: unknown = Reflect.get(api, property);
+    diagnosticApi[property] = typeof value === 'function'
+      ? (...args: unknown[]) => {
+          const result: unknown = Reflect.apply(value, api, args);
+          return isPromiseLike(result)
+            ? result.then((response) => unwrapIpcResponse(response))
+            : result;
+        }
+      : value;
+  }
+  diagnosticApiByBridge.set(api, diagnosticApi);
+  return diagnosticApi as T;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return typeof value === 'object'
+    && value !== null
+    && 'then' in value
+    && typeof value.then === 'function';
 }
 
 export function getInitialInventorySnapshot(): SkillInventorySnapshot | null {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -1,3 +1,5 @@
+import { unwrapIpcResponse } from '@shared/ipc-error';
+
 export const APP_NAME = 'Skill Index';
 
 export const IPC_CHANNELS = {
@@ -1016,7 +1018,19 @@ export interface SkillIndexDevApi {
 type InvokeLike = (channel: string, ...args: unknown[]) => Promise<unknown>;
 type SubscribeLike = (channel: string, listener: (...args: unknown[]) => void) => () => void;
 
-export function createSkillIndexDesktopApi(invoke: InvokeLike, subscribe: SubscribeLike): SkillIndexDesktopApi {
+interface CreateSkillIndexApiOptions {
+  unwrapIpcErrors?: boolean;
+}
+
+export function createSkillIndexDesktopApi(
+  invokeRaw: InvokeLike,
+  subscribe: SubscribeLike,
+  options: CreateSkillIndexApiOptions = {},
+): SkillIndexDesktopApi {
+  const invoke: InvokeLike = options.unwrapIpcErrors === false
+    ? invokeRaw
+    : async (channel, ...args) => unwrapIpcResponse(await invokeRaw(channel, ...args));
+
   return {
     async getShellState() {
       return invoke(IPC_CHANNELS.getShellState) as Promise<AppShellState>;
@@ -1132,7 +1146,14 @@ export function createSkillIndexDesktopApi(invoke: InvokeLike, subscribe: Subscr
   };
 }
 
-export function createSkillIndexDevApi(invoke: InvokeLike): SkillIndexDevApi {
+export function createSkillIndexDevApi(
+  invokeRaw: InvokeLike,
+  options: CreateSkillIndexApiOptions = {},
+): SkillIndexDevApi {
+  const invoke: InvokeLike = options.unwrapIpcErrors === false
+    ? invokeRaw
+    : async (channel, ...args) => unwrapIpcResponse(await invokeRaw(channel, ...args));
+
   return {
     async seedRepresentativeFixtures() {
       return invoke(IPC_CHANNELS.seedRepresentativeFixtures) as Promise<SeedRepresentativeFixturesResult>;

--- a/src/shared/ipc-error.ts
+++ b/src/shared/ipc-error.ts
@@ -1,0 +1,45 @@
+export interface SerializedIpcError {
+  __skillIndexIpcError: true;
+  message: string;
+  trace: string;
+}
+
+export function serializeIpcError(error: unknown): SerializedIpcError {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string'
+      ? error.message
+      : String(error);
+  const trace = error instanceof Error && error.stack
+    ? error.stack
+    : typeof error === 'object' && error !== null && 'stack' in error && typeof error.stack === 'string'
+      ? error.stack
+      : message;
+
+  return {
+    __skillIndexIpcError: true,
+    message,
+    trace,
+  };
+}
+
+export function unwrapIpcResponse<T>(response: T | SerializedIpcError): T {
+  if (!isSerializedIpcError(response)) {
+    return response;
+  }
+
+  const error = new Error(response.message);
+  error.stack = response.trace;
+  throw error;
+}
+
+function isSerializedIpcError(value: unknown): value is SerializedIpcError {
+  return typeof value === 'object'
+    && value !== null
+    && '__skillIndexIpcError' in value
+    && value.__skillIndexIpcError === true
+    && 'message' in value
+    && typeof value.message === 'string'
+    && 'trace' in value
+    && typeof value.trace === 'string';
+}


### PR DESCRIPTION
## Changes

- Preserve main-process error stacks through Electron IPC and `contextBridge`.
- Restore complete traces before renderer error dialogs show or copy them.
- Add regression coverage for main, preload, renderer bridge, and manual rescan dialogs.

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run src/main/ipc.test.ts src/preload/bridge.test.ts src/renderer/src/app/bootstrap.test.ts src/renderer/src/app-shell.test.tsx`
- `pnpm lint`
- `pnpm build`
- Electron Sandbox: used a malformed isolated config, confirmed Show Trace displayed originating frames, and confirmed Copy Trace copied all 10 lines.
