### PR TITLE
Scope preferred canonical paths per skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Skill Index treats `~/.agents` as the user-owned Universal knowledge directory a
 
 Skills and subagents are mirrored into compatible agent locations, while MCPs are translated into each agent's config format with agent-specific settings preserved. The one exclusion is the exact host family already satisfied by an enabled native plugin for that capability; Skill Index does not create a duplicate local materialization there.
 
-Skill Index still respects agent-native folders, config files, and plugin caches. They just should not silently fork what you know. Skill Index also supports alternate canonical paths for people who maintain their own skills repos: add a custom path in Settings, then mark it as the preferred canonical source.
+Skill Index still respects agent-native folders, config files, and plugin caches. They just should not silently fork what you know. Skill Index also supports alternate canonical paths for people who maintain their own skills repos: add a custom path in Settings, then mark it as the preferred canonical source. Only skills that already exist in that directory opt into it; other skills continue to use `~/.agents/skills`.
 
 That is the opinionated stance: organize your knowledge once, make it visible everywhere you work with agents.
 

--- a/docs/reference/inventory-resolution-model.md
+++ b/docs/reference/inventory-resolution-model.md
@@ -31,7 +31,7 @@ symlink targets, including through filesystem aliases.
 
 | Item type | Universal source | Agent-local representation |
 | --- | --- | --- |
-| Skills | Preferred canonical skills directory, default `~/.agents/skills` | Skill package in each agent skills directory, normally a symlink to Universal |
+| Skills | The preferred canonical directory only when that skill already exists there; otherwise `~/.agents/skills` | Skill package in each agent skills directory, normally a symlink to Universal |
 | Subagents | `~/.agents/agents` | One rendered subagent file per agent, in that agent's supported format |
 | MCPs | `~/.agents/mcp.json` | One server entry inside each agent's MCP config |
 
@@ -45,6 +45,11 @@ for skills or **Definition Mismatch** for subagents or MCPs while Universal is
 missing.
 
 Use **Use as Universal** to export a selected plugin candidate into Universal.
+Configuring a preferred canonical directory does not make it the global
+Universal destination. A skill uses that directory only when it already has its
+opted-in canonical package there; all other skills materialize in
+`~/.agents/skills`, regardless of whether their selected source is a plugin or
+an agent-local copy.
 Once Universal exists, any plugin candidate with different content participates
 in the ordinary **Diverged Copies** or **Definition Mismatch** issue alongside
 Universal. Selecting a plugin version replaces only Universal and refreshes

--- a/src/main/capability-actions.ts
+++ b/src/main/capability-actions.ts
@@ -21,7 +21,7 @@ import {
 } from '@shared/skill-index-paths';
 
 import { scanInventory, type ScanSkillInventoryOptions } from '@main/scan-inventory';
