### PR TITLE
Bump version to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillindex",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Local macOS app for keeping your AI setup portable, inspectable, and aligned across agents.",
   "author": "Arjit Jaiswal",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Changes

- set the app release version to `0.2.5` for the fast structural inventory and loading skeleton update

## Evidence

![Home inventory loading state](https://github.com/user-attachments/assets/f41c820a-d1f6-4e3c-a688-0f083e94a2f5)

![Skills inventory loading state](https://github.com/user-attachments/assets/bf557a34-dcd5-43d6-9749-6cbaaa0823f2)

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --maxWorkers=4` (796 tests)
- `pnpm build`
