### PR TITLE
Sort inventory lists alphabetically

### DIFF
--- a/src/renderer/src/inventory-view-model.test.ts
+++ b/src/renderer/src/inventory-view-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { McpRecord, SkillInventorySnapshot, SkillRecord, SkillScanSource } from '@shared/contracts';
+import type { McpRecord, SkillInventorySnapshot, SkillRecord, SkillScanSource, SubagentRecord } from '@shared/contracts';
 
 import { representativeInventorySnapshot } from './representative-preview-data';
 import {
@@ -14,10 +14,12 @@ import {
   getSkillDisplayName,
   getSkillSections,
   getSkillTableRows,
+  getSubagentSections,
+  getSubagentTableRows,
 } from './inventory-view-model';
 
 describe('inventory view ordering', () => {
-  it('orders attention skills by issue count, then displayed title', () => {
+  it('orders attention skills alphabetically by displayed title regardless of issue count', () => {
     const base = structuredClone(representativeInventorySnapshot);
     const missingSymlink = base.skills.find((skill) => skill.name === 'missing-symlink-skill');
     const diverged = base.skills.find((skill) => skill.name === 'diverged-drift-skill');
@@ -37,7 +39,7 @@ describe('inventory view ordering', () => {
           ...diverged!,
           name: 'alpha-skill',
           displayName: 'Zulu Skill',
-          issueReasons: ['diverged-copies'],
+          issueReasons: ['diverged-copies', 'invalid-definition'],
         },
       ],
     };
@@ -53,7 +55,35 @@ describe('inventory view ordering', () => {
     ]);
   });
 
-  it('orders MCP table rows by issue count, then title', () => {
+  it('orders healthy skills alphabetically by displayed title regardless of structural state', () => {
+    const base = structuredClone(representativeInventorySnapshot);
+    const healthy = base.skills.find((skill) => skill.name === 'healthy-skill');
+    const singleSource = base.skills.find((skill) => skill.name === 'single-source-skill');
+    expect(healthy).toBeDefined();
+    expect(singleSource).toBeDefined();
+
+    const snapshot: SkillInventorySnapshot = {
+      ...base,
+      skills: [
+        {
+          ...healthy!,
+          name: 'healthy-zulu-skill',
+          displayName: 'Zulu Skill',
+        },
+        {
+          ...singleSource!,
+          name: 'healthy-alpha-skill',
+          displayName: 'Alpha Skill',
+        },
+      ],
+    };
+
+    const healthyRows = getSkillSections(snapshot).find((section) => section.title === 'Healthy')?.rows ?? [];
+    expect(healthyRows.map((skill) => skill.displayName)).toEqual(['Alpha Skill', 'Zulu Skill']);
+    expect(getSkillTableRows(snapshot).map((skill) => skill.displayName)).toEqual(['Alpha Skill', 'Zulu Skill']);
+  });
+
+  it('orders attention MCPs alphabetically by displayed title regardless of issue count', () => {
     const base = structuredClone(representativeInventorySnapshot);
     const broken = base.mcps?.find((mcp) => mcp.name === 'broken-mcp');
     const diagnostic = base.mcps?.find((mcp) => mcp.name === 'diagnostic-rich-mcp');
@@ -83,14 +113,47 @@ describe('inventory view ordering', () => {
       ],
     };
 
-    expect(getMcpTableRows(snapshot).slice(0, 3).map((mcp) => mcp.name)).toEqual([
-      'middle-mcp',
+    const attentionRows = getMcpSections(snapshot).find((section) => section.title === 'Needs attention')?.rows ?? [];
+    expect(attentionRows.map((mcp) => mcp.name)).toEqual([
       'alpha-mcp',
+      'middle-mcp',
       'zulu-mcp',
+    ]);
+    expect(getMcpTableRows(snapshot).map((mcp) => mcp.name)).toEqual(['alpha-mcp', 'middle-mcp', 'zulu-mcp']);
+  });
+
+  it('orders attention subagents alphabetically by displayed title regardless of issue count', () => {
+    const base = structuredClone(representativeInventorySnapshot);
+    const reviewer = base.subagents?.find((subagent) => subagent.name === 'reviewer');
+    expect(reviewer).toBeDefined();
+
+    const snapshot: SkillInventorySnapshot = {
+      ...base,
+      subagents: [
+        {
+          ...reviewer!,
+          name: 'zeta-subagent',
+          displayName: 'Alpha Subagent',
+          issueReasons: ['missing-from-agents'],
+        } satisfies SubagentRecord,
+        {
+          ...reviewer!,
+          name: 'alpha-subagent',
+          displayName: 'Zulu Subagent',
+          issueReasons: ['missing-from-agents', 'definition-mismatch'],
+        } satisfies SubagentRecord,
+      ],
+    };
+
+    const attentionRows = getSubagentSections(snapshot).find((section) => section.title === 'Needs attention')?.rows ?? [];
+    expect(attentionRows.map((subagent) => subagent.displayName)).toEqual(['Alpha Subagent', 'Zulu Subagent']);
+    expect(getSubagentTableRows(snapshot).map((subagent) => subagent.displayName)).toEqual([
+      'Alpha Subagent',
+      'Zulu Subagent',
     ]);
   });
 
-  it('orders dismissed skills from most issues to fewest issues', () => {
+  it('orders dismissed skills alphabetically regardless of issue count', () => {
     const base = structuredClone(representativeInventorySnapshot);
     const dismissed = base.skills.find((skill) => skill.name === 'dismissed-drift-skill');
     expect(dismissed).toBeDefined();
@@ -100,12 +163,12 @@ describe('inventory view ordering', () => {
       skills: [
         {
           ...dismissed!,
-          name: 'dismissed-two-issues-skill',
+          name: 'zulu-dismissed-skill',
           issueReasons: ['identical-copies', 'invalid-definition'],
         },
         {
           ...dismissed!,
-          name: 'dismissed-one-issue-skill',
+          name: 'alpha-dismissed-skill',
           issueReasons: ['identical-copies'],
         },
         ...base.skills.filter((skill) => skill.name !== 'dismissed-drift-skill'),
@@ -114,12 +177,16 @@ describe('inventory view ordering', () => {
 
     const dismissedRows = getSkillSections(snapshot).find((section) => section.title === 'Dismissed issues')?.rows ?? [];
     expect(dismissedRows.slice(0, 2).map((skill) => skill.name)).toEqual([
-      'dismissed-two-issues-skill',
-      'dismissed-one-issue-skill',
+      'alpha-dismissed-skill',
+      'zulu-dismissed-skill',
     ]);
+    expect(getSkillTableRows(snapshot)
+      .filter((skill) => skill.driftPresentation === 'dismissed')
+      .slice(0, 2)
+      .map((skill) => skill.name)).toEqual(['alpha-dismissed-skill', 'zulu-dismissed-skill']);
   });
 
-  it('orders dismissed MCPs from most issues to fewest issues', () => {
+  it('orders dismissed MCPs alphabetically regardless of issue count', () => {
     const base = structuredClone(representativeInventorySnapshot);
     const dismissed = base.mcps?.find((mcp) => mcp.name === 'muted-mcp');
     expect(dismissed).toBeDefined();
@@ -129,12 +196,12 @@ describe('inventory view ordering', () => {
       mcps: [
         {
           ...dismissed!,
-          name: 'dismissed-two-issues-mcp',
+          name: 'zulu-dismissed-mcp',
           issueReasons: ['definition-mismatch', 'invalid-definition'],
         } satisfies McpRecord,
         {
           ...dismissed!,
-          name: 'dismissed-one-issue-mcp',
+          name: 'alpha-dismissed-mcp',
           issueReasons: ['definition-mismatch'],
         } satisfies McpRecord,
         ...(base.mcps ?? []).filter((mcp) => mcp.name !== 'muted-mcp'),
@@ -143,9 +210,48 @@ describe('inventory view ordering', () => {
 
     const dismissedRows = getMcpSections(snapshot).find((section) => section.title === 'Dismissed issues')?.rows ?? [];
     expect(dismissedRows.slice(0, 2).map((mcp) => mcp.name)).toEqual([
-      'dismissed-two-issues-mcp',
-      'dismissed-one-issue-mcp',
+      'alpha-dismissed-mcp',
+      'zulu-dismissed-mcp',
     ]);
+    expect(getMcpTableRows(snapshot)
+      .filter((mcp) => mcp.presentation === 'dismissed')
+      .slice(0, 2)
+      .map((mcp) => mcp.name)).toEqual(['alpha-dismissed-mcp', 'zulu-dismissed-mcp']);
+  });
+
+  it('orders dismissed subagents alphabetically regardless of issue count', () => {
+    const base = structuredClone(representativeInventorySnapshot);
+    const reviewer = base.subagents?.find((subagent) => subagent.name === 'reviewer');
+    expect(reviewer).toBeDefined();
+
+    const snapshot: SkillInventorySnapshot = {
+      ...base,
+      subagents: [
+        {
+          ...reviewer!,
+          name: 'zulu-dismissed-subagent',
+          displayName: 'Zulu Dismissed Subagent',
+          presentation: 'dismissed',
+          issueReasons: ['missing-from-agents', 'definition-mismatch'],
+        } satisfies SubagentRecord,
+        {
+          ...reviewer!,
+          name: 'alpha-dismissed-subagent',
+          displayName: 'Alpha Dismissed Subagent',
+          presentation: 'dismissed',
+          issueReasons: ['missing-from-agents'],
+        } satisfies SubagentRecord,
+      ],
+    };
+
+    const dismissedRows = getSubagentSections(snapshot).find((section) => section.title === 'Dismissed issues')?.rows ?? [];
+    expect(dismissedRows.map((subagent) => subagent.displayName)).toEqual([
+      'Alpha Dismissed Subagent',
+      'Zulu Dismissed Subagent',
+    ]);
+    expect(getSubagentTableRows(snapshot)
+      .filter((subagent) => subagent.presentation === 'dismissed')
+      .map((subagent) => subagent.displayName)).toEqual(['Alpha Dismissed Subagent', 'Zulu Dismissed Subagent']);
   });
 
   it('uses universal wording for plugin-managed skill access guidance', () => {

--- a/src/renderer/src/inventory-view-model.ts
+++ b/src/renderer/src/inventory-view-model.ts
@@ -25,11 +25,11 @@ export interface SkillAccessState {
 }
 
 export function getSkillSections(snapshot: SkillInventorySnapshot): InventorySection<SkillRecord>[] {
-  const driftedRows = snapshot.skills.filter((skill) => skill.driftPresentation === 'active').sort(compareIssueDenseSkillRows);
-  const dismissedRows = snapshot.skills.filter((skill) => skill.driftPresentation === 'dismissed').sort(compareIssueDenseSkillRows);
+  const driftedRows = snapshot.skills.filter((skill) => skill.driftPresentation === 'active').sort(compareAlphabeticallyBySkillName);
+  const dismissedRows = snapshot.skills.filter((skill) => skill.driftPresentation === 'dismissed').sort(compareAlphabeticallyBySkillName);
   const healthyRows = snapshot.skills
     .filter((skill) => skill.driftPresentation === 'none')
-    .sort(compareStableRows);
+    .sort(compareAlphabeticallyBySkillName);
 
   const sections: InventorySection<SkillRecord>[] = [
     {
@@ -75,13 +75,13 @@ export function getMcpSections(snapshot: SkillInventorySnapshot): InventorySecti
   const mcps = snapshot.mcps ?? [];
   const attentionRows = mcps
     .filter((mcp) => mcp.status === 'needs-attention' && mcp.presentation === 'active')
-    .sort(compareIssueDenseMcpRows);
+    .sort(compareAlphabeticallyByMcpName);
   const mutedRows = mcps
     .filter((mcp) => mcp.status === 'needs-attention' && mcp.presentation === 'dismissed')
-    .sort(compareIssueDenseMcpRows);
+    .sort(compareAlphabeticallyByMcpName);
   const healthyRows = mcps
     .filter((mcp) => mcp.status === 'healthy')
-    .sort(compareAlphabeticallyByName);
+    .sort(compareAlphabeticallyByMcpName);
 
   const sections: InventorySection<McpRecord>[] = [
     {
@@ -115,13 +115,13 @@ export function getSubagentSections(snapshot: SkillInventorySnapshot): Inventory
   const subagents = snapshot.subagents ?? [];
   const attentionRows = subagents
     .filter((subagent) => subagent.status === 'needs-attention' && subagent.presentation === 'active')
-    .sort(compareIssueDenseSubagentRows);
+    .sort(compareAlphabeticallyBySubagentName);
   const mutedRows = subagents
     .filter((subagent) => subagent.status === 'needs-attention' && subagent.presentation === 'dismissed')
-    .sort(compareIssueDenseSubagentRows);
+    .sort(compareAlphabeticallyBySubagentName);
   const healthyRows = subagents
     .filter((subagent) => subagent.status === 'healthy')
-    .sort(compareAlphabeticallyByName);
+    .sort(compareAlphabeticallyBySubagentName);
 
   const sections: InventorySection<SubagentRecord>[] = [
     {
@@ -318,19 +318,6 @@ export function getSkillAccessState(
   };
 }
 
-function compareIssueDenseSkillRows(left: SkillRecord, right: SkillRecord): number {
-  const issueCountDifference = getSkillIssueCount(right) - getSkillIssueCount(left);
-  if (issueCountDifference !== 0) {
-    return issueCountDifference;
-  }
-
-  return compareAlphabeticallyBySkillName(left, right);
-}
-
-function compareAlphabeticallyByName<T extends { name: string }>(left: T, right: T): number {
-  return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
-}
-
 function compareAlphabeticallyByMcpName(left: McpRecord, right: McpRecord): number {
   return getMcpDisplayName(left).localeCompare(getMcpDisplayName(right), undefined, { sensitivity: 'base' })
     || left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
@@ -370,35 +357,19 @@ function stripPluginQualifierFromName(
     : displayName;
 }
 
-function compareStableRows(left: SkillRecord, right: SkillRecord): number {
-  return getStableRank(left) - getStableRank(right) || compareAlphabeticallyBySkillName(left, right);
-}
-
 function compareSkillTableRows(left: SkillRecord, right: SkillRecord): number {
   const presentationRank = getSkillTablePresentationRank(left) - getSkillTablePresentationRank(right);
   if (presentationRank !== 0) {
     return presentationRank;
   }
 
-  if (left.driftPresentation !== 'none') {
-    return compareIssueDenseSkillRows(left, right);
-  }
-
-  return compareStableRows(left, right);
+  return compareAlphabeticallyBySkillName(left, right);
 }
 
 function compareMcpTableRows(left: McpRecord, right: McpRecord): number {
   const presentationRank = getMcpTablePresentationRank(left) - getMcpTablePresentationRank(right);
   if (presentationRank !== 0) {
     return presentationRank;
-  }
-
-  if (left.presentation === 'active' && right.presentation === 'active') {
-    return compareIssueDenseMcpRows(left, right);
-  }
-
-  if (left.presentation === 'dismissed' && right.presentation === 'dismissed') {
-    return compareIssueDenseMcpRows(left, right);
   }
 
   return compareAlphabeticallyByMcpName(left, right);
@@ -408,32 +379,6 @@ function compareSubagentTableRows(left: SubagentRecord, right: SubagentRecord): 
   const presentationRank = getSubagentTablePresentationRank(left) - getSubagentTablePresentationRank(right);
   if (presentationRank !== 0) {
     return presentationRank;
-  }
-
-  if (left.presentation === 'active' && right.presentation === 'active') {
-    return compareIssueDenseSubagentRows(left, right);
-  }
-
-  if (left.presentation === 'dismissed' && right.presentation === 'dismissed') {
-    return compareIssueDenseSubagentRows(left, right);
-  }
-
-  return compareAlphabeticallyBySubagentName(left, right);
-}
-
-function compareIssueDenseMcpRows(left: McpRecord, right: McpRecord): number {
-  const issueCountDifference = getMcpIssueCount(right) - getMcpIssueCount(left);
-  if (issueCountDifference !== 0) {
-    return issueCountDifference;
-  }
-
-  return compareAlphabeticallyByMcpName(left, right);
-}
-
-function compareIssueDenseSubagentRows(left: SubagentRecord, right: SubagentRecord): number {
-  const issueCountDifference = right.issueReasons.length - left.issueReasons.length;
-  if (issueCountDifference !== 0) {
-    return issueCountDifference;
   }
 
   return compareAlphabeticallyBySubagentName(left, right);
@@ -484,59 +429,6 @@ export function getSubagentDisplayName(subagent: Pick<SubagentRecord, 'name' | '
 function stripPluginQualifier(value: string): string {
   const qualifierEnd = value.indexOf(':');
   return qualifierEnd > 0 ? value.slice(qualifierEnd + 1) : value;
-}
-
-function getStableRank(skill: SkillRecord): number {
-  if (skill.driftPresentation === 'dismissed') {
-    return 2;
-  }
-
-  if (skill.structuralState === 'single-source-noncanonical') {
-    return 1;
-  }
-
-  if (skill.structuralState === 'missing-symlinks') {
-    return 1;
-  }
-
-  return 0;
-}
-
-function getSkillIssueCount(skill: SkillRecord): number {
-  const reasons = new Set(skill.issueReasons ?? []);
-
-  if ((skill.detailDiagnostics.definitionIssues?.length ?? 0) > 0) {
-    reasons.add('invalid-definition');
-  }
-
-  if ((skill.detailDiagnostics.missingInstallSources?.length ?? 0) > 0) {
-    reasons.add('missing-symlinks');
-  }
-
-  if (reasons.size === 0) {
-    switch (skill.structuralState) {
-      case 'missing-symlinks':
-        reasons.add('missing-symlinks');
-        break;
-      case 'single-source-noncanonical':
-        reasons.add('missing-canonical');
-        break;
-      case 'identical-drift':
-        reasons.add('identical-copies');
-        break;
-      case 'diverged-drift':
-        reasons.add('diverged-copies');
-        break;
-      case 'healthy':
-        break;
-    }
-  }
-
-  return reasons.size;
-}
-
-function getMcpIssueCount(mcp: McpRecord): number {
-  return mcp.issueReasons.length;
 }
 
 function getSourceById(

--- a/src/renderer/src/views/InventoryViewChrome.test.tsx
+++ b/src/renderer/src/views/InventoryViewChrome.test.tsx
@@ -612,7 +612,7 @@ describe('inventory view chrome', () => {
     });
   });
 
-  it('renders one status pill per issue and orders active rows by issue count', () => {
+  it('renders one status pill per issue while preserving alphabetical row order', () => {
     render(
       <McpWorkspaceView
         inventorySnapshot={representativeInventorySnapshot}
@@ -645,6 +645,8 @@ describe('inventory view chrome', () => {
     expect(rows.item(0)).toHaveTextContent('broken-mcp');
     expect(rows.item(0)).toHaveTextContent('Definition Mismatch');
     expect(rows.item(0)).toHaveTextContent('Invalid Definition');
+    expect(rows.item(1)).toHaveTextContent('diagnostic-rich-mcp');
+    expect(rows.item(2)).toHaveTextContent('missing-from-agents-mcp');
   });
 
   it('shows filter-specific empty states for Skills when a non-empty inventory has no matches for the active filter', () => {


### PR DESCRIPTION
## Changes

- Sort Skills, MCPs, and Subagents alphabetically by display name within Needs Attention, Dismissed, and Healthy groups.
- Keep list and keyboard-navigation ordering aligned, regardless of issue count or skill structural state.
- Cover alphabetical ordering across all three inventory types and status groups.

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run src/renderer/src/inventory-view-model.test.ts src/renderer/src/views/InventoryViewChrome.test.tsx --reporter=dot`
- `pnpm exec eslint src/renderer/src/inventory-view-model.ts src/renderer/src/inventory-view-model.test.ts src/renderer/src/views/InventoryViewChrome.test.tsx`
- Playwright verification against the Sandbox inventory in the Skills, MCPs, and Subagents tabs