-import { makeSkillCanonical } from '@main/skill-canonicalization';
+import { makeSkillCanonical, resolveCanonicalSkillSource } from '@main/skill-canonicalization';
 import {
   resolveInventoryIssue,
   updateMcpUniversalFromPluginSource,
@@ -38,6 +38,7 @@ export interface CapabilityActionOptions extends ScanSkillInventoryOptions {
 }
 
 const UNIVERSAL_CHOICE_AUTO_REPAIR_ISSUES: SkillResolvableIssue[] = [
+  'missing-canonical',
   'broken-symlink',
   'wrong-symlink-target',
   'missing-symlinks',
@@ -192,11 +193,17 @@ async function persistSkillUniversalDecision(
   const capabilityName = getCapabilityName(skill, selectedLocation);
   const acceptedAlternates = findUniversalDecisionAlternates(snapshot, skill, selectedLocation, capabilityName);
   await materializeSelectedSymlinkUniversal(selectedLocation, snapshot);
+  const universalLocation = resolveSkillUniversalDecisionLocation(
+    skill,
+    selectedLocation,
+    snapshot,
+    options.paths,
+  );
   const decision: SkillUniversalDecision = {
-    id: createSkillUniversalDecisionId(skill.name, selectedLocation),
+    id: createSkillUniversalDecisionId(skill.name, universalLocation),
     skillName: skill.name,
     state: 'user-confirmed',
-    universal: buildSkillUniversalOrigin(selectedLocation),
+    universal: buildSkillUniversalOrigin(universalLocation),
     acceptedAlternates,
     updatedAt: new Date().toISOString(),
   };
@@ -216,6 +223,39 @@ async function persistSkillUniversalDecision(
       decision,
     ],
   });
+}
+
+function resolveSkillUniversalDecisionLocation(
+  skill: SkillRecord,
+  selectedLocation: SkillLocationRecord,
+  snapshot: SkillInventorySnapshot,
+  paths: SkillIndexPaths,
+): SkillLocationRecord {
+  const canonicalSource = resolveCanonicalSkillSource(
+    snapshot,
+    selectedLocation.sourceScope,
+    skill.name,
+    paths,
+  );
+  const universalPath = path.join(canonicalSource.skillsDir, skill.name);
+
+  return {
+    ...selectedLocation,
+    path: universalPath,
+    entrypointPath: selectedLocation.installKind === 'directory'
+      ? path.join(universalPath, 'SKILL.md')
+      : universalPath,
+    sourceId: canonicalSource.id,
+    sourceLabel: canonicalSource.label,
+    sourceScope: canonicalSource.scope,
+    fileType: 'real-file',
+    canonical: true,
+    resolvedPath: universalPath,
+    symlinkTarget: undefined,
+    provenance: undefined,
+    canonicalRole: 'canonical',
+    mutability: canonicalSource.writable ? 'writable' : selectedLocation.mutability,
+  };
 }
 
 function isSelectableUniversalVersion(location: SkillLocationRecord): boolean {

--- a/src/main/issue-resolution.test.ts
+++ b/src/main/issue-resolution.test.ts
@@ -2215,7 +2215,7 @@ describe('resolveInventoryIssue', () => {
     expect(resolvedSkill?.detailDiagnostics.universalDecision?.acceptedAlternates).toEqual([]);
   });
 
-  it('materializes an .agents symlink as Universal when it points at the preferred canonical source', async () => {
+  it('preserves preferred ownership when the skill already exists in the preferred canonical source', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-preferred-agents-choice-'));
     const homeDir = await mkdtemp(path.join(tmpdir(), 'skillindex-live-home-'));
     const paths = resolveSkillIndexPaths({
@@ -2275,10 +2275,11 @@ describe('resolveInventoryIssue', () => {
       includeLiveSources: true,
     });
 
-    await expect(lstat(agentsPath).then((stats) => stats.isSymbolicLink())).resolves.toBe(false);
+    await expect(lstat(agentsPath).then((stats) => stats.isSymbolicLink())).resolves.toBe(true);
     await expect(readFile(path.join(agentsPath, 'SKILL.md'), 'utf8')).resolves.toContain('Preferred canonical repo skill.');
-    expect(await readlink(preferredPath)).toBe(agentsPath);
-    expect(await readlink(factoryPath)).toBe(agentsPath);
+    await expect(lstat(preferredPath).then((stats) => stats.isSymbolicLink())).resolves.toBe(false);
+    expect(await readlink(agentsPath)).toBe(preferredPath);
+    expect(await readlink(factoryPath)).toBe(preferredPath);
     expect(resolvedSnapshot.skills.find((skill) => skill.name === skillName)).toMatchObject({
       structuralState: 'healthy',
       isDrifted: false,
@@ -2288,12 +2289,71 @@ describe('resolveInventoryIssue', () => {
           state: 'user-confirmed',
           universal: {
             kind: 'path',
-            sourceId: 'live-agents',
-            path: agentsPath,
+            sourceId: `preferred-canonical:${preferredSkillsDir}`,
+            path: preferredPath,
           },
         },
       },
     });
+  });
+
+  it('uses .agents for an unowned skill when an unrelated preferred canonical skill exists', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'skillindex-unrelated-preferred-choice-'));
+    const homeDir = await mkdtemp(path.join(tmpdir(), 'skillindex-live-home-'));
+    const paths = resolveSkillIndexPaths({
+      env: { SKILL_INDEX_DATA_DIR: root },
+      homeDir,
+    });
+    const skillName = 'standard-selected-skill';
+    const preferredSkillsDir = path.join(homeDir, 'repos', 'arjit-skills', 'skills');
+    const unexpectedPreferredPath = path.join(preferredSkillsDir, skillName);
+    const agentsPath = path.join(homeDir, '.agents', 'skills', skillName);
+    const factoryPath = path.join(homeDir, '.factory', 'skills', skillName);
+    const selectedContent = [
+      '---',
+      `name: ${skillName}`,
+      'description: Selected agent-local version.',
+      '---',
+      '',
+      '# Selected version',
+      '',
+    ].join('\n');
+    await writeSkillFile(path.join(preferredSkillsDir, 'repo-owned-skill', 'SKILL.md'), [
+      '---',
+      'name: repo-owned-skill',
+      'description: This unrelated skill opts into the preferred repository.',
+      '---',
+      '',
+      '# Repo-owned skill',
+      '',
+    ].join('\n'));
+    await writeSkillFile(path.join(factoryPath, 'SKILL.md'), selectedContent);
+    await writeSkillFile(path.join(homeDir, '.factory', 'settings.json'), '{}\n');
+    await writeSkillIndexConfig(paths.configFile, {
+      customScanPaths: [],
+      preferredCanonicalSourcePath: preferredSkillsDir,
+      dismissedDriftSignatures: [],
+      dismissedMcpSignatures: [],
+    });
+
+    const resolvedSnapshot = await applyCapabilityAction({
+      entity: 'skill',
+      action: 'choose-universal-version',
+      skillName,
+      selectedVariantPath: factoryPath,
+    }, {
+      paths,
+      homeDir,
+      includeSandboxSources: false,
+      includeLiveSources: true,
+    });
+
+    await expect(lstat(agentsPath).then((stats) => stats.isSymbolicLink())).resolves.toBe(false);
+    await expect(readFile(path.join(agentsPath, 'SKILL.md'), 'utf8')).resolves.toBe(selectedContent);
+    expect(await readlink(factoryPath)).toBe(agentsPath);
+    await expect(lstat(unexpectedPreferredPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(resolvedSnapshot.skills.find((skill) => skill.name === skillName)?.detailDiagnostics.universalDecision?.universal)
+      .toMatchObject({ kind: 'path', sourceId: 'live-agents', path: agentsPath });
   });
 
   it('rejects stale skill issue resolution requests after the issue is already resolved', async () => {
@@ -2706,7 +2766,7 @@ describe('resolveInventoryIssue', () => {
     expect(await readFile(paths.cacheFile, 'utf8')).toBe(beforeCache);
   });
 
-  it('creates missing live canonical packages in the preferred source when configured', async () => {
+  it('creates missing live canonical packages in .agents when the skill has not opted into the preferred source', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-resolve-live-'));
     const homeDir = await mkdtemp(path.join(tmpdir(), 'skillindex-live-home-'));
     const paths = resolveSkillIndexPaths({
@@ -2718,6 +2778,7 @@ describe('resolveInventoryIssue', () => {
     const skillName = 'preferred-missing-canonical-skill';
     const preferredSkillsDir = path.join(homeDir, 'repos', 'arjit-skills', 'skills');
     const preferredPath = path.join(preferredSkillsDir, skillName);
+    const agentsPath = path.join(homeDir, '.agents', 'skills', skillName);
     const claudePath = path.join(homeDir, '.claude', 'skills', skillName);
     const skillContent = [
       '---',
@@ -2753,8 +2814,9 @@ describe('resolveInventoryIssue', () => {
       },
     );
 
-    expect(await readFile(path.join(preferredPath, 'SKILL.md'), 'utf8')).toBe(skillContent);
-    expect(await readlink(claudePath)).toBe(preferredPath);
+    expect(await readFile(path.join(agentsPath, 'SKILL.md'), 'utf8')).toBe(skillContent);
+    expect(await readlink(claudePath)).toBe(agentsPath);
+    await expect(lstat(preferredPath)).rejects.toMatchObject({ code: 'ENOENT' });
     expect(resolvedSnapshot.skills.find((skill) => skill.name === skillName)).toMatchObject({
       structuralState: 'healthy',
       isDrifted: false,
@@ -2762,7 +2824,7 @@ describe('resolveInventoryIssue', () => {
     });
   });
 
-  it('repairs diverged live copies to the selected version in the preferred canonical source when configured', async () => {
+  it('repairs an unowned diverged skill in .agents instead of the configured preferred source', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'skillindex-resolve-live-'));
     const homeDir = await mkdtemp(path.join(tmpdir(), 'skillindex-live-home-'));
     const paths = resolveSkillIndexPaths({
@@ -2822,9 +2884,10 @@ describe('resolveInventoryIssue', () => {
       },
     );
 
-    expect(await readFile(path.join(preferredPath, 'SKILL.md'), 'utf8')).toBe(selectedContent);
-    expect(await readlink(agentsPath)).toBe(preferredPath);
-    expect(await readlink(claudePath)).toBe(preferredPath);
+    expect(await readFile(path.join(agentsPath, 'SKILL.md'), 'utf8')).toBe(selectedContent);
+    await expect(lstat(agentsPath).then((stats) => stats.isSymbolicLink())).resolves.toBe(false);
+    expect(await readlink(claudePath)).toBe(agentsPath);
+    await expect(lstat(preferredPath)).rejects.toMatchObject({ code: 'ENOENT' });
     expect(resolvedSnapshot.skills.find((skill) => skill.name === skillName)).toMatchObject({
       structuralState: 'healthy',
       isDrifted: false,

--- a/src/main/issue-resolution.ts
+++ b/src/main/issue-resolution.ts
@@ -511,6 +511,7 @@ async function resolveSkillIssueIfCurrent(
         {
           ...options,
           preparedSnapshot: snapshot,
+          allowDefaultUniversalRoot: true,
           // Non-plugin canonicalization keeps the existing two-step behavior.
           // Promoting a managed plugin source is one explicit export operation:
           // create Universal and distribute it to every compatible writable host.

--- a/src/main/skill-canonicalization.test.ts
+++ b/src/main/skill-canonicalization.test.ts
@@ -536,6 +536,46 @@ describe('makeSkillCanonical', () => {
     expect(await readFile(path.join(nextPluginPath, 'assets', 'payload.bin'))).toEqual(beforeNextPluginAsset);
   });
 
+  it('promotes plugin skills into .agents even when a preferred canonical source is configured', async () => {
+    const root = await createRoot('skillindex-canonicalize-plugin-preferred-');
+    const homeDir = await createRoot('skillindex-live-home-');
+    const paths = resolveSkillIndexPaths({
+      env: { SKILL_INDEX_DATA_DIR: root },
+      homeDir,
+    });
+    const preferredSkillsDir = path.join(homeDir, 'repos', 'preferred-skills');
+    const pluginRoot = path.join(homeDir, '.codex', 'plugins', 'cache', 'official', 'tools', '1.0.0');
+    const pluginPath = path.join(pluginRoot, 'skills', 'foo');
+    const universalPath = path.join(homeDir, '.agents', 'skills', 'tools:foo');
+    const incorrectlyPreferredPath = path.join(preferredSkillsDir, 'tools:foo');
+
+    await mkdir(path.join(pluginRoot, '.codex-plugin'), { recursive: true });
+    await writeFile(path.join(pluginRoot, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'tools', version: '1.0.0' }), 'utf8');
+    await writeSkillFile(path.join(pluginPath, 'SKILL.md'), '# Plugin foo\n');
+    await mkdir(preferredSkillsDir, { recursive: true });
+    await writeSkillIndexConfig(paths.configFile, {
+      customScanPaths: [],
+      preferredCanonicalSourcePath: preferredSkillsDir,
+      dismissedDriftSignatures: [],
+      dismissedMcpSignatures: [],
+    });
+
+    const snapshot = await makeSkillCanonical({
+      skillName: 'tools:foo',
+      selectedVariantPath: pluginPath,
+    }, {
+      paths,
+      homeDir,
+      includeSandboxSources: false,
+      includeLiveSources: true,
+    });
+
+    await expect(readFile(path.join(universalPath, 'SKILL.md'), 'utf8')).resolves.toBe('# Plugin foo\n');
+    await expect(lstat(incorrectlyPreferredPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(snapshot.skills.find((skill) => skill.name === 'tools:foo')?.detailDiagnostics.universalDecision?.universal)
+      .toMatchObject({ kind: 'path', sourceId: 'live-agents', path: universalPath });
+  });
+
   it.each([
     { kind: 'file' as const, leakedRelativePath: 'assets/leak.txt' },
     { kind: 'directory' as const, leakedRelativePath: 'resources/leak/secret.txt' },

--- a/src/main/skill-canonicalization.ts
+++ b/src/main/skill-canonicalization.ts
@@ -32,6 +32,7 @@ export interface MakeSkillCanonicalOptions extends ScanSkillInventoryOptions {
   /** Snapshot prepared by a caller that has already planned an audited action. */
   preparedSnapshot?: SkillInventorySnapshot;
   linkMissingAgentInstalls?: boolean;
+  allowDefaultUniversalRoot?: boolean;
   testFailSkillLinkAt?: number;
   testFailSkillDecisionPersist?: boolean;
 }
@@ -91,7 +92,12 @@ export async function makeSkillCanonical(
   assertAffectedSourcesWritableOrPlugin(sources);
 
   const mutationScope = resolveSkillMutationScope(skill, request);
-  const canonicalPath = resolveCanonicalSkillInstallPath(beforeSnapshot, skill.name, mutationScope, paths);
+  const canonicalPath = resolveCanonicalSkillInstallPath(
+    beforeSnapshot,
+    skill.name,
+    mutationScope,
+    paths,
+  );
   const realFileCandidates = skill.locations
     .filter((location) => location.fileType === 'real-file')
     .sort(compareNewestRealFiles);
@@ -111,7 +117,14 @@ export async function makeSkillCanonical(
     request,
     structuralState: skill.structuralState,
   });
-  const canonicalSource = resolveCanonicalSkillSource(beforeSnapshot, mutationScope, undefined, paths);
+  const allowDefaultUniversalRoot = selectedSource.provenance?.kind === 'plugin'
+    || options.allowDefaultUniversalRoot === true;
+  const canonicalSource = resolveCanonicalSkillSource(
+    beforeSnapshot,
+    mutationScope,
+    skill.name,
+    paths,
+  );
   const universalTargetPath = canonicalPath;
   const persistedUniversalLocation = createCanonicalDecisionLocation(selectedSource, canonicalPath, canonicalSource);
   if (path.normalize(selectedSource.path) !== path.normalize(canonicalPath)) {
@@ -123,7 +136,7 @@ export async function makeSkillCanonical(
     skillName: skill.name,
     scope: mutationScope,
     sources: beforeSnapshot.sources,
-    allowDefaultUniversalRoot: selectedSource.provenance?.kind === 'plugin',
+    allowDefaultUniversalRoot,
   });
   const shouldLinkMissingAgentInstalls = options.linkMissingAgentInstalls !== false;
   const selectedSkillPluginCandidates = (skill.managedSourceCandidates ?? [])
@@ -177,7 +190,7 @@ export async function makeSkillCanonical(
     sources: beforeSnapshot.sources,
     universalRoot: canonicalSource.skillsDir,
     scope: mutationScope,
-    allowDefaultUniversalRoot: selectedSource.provenance?.kind === 'plugin',
+    allowDefaultUniversalRoot,
   });
   let linkTransaction: Awaited<ReturnType<typeof replaceSkillLinksTransaction>> | undefined;
   try {
@@ -345,17 +358,23 @@ function resolveCanonicalSkillInstallPath(
   scope: SkillLocationRecord['sourceScope'],
   paths: SkillIndexPaths,
 ): string {
-  return getSkillInstallPath(resolveCanonicalSkillSource(snapshot, scope, skillName, paths).skillsDir, skillName);
+  return getSkillInstallPath(
+    resolveCanonicalSkillSource(snapshot, scope, skillName, paths).skillsDir,
+    skillName,
+  );
 }
 
-function resolveCanonicalSkillSource(
+export function resolveCanonicalSkillSource(
   snapshot: SkillInventorySnapshot,
   scope: SkillLocationRecord['sourceScope'],
-  skillName?: string,
+  skillName: string,
   paths?: SkillIndexPaths,
 ): SkillInventorySnapshot['sources'][number] {
+  const skill = snapshot.skills.find((entry) => entry.name === skillName);
   const preferredCanonicalSource = snapshot.sources.find((source) =>
-    source.preferredCanonical === true && source.scope === scope);
+    source.preferredCanonical === true
+    && source.scope === scope
+    && skill?.locations.some((location) => location.sourceId === source.id));
   if (preferredCanonicalSource) {
     return preferredCanonicalSource;
   }


### PR DESCRIPTION
## Changes

- Treat the preferred canonical directory as a per-skill opt-in instead of the default destination for every Universal skill.
- Materialize unowned plugin and agent-local skill selections under `~/.agents/skills` while preserving skills already owned by the preferred directory.
- Keep persisted Universal decisions aligned with the selected filesystem destination and document the behavior.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (778 tests)
- Electron Sandbox: promoted an ordinary non-plugin skill with an unrelated preferred directory configured; verified `.agents` materialization and no preferred-directory write
