### PR TITLE
Hide redundant provider-specific MCP warning

### DIFF
--- a/src/renderer/src/components/DetailInspectorPanel.test.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.test.tsx
@@ -53,6 +53,7 @@ function createPluginBoundMcp(): McpRecord {
       dependencyWarnings: [
         { kind: 'plugin-root-variable', detail: 'References a plugin-root environment variable.' },
         { kind: 'plugin-contained-path', detail: `References a path inside ${pluginRoot}.` },
+        { kind: 'provider-specific-field', detail: 'Uses provider-specific fields: oauth_resource.' },
       ],
     }],
   };
@@ -109,7 +110,7 @@ describe('DetailInspectorPanel', () => {
     expect(evidence).not.toHaveClass('detail-inspector-panel__badge');
   });
 
-  it('shows selected plugin MCP dependency warnings without disabling promotion', () => {
+  it('shows actionable plugin MCP dependency warnings without duplicating agent-specific settings', () => {
     const mcp = createPluginBoundMcp();
     const model = buildMcpInspectorModel(mcp, {
       selectedProblemKey: 'missing-universal',
@@ -136,6 +137,9 @@ describe('DetailInspectorPanel', () => {
     expect(within(warnings).getByText('References a plugin-root environment variable.')).toBeVisible();
     expect(within(warnings).getByText('Plugin cache path')).toBeVisible();
     expect(within(warnings).getByText(/References a path inside .*plugin-bound-mcp\/1\.0\.0/)).toBeVisible();
+    expect(within(warnings).queryByText('Provider-specific field')).not.toBeInTheDocument();
+    expect(within(warnings).queryByText('Uses provider-specific fields: oauth_resource.')).not.toBeInTheDocument();
+    expect(screen.getByText('Agent-specific settings')).toBeVisible();
     expect(screen.getByRole('button', { name: /Promote to Universal/i })).toBeEnabled();
   });
 

--- a/src/renderer/src/components/DetailInspectorPanel.tsx
+++ b/src/renderer/src/components/DetailInspectorPanel.tsx
@@ -81,6 +81,10 @@ export function DetailInspectorPanel({
     </div>
   );
   const activeProblem = model.activeProblem;
+  const selectedVariantDependencyWarnings = activeProblem.kind === 'variant-resolution'
+    ? (activeProblem.selectedVariant?.dependencyWarnings ?? []).filter((warning) =>
+        warning.kind !== 'provider-specific-field' || !activeProblem.definitionBreakdown)
+    : [];
   const diffStats = activeProblem.kind === 'variant-resolution'
     ? getDiffStats(activeProblem.diffLines)
     : null;
@@ -323,13 +327,13 @@ export function DetailInspectorPanel({
                 ))}
               </div>
 
-              {(activeProblem.selectedVariant?.dependencyWarnings?.length ?? 0) > 0 ? (
+              {selectedVariantDependencyWarnings.length > 0 ? (
                 <div
                   aria-label="Selected plugin candidate dependency warnings"
                   className="detail-inspector-panel__structural-list"
                   role="list"
                 >
-                  {activeProblem.selectedVariant?.dependencyWarnings?.map((warning) => (
+                  {selectedVariantDependencyWarnings.map((warning) => (
                     <div
                       className="detail-inspector-panel__structural-item"
                       key={`${warning.kind}:${warning.detail}`}


### PR DESCRIPTION
## Changes

- Hide provider-specific dependency warnings when the MCP definition breakdown already presents those values as agent-specific settings.
- Keep plugin root and plugin cache path warnings visible.
- Cover the rendering behavior with a focused regression test.

## Validation

- `pnpm exec eslint src/renderer/src/components/DetailInspectorPanel.tsx src/renderer/src/components/DetailInspectorPanel.test.tsx`
- `pnpm exec vitest run src/renderer/src/components/DetailInspectorPanel.test.tsx`
- `pnpm typecheck`
- Playwright browser preview of the MCP definition breakdown
