### PR TITLE
Show inventory before connectivity checks

### DIFF
--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -120,9 +120,9 @@ vi.mock('@main/scan-inventory', () => ({
 }));
 
 describe('registerIpcHandlers', () => {
-  it('enables MCP connectivity verification for app-driven full scans', () => {
+  it('keeps app-driven full scans structural so connectivity cannot block inventory', () => {
     expect(createInventoryRuntime).toHaveBeenCalledWith({
-      verifyMcpConnectivityOnFullScan: true,
+      verifyMcpConnectivityOnFullScan: false,
     });
   });
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -50,7 +50,7 @@ import {
 } from '@shared/skill-index-paths';
 
 const inventoryRuntime = createInventoryRuntime({
-  verifyMcpConnectivityOnFullScan: true,
+  verifyMcpConnectivityOnFullScan: false,
 });
 let hasRegisteredInventoryBroadcast = false;
 let hasRegisteredAuditBroadcast = false;

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -491,8 +491,11 @@ export default function App() {
     };
 
     const hydrateInventory = async () => {
+      let startupInventorySourceMode: InventorySourceMode = 'live';
+
       try {
         const [nextShellState, nextSettingsState] = await startupStatePromise;
+        startupInventorySourceMode = nextShellState.devTools?.inventoryMode ?? 'live';
         if (nextSettingsState.onboardingCompletedAt === null) {
           return;
         }
@@ -525,6 +528,9 @@ export default function App() {
         }
 
         applyInventorySnapshot(nextInventorySnapshot);
+        if (startupInventorySourceMode === 'live') {
+          startMcpConnectivityTest();
+        }
       } catch (error) {
         if (!isMounted) {
           return;
@@ -540,7 +546,7 @@ export default function App() {
     return () => {
       isMounted = false;
     };
-  }, [applyInventorySnapshot, desktopApi, devApi, showErrorToast]);
+  }, [applyInventorySnapshot, desktopApi, devApi, showErrorToast, startMcpConnectivityTest]);
 
   useEffect(() => {
     return desktopApi.onInventoryUpdated((nextInventorySnapshot) => {
@@ -1471,7 +1477,7 @@ export default function App() {
         label: 'Skills',
         icon: 'skills' as const,
         badge: inventorySnapshot?.counts.driftedSkills ?? 0,
-        meta: inventorySnapshot?.counts.totalSkills ?? 0,
+        meta: inventorySnapshot ? inventorySnapshot.counts.totalSkills : undefined,
         tone: 'attention' as const,
       },
       {
@@ -1479,7 +1485,7 @@ export default function App() {
         label: 'MCPs',
         icon: 'mcps' as const,
         badge: inventorySnapshot?.mcpCounts?.attentionMcps ?? 0,
-        meta: inventorySnapshot?.mcpCounts?.totalMcps ?? 0,
+        meta: inventorySnapshot ? inventorySnapshot.mcpCounts?.totalMcps ?? 0 : undefined,
         tone: 'attention' as const,
       },
       {
@@ -1487,14 +1493,14 @@ export default function App() {
         label: 'Subagents',
         icon: 'subagents' as const,
         badge: inventorySnapshot?.subagentCounts?.attentionSubagents ?? 0,
-        meta: inventorySnapshot?.subagentCounts?.totalSubagents ?? 0,
+        meta: inventorySnapshot ? inventorySnapshot.subagentCounts?.totalSubagents ?? 0 : undefined,
         tone: 'attention' as const,
       },
       {
         tab: 'plugins' as const,
         label: 'Plugins',
         icon: 'plugins' as const,
-        meta: inventorySnapshot?.plugins?.length ?? 0,
+        meta: inventorySnapshot ? inventorySnapshot.plugins?.length ?? 0 : undefined,
       },
     ],
     [

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1469,6 +1469,7 @@ export default function App() {
     };
   }, [blurActiveSearch, focusActiveSearch, navigateActiveInventoryList]);
 
+  const hasInventorySnapshot = inventorySnapshot !== null;
   const navItems = useMemo(
     () => [
       { tab: 'home' as const, label: 'Home', icon: 'home' as const },
@@ -1477,7 +1478,7 @@ export default function App() {
         label: 'Skills',
         icon: 'skills' as const,
         badge: inventorySnapshot?.counts.driftedSkills ?? 0,
-        meta: inventorySnapshot ? inventorySnapshot.counts.totalSkills : undefined,
+        meta: hasInventorySnapshot ? inventorySnapshot.counts.totalSkills : undefined,
         tone: 'attention' as const,
       },
       {
@@ -1485,7 +1486,7 @@ export default function App() {
         label: 'MCPs',
         icon: 'mcps' as const,
         badge: inventorySnapshot?.mcpCounts?.attentionMcps ?? 0,
-        meta: inventorySnapshot ? inventorySnapshot.mcpCounts?.totalMcps ?? 0 : undefined,
+        meta: hasInventorySnapshot ? inventorySnapshot.mcpCounts?.totalMcps ?? 0 : undefined,
         tone: 'attention' as const,
       },
       {
@@ -1493,17 +1494,18 @@ export default function App() {
         label: 'Subagents',
         icon: 'subagents' as const,
         badge: inventorySnapshot?.subagentCounts?.attentionSubagents ?? 0,
-        meta: inventorySnapshot ? inventorySnapshot.subagentCounts?.totalSubagents ?? 0 : undefined,
+        meta: hasInventorySnapshot ? inventorySnapshot.subagentCounts?.totalSubagents ?? 0 : undefined,
         tone: 'attention' as const,
       },
       {
         tab: 'plugins' as const,
         label: 'Plugins',
         icon: 'plugins' as const,
-        meta: inventorySnapshot ? inventorySnapshot.plugins?.length ?? 0 : undefined,
+        meta: hasInventorySnapshot ? inventorySnapshot.plugins?.length ?? 0 : undefined,
       },
     ],
     [
+      hasInventorySnapshot,
       inventorySnapshot?.counts.driftedSkills,
       inventorySnapshot?.counts.totalSkills,
       inventorySnapshot?.mcpCounts?.attentionMcps,

--- a/src/renderer/src/app-shell.test.tsx
+++ b/src/renderer/src/app-shell.test.tsx
@@ -971,15 +971,44 @@ describe('App shell inventory views', () => {
     render(<App />);
 
     expect(await screen.findByRole('heading', { name: /^Home$/i, level: 2 })).toBeInTheDocument();
-    expect(screen.getByText(/Loading your inventory summary/i)).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Scanning local inventory' })).toBeInTheDocument();
+    expect(screen.queryByText(/Loading your inventory summary/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Home inventory metrics/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Scanning...')).toBeInTheDocument();
+    expect(within(getPrimaryNav()).getByRole('button', { name: /^Skills/i })).not.toHaveTextContent(/^Skills0$/);
 
     cachedInventoryDeferred.resolve(null);
     liveInventoryDeferred.resolve(createOperationalBaselineInventorySnapshot());
 
     await screen.findByLabelText(/Home inventory metrics/i);
+    expect(screen.queryByRole('status', { name: 'Scanning local inventory' })).not.toBeInTheDocument();
     expect(getHomeStatValue('Skills', 'on disk')).toBe('7');
     expect(getHomeAttentionSection()).toBeInTheDocument();
+  });
+
+  it('starts live MCP connectivity only after structural inventory is visible', async () => {
+    const structuralInventoryDeferred = createDeferred<SkillInventorySnapshot>();
+    const connectivityDeferred = createDeferred<SkillInventorySnapshot>();
+    getShellStateMock.mockResolvedValue(createShellState({ devTools: undefined }));
+    readCachedInventoryMock.mockResolvedValue(null);
+    scanInventoryMock.mockReturnValue(structuralInventoryDeferred.promise);
+    testMcpConnectivityMock.mockReturnValue(connectivityDeferred.promise);
+
+    render(<App />);
+
+    expect(await screen.findByRole('status', { name: 'Scanning local inventory' })).toBeInTheDocument();
+    expect(testMcpConnectivityMock).not.toHaveBeenCalled();
+
+    structuralInventoryDeferred.resolve(createOperationalBaselineInventorySnapshot());
+
+    await screen.findByLabelText(/Home inventory metrics/i);
+    await waitFor(() => {
+      expect(testMcpConnectivityMock).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByText('Testing MCP connectivity…')).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Scanning local inventory' })).not.toBeInTheDocument();
+    expect(getHomeStatValue('Skills', 'on disk')).toBe('7');
+    expect(screen.getByRole('button', { name: /Cancel MCP connectivity test/i })).toBeEnabled();
   });
 
   it('hydrates Home metrics and shell badges from the bootstrapped cached snapshot before live reconciliation resolves', async () => {
@@ -1196,11 +1225,18 @@ describe('App shell inventory views', () => {
     const connectivityDeferred = createDeferred<SkillInventorySnapshot>();
     getShellStateMock.mockResolvedValue(liveShellState);
     rescanInventoryMock.mockReturnValueOnce(rescanDeferred.promise);
-    testMcpConnectivityMock.mockReturnValueOnce(connectivityDeferred.promise);
+    testMcpConnectivityMock
+      .mockResolvedValueOnce(createInventorySnapshot())
+      .mockReturnValueOnce(connectivityDeferred.promise);
 
     render(<App />);
 
     await screen.findByLabelText(/Home inventory metrics/i);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Rescan$/i })).toBeEnabled();
+      expect(testMcpConnectivityMock).toHaveBeenCalledTimes(1);
+    });
+    testMcpConnectivityMock.mockClear();
     fireEvent.click(screen.getByRole('button', { name: /^Rescan$/i }));
 
     await waitFor(() => {

--- a/src/renderer/src/components/AppSidebar.tsx
+++ b/src/renderer/src/components/AppSidebar.tsx
@@ -78,6 +78,9 @@ export function AppSidebar({
                 <span className="nav-button-trailing">
                   {item.badge ? <span className={`nav-badge nav-badge--${item.tone}`}>{item.badge}</span> : null}
                   {typeof item.meta === 'number' ? <span className="nav-secondary-count">{item.meta}</span> : null}
+                  {item.tab !== 'home' && typeof item.meta !== 'number' ? (
+                    <span aria-hidden="true" className="nav-secondary-count nav-secondary-count--loading" />
+                  ) : null}
                 </span>
               </button>
             </li>
@@ -138,7 +141,11 @@ export function AppSidebar({
                   <span>Agent Directory</span>
                 </span>
                 <span className="nav-button-trailing">
-                  <span className="nav-secondary-count">{inventorySnapshot?.agentCounts?.installedAgents ?? 0}</span>
+                  {inventorySnapshot ? (
+                    <span className="nav-secondary-count">{inventorySnapshot.agentCounts?.installedAgents ?? 0}</span>
+                  ) : (
+                    <span aria-hidden="true" className="nav-secondary-count nav-secondary-count--loading" />
+                  )}
                 </span>
               </button>
             </li>
@@ -172,7 +179,7 @@ export function AppSidebar({
         <div className={`sidebar-meta${updateButton ? ' sidebar-meta--with-update' : ''}`}>
           <div>
             <p className="sidebar-meta-label">Last scan</p>
-            <p className="sidebar-meta-copy">{inventorySnapshot ? lastScanLabel : 'Not scanned yet'}</p>
+            <p className="sidebar-meta-copy">{inventorySnapshot ? lastScanLabel : 'Scanning...'}</p>
           </div>
           {updateButton ? (
             <button

--- a/src/renderer/src/components/InventoryLoadingSkeleton.test.tsx
+++ b/src/renderer/src/components/InventoryLoadingSkeleton.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  HomeInventoryLoadingSkeleton,
+  InventoryListLoadingSkeleton,
+} from './InventoryLoadingSkeleton';
+
+describe('InventoryLoadingSkeleton', () => {
+  it('announces one concise loading status for the Home skeleton', () => {
+    const { container } = render(<HomeInventoryLoadingSkeleton />);
+
+    expect(screen.getByRole('status', { name: 'Scanning local inventory' })).toBeInTheDocument();
+    expect(container.querySelectorAll('.inventory-skeleton__metric')).toHaveLength(3);
+    expect(container.querySelectorAll('.inventory-skeleton__row')).toHaveLength(3);
+  });
+
+  it('renders a layout-shaped inventory list without exposing decorative rows', () => {
+    const { container } = render(<InventoryListLoadingSkeleton />);
+
+    expect(screen.getByRole('status', { name: 'Scanning local inventory' })).toBeInTheDocument();
+    expect(container.querySelectorAll('.inventory-skeleton__section')).toHaveLength(2);
+    expect(container.querySelectorAll('.inventory-skeleton__row')).toHaveLength(6);
+    expect(container.querySelectorAll('[aria-hidden="true"] .inventory-skeleton__row')).toHaveLength(6);
+  });
+});

--- a/src/renderer/src/components/InventoryLoadingSkeleton.tsx
+++ b/src/renderer/src/components/InventoryLoadingSkeleton.tsx
@@ -1,0 +1,80 @@
+const HOME_METRICS = ['skills', 'mcps', 'subagents'] as const;
+const LIST_SECTIONS = [3, 3] as const;
+
+function LoadingStatus() {
+  return (
+    <span aria-label="Scanning local inventory" className="sr-only" role="status">
+      Scanning local inventory
+    </span>
+  );
+}
+
+function SkeletonRow({ index }: { index: number }) {
+  return (
+    <div className="inventory-skeleton__row" data-row-index={index}>
+      <div className="inventory-skeleton__row-copy">
+        <span className="inventory-skeleton__shape inventory-skeleton__line inventory-skeleton__line--title" />
+        <span className="inventory-skeleton__shape inventory-skeleton__line inventory-skeleton__line--copy" />
+      </div>
+      <span className="inventory-skeleton__shape inventory-skeleton__pill" />
+    </div>
+  );
+}
+
+export function HomeInventoryLoadingSkeleton() {
+  return (
+    <section aria-busy="true" className="inventory-skeleton inventory-skeleton--home">
+      <LoadingStatus />
+      <div aria-hidden="true">
+        <div className="inventory-skeleton__metrics">
+          {HOME_METRICS.map((metric) => (
+            <div className="inventory-skeleton__metric" key={metric}>
+              <span className="inventory-skeleton__shape inventory-skeleton__line inventory-skeleton__line--label" />
+              <span className="inventory-skeleton__shape inventory-skeleton__value" />
+              <div className="inventory-skeleton__metric-status">
+                <span className="inventory-skeleton__shape inventory-skeleton__dot" />
+                <span className="inventory-skeleton__shape inventory-skeleton__line inventory-skeleton__line--status" />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="inventory-skeleton__status-strip">
+          <span className="inventory-skeleton__shape inventory-skeleton__status-icon" />
+          <div className="inventory-skeleton__status-copy">
+            <span className="inventory-skeleton__shape inventory-skeleton__line inventory-skeleton__line--status-title" />
+            <span className="inventory-skeleton__shape inventory-skeleton__line inventory-skeleton__line--status-copy" />
+          </div>
+        </div>
+
+        <div className="inventory-skeleton__card">
+          <div className="inventory-skeleton__card-header">
+            <span className="inventory-skeleton__shape inventory-skeleton__line inventory-skeleton__line--card-title" />
+          </div>
+          {[0, 1, 2].map((index) => <SkeletonRow index={index} key={index} />)}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function InventoryListLoadingSkeleton() {
+  return (
+    <section aria-busy="true" className="inventory-skeleton inventory-skeleton--list">
+      <LoadingStatus />
+      <div aria-hidden="true">
+        {LIST_SECTIONS.map((rowCount, sectionIndex) => (
+          <div className="inventory-skeleton__section" key={sectionIndex}>
+            <div className="inventory-skeleton__section-header">
+              <span className="inventory-skeleton__shape inventory-skeleton__section-label" />
+              <span className="inventory-skeleton__shape inventory-skeleton__section-count" />
+            </div>
+            {Array.from({ length: rowCount }, (_, rowIndex) => (
+              <SkeletonRow index={rowIndex} key={rowIndex} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -61,6 +61,18 @@
   box-sizing: border-box;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 html,
 body,
 #root {
@@ -6948,6 +6960,237 @@ body {
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
+}
+
+.inventory-skeleton {
+  width: 100%;
+  min-width: 0;
+}
+
+.inventory-skeleton--home {
+  flex: 1 1 auto;
+}
+
+.inventory-skeleton__shape,
+.inventory-skeleton__metric,
+.inventory-skeleton__status-icon {
+  background-image: linear-gradient(
+    100deg,
+    #efefeb 20%,
+    #f8f8f5 42%,
+    #efefeb 64%
+  );
+  background-size: 220% 100%;
+  animation: inventory-skeleton-shimmer 1.65s ease-in-out infinite;
+}
+
+.inventory-skeleton__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.inventory-skeleton__metric {
+  min-height: 128px;
+  padding: 14px 15px;
+  border: 1px solid var(--panel-border);
+  border-radius: 7px;
+  background-color: var(--panel-bg);
+}
+
+.inventory-skeleton__metric > .inventory-skeleton__shape,
+.inventory-skeleton__status-strip .inventory-skeleton__shape,
+.inventory-skeleton__card .inventory-skeleton__shape,
+.inventory-skeleton__section .inventory-skeleton__shape {
+  display: block;
+}
+
+.inventory-skeleton__line,
+.inventory-skeleton__value,
+.inventory-skeleton__pill,
+.inventory-skeleton__dot,
+.inventory-skeleton__section-count {
+  border-radius: 999px;
+}
+
+.inventory-skeleton__line--label {
+  width: 54px;
+  height: 8px;
+  margin-bottom: 15px;
+}
+
+.inventory-skeleton__value {
+  width: 46px;
+  height: 27px;
+}
+
+.inventory-skeleton__metric-status {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 13px;
+  padding-top: 11px;
+  border-top: 1px solid #ededea;
+}
+
+.inventory-skeleton__dot {
+  width: 7px;
+  height: 7px;
+}
+
+.inventory-skeleton__line--status {
+  width: 88px;
+  height: 8px;
+}
+
+.inventory-skeleton__status-strip {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 54px;
+  margin-bottom: 18px;
+  padding: 12px 16px;
+  border: 1px solid var(--panel-border);
+  border-radius: 7px;
+  background: var(--panel-bg);
+}
+
+.inventory-skeleton__status-icon {
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+}
+
+.inventory-skeleton__status-copy {
+  display: grid;
+  gap: 7px;
+  width: min(420px, 62%);
+}
+
+.inventory-skeleton__line--status-title {
+  width: 156px;
+  height: 9px;
+}
+
+.inventory-skeleton__line--status-copy {
+  width: 100%;
+  height: 7px;
+}
+
+.inventory-skeleton__card {
+  overflow: hidden;
+  border: 1px solid var(--panel-border);
+  border-radius: 7px;
+  background: var(--panel-bg);
+}
+
+.inventory-skeleton__card-header,
+.inventory-skeleton__section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 43px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--panel-border);
+  background: var(--panel-muted-bg);
+}
+
+.inventory-skeleton__line--card-title {
+  width: 112px;
+  height: 9px;
+}
+
+.inventory-skeleton__row {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 16px;
+  min-height: 59px;
+  padding: 11px 16px;
+  border-bottom: 1px solid #ededea;
+}
+
+.inventory-skeleton__row:last-child {
+  border-bottom: 0;
+}
+
+.inventory-skeleton__row-copy {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.inventory-skeleton__line--title {
+  width: min(230px, 48%);
+  height: 10px;
+}
+
+.inventory-skeleton__line--copy {
+  width: min(390px, 72%);
+  height: 7px;
+}
+
+.inventory-skeleton__row[data-row-index='1'] .inventory-skeleton__line--title {
+  width: min(180px, 42%);
+}
+
+.inventory-skeleton__row[data-row-index='2'] .inventory-skeleton__line--title {
+  width: min(260px, 54%);
+}
+
+.inventory-skeleton__row[data-row-index='1'] .inventory-skeleton__line--copy {
+  width: min(320px, 64%);
+}
+
+.inventory-skeleton__pill {
+  width: 86px;
+  height: 21px;
+}
+
+.inventory-skeleton--list {
+  min-height: 100%;
+  background: var(--panel-bg);
+}
+
+.inventory-skeleton__section + .inventory-skeleton__section {
+  border-top: 1px solid var(--panel-border);
+}
+
+.inventory-skeleton__section-header {
+  min-height: 37px;
+  padding-block: 10px;
+}
+
+.inventory-skeleton__section-label {
+  width: 88px;
+  height: 8px;
+  border-radius: 999px;
+}
+
+.inventory-skeleton__section-count {
+  width: 18px;
+  height: 8px;
+}
+
+@keyframes inventory-skeleton-shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+
+  100% {
+    background-position: -120% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inventory-skeleton__shape,
+  .inventory-skeleton__metric,
+  .inventory-skeleton__status-icon {
+    animation: none;
+  }
 }
 
 .master-list-row {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -5366,6 +5366,17 @@ body {
   color: var(--text-tertiary);
 }
 
+.nav-secondary-count--loading {
+  align-self: center;
+  width: 14px;
+  height: 6px;
+  margin-left: 6px;
+  border-radius: 999px;
+  background-image: linear-gradient(100deg, #dcdbd5 20%, #efeee9 45%, #dcdbd5 70%);
+  background-size: 220% 100%;
+  animation: inventory-skeleton-shimmer 1.65s ease-in-out infinite;
+}
+
 .sidebar-footer {
   margin-top: auto;
   gap: 12px;
@@ -7188,7 +7199,8 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .inventory-skeleton__shape,
   .inventory-skeleton__metric,
-  .inventory-skeleton__status-icon {
+  .inventory-skeleton__status-icon,
+  .nav-secondary-count--loading {
     animation: none;
   }
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -7040,7 +7040,7 @@ body {
   gap: 7px;
   margin-top: 13px;
   padding-top: 11px;
-  border-top: 1px solid #ededea;
+  border-top: 1px solid var(--panel-border);
 }
 
 .inventory-skeleton__dot {
@@ -7119,7 +7119,7 @@ body {
   gap: 16px;
   min-height: 59px;
   padding: 11px 16px;
-  border-bottom: 1px solid #ededea;
+  border-bottom: 1px solid var(--panel-border);
 }
 
 .inventory-skeleton__row:last-child {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -6982,9 +6982,7 @@ body {
   flex: 1 1 auto;
 }
 
-.inventory-skeleton__shape,
-.inventory-skeleton__metric,
-.inventory-skeleton__status-icon {
+.inventory-skeleton__shape {
   background-image: linear-gradient(
     100deg,
     #efefeb 20%,
@@ -7198,8 +7196,6 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
   .inventory-skeleton__shape,
-  .inventory-skeleton__metric,
-  .inventory-skeleton__status-icon,
   .nav-secondary-count--loading {
     animation: none;
   }

--- a/src/renderer/src/styles.test.ts
+++ b/src/renderer/src/styles.test.ts
@@ -19,6 +19,15 @@ interface CascadedValue {
 const stylesPath = path.resolve(process.cwd(), 'src/renderer/src/styles.css');
 
 describe('renderer stylesheet layout regressions', () => {
+  it('uses the shared panel border for inventory skeleton dividers', () => {
+    const rules = collectCssRules(readFileSync(stylesPath, 'utf8'));
+    const metricStatusStyles = computeStyles(rules, 1440, ['inventory-skeleton__metric-status'], []);
+    const rowRule = rules.find((rule) => rule.selectors.includes('.inventory-skeleton__row'));
+
+    expect(metricStatusStyles['border-top']).toBe('1px solid var(--panel-border)');
+    expect(rowRule?.declarations['border-bottom']).toBe('1px solid var(--panel-border)');
+  });
+
   it('keeps a vertical divider when the split workspace remains side by side below the legacy stacking breakpoint', () => {
     const rules = collectCssRules(readFileSync(stylesPath, 'utf8'));
     const viewportWidth = 1239;

--- a/src/renderer/src/views/AgentsWorkspaceView.tsx
+++ b/src/renderer/src/views/AgentsWorkspaceView.tsx
@@ -4,6 +4,7 @@ import type { AgentInstallState, AgentRecord, SkillInventorySnapshot } from '@sh
 
 import { hasSearchQuery } from '../inventory-view-model';
 import { AgentStatusRow, EmptyStatePanel, HeaderSearch, InventorySectionBlock, PageTopBar, RescanToolbarButton, WorkspaceFilterBar } from '../components/ui';
+import { InventoryListLoadingSkeleton } from '../components/InventoryLoadingSkeleton';
 
 type AgentStatusFilter = 'all' | AgentInstallState;
 
@@ -119,7 +120,7 @@ export function AgentsWorkspaceView({
               />
             )
           ) : (
-            <EmptyStatePanel message="Scanning your supported agents…" />
+            <InventoryListLoadingSkeleton />
           )}
         </section>
       </div>

--- a/src/renderer/src/views/HomeDashboard.test.tsx
+++ b/src/renderer/src/views/HomeDashboard.test.tsx
@@ -15,6 +15,14 @@ const safeRepairRequest: ResolveIssueRequest = {
 };
 
 describe('HomeDashboard', () => {
+  it('shows a layout-shaped skeleton while the first inventory snapshot is loading', () => {
+    renderDashboard({ inventorySnapshot: null });
+
+    expect(screen.getByRole('status', { name: 'Scanning local inventory' })).toBeInTheDocument();
+    expect(screen.queryByText(/Loading your inventory summary/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Home inventory metrics')).not.toBeInTheDocument();
+  });
+
   it('uses rescan loading copy for the global rescan action', () => {
     renderDashboard({ isRescanning: true });
 

--- a/src/renderer/src/views/HomeDashboard.tsx
+++ b/src/renderer/src/views/HomeDashboard.tsx
@@ -21,8 +21,8 @@ import {
   formatLastScanLabel,
 } from '../lib/inventory-presentation';
 import { AutoRepairReviewPanel } from '../components/AutoRepairReview';
+import { HomeInventoryLoadingSkeleton } from '../components/InventoryLoadingSkeleton';
 import {
-  EmptyStatePanel,
   PageTopBar,
   PLUGIN_MCP_TOOLTIP,
   PLUGIN_SKILL_TOOLTIP,
@@ -496,7 +496,7 @@ export function HomeDashboard({
             <HomeNeedsAttentionCard groups={attentionGroups} lastCheckedLabel={lastCheckedLabel} />
           </>
         ) : (
-          <EmptyStatePanel message="Loading your inventory summary…" />
+          <HomeInventoryLoadingSkeleton />
         )}
       </div>
     </main>

--- a/src/renderer/src/views/InventoryViewChrome.test.tsx
+++ b/src/renderer/src/views/InventoryViewChrome.test.tsx
@@ -23,7 +23,7 @@ function renderSkillsWorkspaceView({
   statusFilter = 'all',
 }: {
   autoResolvableRequests?: ResolveIssueRequest[];
-  inventorySnapshot?: typeof representativeInventorySnapshot;
+  inventorySnapshot?: typeof representativeInventorySnapshot | null;
   isAutoResolving?: boolean;
   isRescanning?: boolean;
   onAutoResolve?: () => void;
@@ -60,7 +60,7 @@ function renderSkillsWorkspaceView({
       setSelectedSkillVariantPath={vi.fn()}
       setSelectionOverrideSkillName={vi.fn()}
       setStatusFilter={vi.fn()}
-      sourceIndex={new Map(inventorySnapshot.sources.map((source) => [source.id, source]))}
+      sourceIndex={new Map(inventorySnapshot?.sources.map((source) => [source.id, source]) ?? [])}
       statusFilter={statusFilter}
     />,
   );
@@ -222,6 +222,13 @@ function renderPluginsWorkspaceView({
 }
 
 describe('inventory view chrome', () => {
+  it('shows a layout-shaped skeleton while the Skills snapshot is loading', () => {
+    renderSkillsWorkspaceView({ inventorySnapshot: null, rows: [] });
+
+    expect(screen.getByRole('status', { name: 'Scanning local inventory' })).toBeInTheDocument();
+    expect(screen.queryByText(/Scanning your skill inventory/i)).not.toBeInTheDocument();
+  });
+
   it('shows only the status filter pills for the Skills workspace', () => {
     renderSkillsWorkspaceView();
 

--- a/src/renderer/src/views/McpWorkspaceView.tsx
+++ b/src/renderer/src/views/McpWorkspaceView.tsx
@@ -23,6 +23,7 @@ import { getInventoryRemovalPresentation } from '../lib/removal-presentation';
 import type { InspectorModel, InspectorProvenanceSummaryRow } from '../lib/detail-inspector-model';
 import { ScopedAutoRepairControl } from '../components/AutoRepairReview';
 import { DetailInspectorPanel } from '../components/DetailInspectorPanel';
+import { InventoryListLoadingSkeleton } from '../components/InventoryLoadingSkeleton';
 import {
   EmptyStatePanel,
   HeaderSearch,
@@ -193,7 +194,7 @@ export function McpWorkspaceView({
                   <EmptyStatePanel message={emptyStateMessage} />
                 )
               ) : (
-                <EmptyStatePanel message="Scanning your MCP inventory…" />
+                <InventoryListLoadingSkeleton />
               )}
             </section>
 

--- a/src/renderer/src/views/PluginsWorkspaceView.tsx
+++ b/src/renderer/src/views/PluginsWorkspaceView.tsx
@@ -17,6 +17,7 @@ import {
   RescanToolbarButton,
 } from '../components/ui';
 import { formatInspectorDisplayPath } from '../lib/inventory-presentation';
+import { InventoryListLoadingSkeleton } from '../components/InventoryLoadingSkeleton';
 
 export function PluginsWorkspaceView({
   addActionControl,
@@ -112,7 +113,7 @@ export function PluginsWorkspaceView({
                 />
               )
             ) : (
-              <EmptyStatePanel message="Scanning your plugin inventory…" />
+              <InventoryListLoadingSkeleton />
             )}
           </section>
 

--- a/src/renderer/src/views/SkillsWorkspaceView.tsx
+++ b/src/renderer/src/views/SkillsWorkspaceView.tsx
@@ -24,6 +24,7 @@ import { getSkillResolveActionState } from '../lib/issue-resolution';
 import type { InspectorLocationAction, InspectorModel, InspectorProvenanceSummaryRow } from '../lib/detail-inspector-model';
 import { ScopedAutoRepairControl } from '../components/AutoRepairReview';
 import { DetailInspectorPanel } from '../components/DetailInspectorPanel';
+import { InventoryListLoadingSkeleton } from '../components/InventoryLoadingSkeleton';
 import {
   EmptyStatePanel,
   HeaderSearch,
@@ -214,7 +215,7 @@ export function SkillsWorkspaceView({
                   <EmptyStatePanel message={emptyStateMessage} />
                 )
               ) : (
-                <EmptyStatePanel message="Scanning your skill inventory…" />
+                <InventoryListLoadingSkeleton />
               )}
             </section>
 

--- a/src/renderer/src/views/SubagentsWorkspaceView.tsx
+++ b/src/renderer/src/views/SubagentsWorkspaceView.tsx
@@ -26,6 +26,7 @@ import { getSubagentResolveActionState } from '../lib/issue-resolution';
 import { getInventoryRemovalPresentation } from '../lib/removal-presentation';
 import { ScopedAutoRepairControl } from '../components/AutoRepairReview';
 import { DetailInspectorPanel } from '../components/DetailInspectorPanel';
+import { InventoryListLoadingSkeleton } from '../components/InventoryLoadingSkeleton';
 import {
   EmptyStatePanel,
   HeaderSearch,
@@ -199,7 +200,7 @@ export function SubagentsWorkspaceView({
                 <EmptyStatePanel message={emptyStateMessage} />
               )
             ) : (
-              <EmptyStatePanel message="Scanning your subagent inventory..." />
+              <InventoryListLoadingSkeleton />
             )}
           </section>
 


### PR DESCRIPTION
## Changes

- render structural inventory without waiting for MCP connectivity checks, then test live MCP connectivity in the background
- replace cacheless Home and inventory placeholders with reduced-motion-aware skeletons
- keep sidebar counts neutral until inventory is known without changing completed zero-item states

## Evidence

![Home cacheless loading state](https://github.com/user-attachments/assets/a5107366-94e5-4179-a3f2-a3a1b568ab3e)

![Skills cacheless loading state](https://github.com/user-attachments/assets/eea9f769-e10a-4af9-8d52-78b436710455)

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run src/main/ipc.test.ts src/renderer/src/components/InventoryLoadingSkeleton.test.tsx src/renderer/src/views/HomeDashboard.test.tsx src/renderer/src/views/InventoryViewChrome.test.tsx src/renderer/src/app-shell.test.tsx src/renderer/src/styles.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
